### PR TITLE
Add path to rpb classification entries as SKOS.definition (RPB-319)

### DIFF
--- a/output/rpb.ndjson
+++ b/output/rpb.ndjson
@@ -1,1101 +1,1101 @@
 {"prefLabel":"Landeskunde","uri":"http://purl.org/lobid/rpb#n100000"}
-{"prefLabel":"Landeskunde allgemein","uri":"http://purl.org/lobid/rpb#n100100"}
-{"prefLabel":"Bibliografie","uri":"http://purl.org/lobid/rpb#n101000"}
-{"prefLabel":"Landesbeschreibung","uri":"http://purl.org/lobid/rpb#n102000"}
-{"prefLabel":"Kreisbeschreibung","uri":"http://purl.org/lobid/rpb#n102040"}
-{"prefLabel":"Verbandsgemeindebeschreibung","uri":"http://purl.org/lobid/rpb#n102042"}
-{"prefLabel":"Regionenbeschreibung","uri":"http://purl.org/lobid/rpb#n102045"}
-{"prefLabel":"Ortsbeschreibung","uri":"http://purl.org/lobid/rpb#n102050"}
-{"prefLabel":"Reisebericht","uri":"http://purl.org/lobid/rpb#n102060"}
-{"prefLabel":"Wandern / Führer","uri":"http://purl.org/lobid/rpb#n102070"}
-{"prefLabel":"Heimatpflege","uri":"http://purl.org/lobid/rpb#n105000"}
-{"prefLabel":"Heimatverein","uri":"http://purl.org/lobid/rpb#n106000"}
-{"prefLabel":"Biografie","uri":"http://purl.org/lobid/rpb#n109000"}
+{"prefLabel":"Landeskunde allgemein","uri":"http://purl.org/lobid/rpb#n100100","definition":"Landeskunde (n100000) > Landeskunde allgemein (n100100)"}
+{"prefLabel":"Bibliografie","uri":"http://purl.org/lobid/rpb#n101000","definition":"Landeskunde (n100000) > Bibliografie (n101000)"}
+{"prefLabel":"Landesbeschreibung","uri":"http://purl.org/lobid/rpb#n102000","definition":"Landeskunde (n100000) > Landesbeschreibung (n102000)"}
+{"prefLabel":"Kreisbeschreibung","uri":"http://purl.org/lobid/rpb#n102040","definition":"Landeskunde (n100000) > Landesbeschreibung (n102000) > Kreisbeschreibung (n102040)"}
+{"prefLabel":"Verbandsgemeindebeschreibung","uri":"http://purl.org/lobid/rpb#n102042","definition":"Landeskunde (n100000) > Landesbeschreibung (n102000) > Verbandsgemeindebeschreibung (n102042)"}
+{"prefLabel":"Regionenbeschreibung","uri":"http://purl.org/lobid/rpb#n102045","definition":"Landeskunde (n100000) > Landesbeschreibung (n102000) > Regionenbeschreibung (n102045)"}
+{"prefLabel":"Ortsbeschreibung","uri":"http://purl.org/lobid/rpb#n102050","definition":"Landeskunde (n100000) > Landesbeschreibung (n102000) > Ortsbeschreibung (n102050)"}
+{"prefLabel":"Reisebericht","uri":"http://purl.org/lobid/rpb#n102060","definition":"Landeskunde (n100000) > Landesbeschreibung (n102000) > Reisebericht (n102060)"}
+{"prefLabel":"Wandern / Führer","uri":"http://purl.org/lobid/rpb#n102070","definition":"Landeskunde (n100000) > Landesbeschreibung (n102000) > Wandern / Führer (n102070)"}
+{"prefLabel":"Heimatpflege","uri":"http://purl.org/lobid/rpb#n105000","definition":"Landeskunde (n100000) > Heimatpflege (n105000)"}
+{"prefLabel":"Heimatverein","uri":"http://purl.org/lobid/rpb#n106000","definition":"Landeskunde (n100000) > Heimatverein (n106000)"}
+{"prefLabel":"Biografie","uri":"http://purl.org/lobid/rpb#n109000","definition":"Landeskunde (n100000) > Biografie (n109000)"}
 {"prefLabel":"Kartografie. Geodäsie","uri":"http://purl.org/lobid/rpb#n120000"}
-{"prefLabel":"Kartografie. Geodäsie allgemein","uri":"http://purl.org/lobid/rpb#n120100"}
-{"prefLabel":"Kartografie","uri":"http://purl.org/lobid/rpb#n122000"}
-{"prefLabel":"Kartenauswertung","uri":"http://purl.org/lobid/rpb#n122030"}
-{"prefLabel":"Computerkartografie","uri":"http://purl.org/lobid/rpb#n122050"}
-{"prefLabel":"Luftbildauswertung","uri":"http://purl.org/lobid/rpb#n122070"}
-{"prefLabel":"Geodäsie","uri":"http://purl.org/lobid/rpb#n124000"}
-{"prefLabel":"Karte","uri":"http://purl.org/lobid/rpb#n126000"}
+{"prefLabel":"Kartografie. Geodäsie allgemein","uri":"http://purl.org/lobid/rpb#n120100","definition":"Kartografie. Geodäsie (n120000) > Kartografie. Geodäsie allgemein (n120100)"}
+{"prefLabel":"Kartografie","uri":"http://purl.org/lobid/rpb#n122000","definition":"Kartografie. Geodäsie (n120000) > Kartografie (n122000)"}
+{"prefLabel":"Kartenauswertung","uri":"http://purl.org/lobid/rpb#n122030","definition":"Kartografie. Geodäsie (n120000) > Kartografie (n122000) > Kartenauswertung (n122030)"}
+{"prefLabel":"Computerkartografie","uri":"http://purl.org/lobid/rpb#n122050","definition":"Kartografie. Geodäsie (n120000) > Kartografie (n122000) > Computerkartografie (n122050)"}
+{"prefLabel":"Luftbildauswertung","uri":"http://purl.org/lobid/rpb#n122070","definition":"Kartografie. Geodäsie (n120000) > Kartografie (n122000) > Luftbildauswertung (n122070)"}
+{"prefLabel":"Geodäsie","uri":"http://purl.org/lobid/rpb#n124000","definition":"Kartografie. Geodäsie (n120000) > Geodäsie (n124000)"}
+{"prefLabel":"Karte","uri":"http://purl.org/lobid/rpb#n126000","definition":"Kartografie. Geodäsie (n120000) > Karte (n126000)"}
 {"prefLabel":"Geowissenschaften","uri":"http://purl.org/lobid/rpb#n140000"}
-{"prefLabel":"Geowissenschaften allgemein","uri":"http://purl.org/lobid/rpb#n140100"}
-{"prefLabel":"Geophysik","uri":"http://purl.org/lobid/rpb#n141000"}
-{"prefLabel":"Erdmagnetismus","uri":"http://purl.org/lobid/rpb#n141020"}
-{"prefLabel":"Schwere","uri":"http://purl.org/lobid/rpb#n141030"}
-{"prefLabel":"Erdbeben","uri":"http://purl.org/lobid/rpb#n141040"}
-{"prefLabel":"Geologie","uri":"http://purl.org/lobid/rpb#n141200"}
-{"prefLabel":"Tektonik","uri":"http://purl.org/lobid/rpb#n141220"}
-{"prefLabel":"Ingenieurgeologie","uri":"http://purl.org/lobid/rpb#n141230"}
-{"prefLabel":"Stratigraphie","uri":"http://purl.org/lobid/rpb#n141240"}
-{"prefLabel":"Mineralogie. Gesteinskunde","uri":"http://purl.org/lobid/rpb#n141400"}
-{"prefLabel":"Mineralogie","uri":"http://purl.org/lobid/rpb#n141420"}
-{"prefLabel":"Gesteinskunde","uri":"http://purl.org/lobid/rpb#n141430"}
-{"prefLabel":"Geochemie","uri":"http://purl.org/lobid/rpb#n141440"}
-{"prefLabel":"Lagerstättenkunde","uri":"http://purl.org/lobid/rpb#n141450"}
-{"prefLabel":"Mineralquelle. Thermalquelle","uri":"http://purl.org/lobid/rpb#n141460"}
-{"prefLabel":"Paläontologie","uri":"http://purl.org/lobid/rpb#n141600"}
-{"prefLabel":"Paläobotanik","uri":"http://purl.org/lobid/rpb#n141620"}
-{"prefLabel":"Fossile Sporenpflanzen","uri":"http://purl.org/lobid/rpb#n141622"}
-{"prefLabel":"Fossile Samenpflanzen","uri":"http://purl.org/lobid/rpb#n141624"}
-{"prefLabel":"Paläozoologie","uri":"http://purl.org/lobid/rpb#n141630"}
-{"prefLabel":"Fossile Wirbellose","uri":"http://purl.org/lobid/rpb#n141632"}
-{"prefLabel":"Fossile Wirbeltiere","uri":"http://purl.org/lobid/rpb#n141634"}
-{"prefLabel":"Mikropaläontologie","uri":"http://purl.org/lobid/rpb#n141640"}
-{"prefLabel":"Bodenkunde","uri":"http://purl.org/lobid/rpb#n142000"}
-{"prefLabel":"Bodenentwicklung","uri":"http://purl.org/lobid/rpb#n142020"}
-{"prefLabel":"Bodenphysik","uri":"http://purl.org/lobid/rpb#n142030"}
-{"prefLabel":"Bodenbiologie","uri":"http://purl.org/lobid/rpb#n142040"}
-{"prefLabel":"Bodenmechanik","uri":"http://purl.org/lobid/rpb#n142050"}
-{"prefLabel":"Bodenchemie","uri":"http://purl.org/lobid/rpb#n142060"}
-{"prefLabel":"Geomorphologie","uri":"http://purl.org/lobid/rpb#n142100"}
-{"prefLabel":"Relief / Geografie","uri":"http://purl.org/lobid/rpb#n142110"}
-{"prefLabel":"Abtragung","uri":"http://purl.org/lobid/rpb#n142120"}
-{"prefLabel":"Klimamorphologie","uri":"http://purl.org/lobid/rpb#n142130"}
-{"prefLabel":"Glazialmorphologie. Periglazialgeomorphologie","uri":"http://purl.org/lobid/rpb#n142140"}
-{"prefLabel":"Vulkanismus","uri":"http://purl.org/lobid/rpb#n142150"}
-{"prefLabel":"Karst","uri":"http://purl.org/lobid/rpb#n142170"}
-{"prefLabel":"Höhle","uri":"http://purl.org/lobid/rpb#n142180"}
-{"prefLabel":"Angewandte Geomorphologie","uri":"http://purl.org/lobid/rpb#n142190"}
-{"prefLabel":"Wasser","uri":"http://purl.org/lobid/rpb#n142300"}
-{"prefLabel":"Wasserrecht","uri":"http://purl.org/lobid/rpb#n142310"}
-{"prefLabel":"Fließgewässer","uri":"http://purl.org/lobid/rpb#n142320"}
-{"prefLabel":"Hochwasser","uri":"http://purl.org/lobid/rpb#n142323"}
-{"prefLabel":"Niedrigwasser","uri":"http://purl.org/lobid/rpb#n142325"}
-{"prefLabel":"See","uri":"http://purl.org/lobid/rpb#n142330"}
-{"prefLabel":"Moor","uri":"http://purl.org/lobid/rpb#n142340"}
-{"prefLabel":"Hydrogeologie","uri":"http://purl.org/lobid/rpb#n142350"}
-{"prefLabel":"Bodenwasser","uri":"http://purl.org/lobid/rpb#n142352"}
-{"prefLabel":"Wasserhaushalt","uri":"http://purl.org/lobid/rpb#n142360"}
-{"prefLabel":"Wasserwirtschaft","uri":"http://purl.org/lobid/rpb#n142370"}
-{"prefLabel":"Trinkwasserversorgung","uri":"http://purl.org/lobid/rpb#n142372"}
-{"prefLabel":"Brauchwasser","uri":"http://purl.org/lobid/rpb#n142375"}
-{"prefLabel":"Hydroökologie","uri":"http://purl.org/lobid/rpb#n142380"}
-{"prefLabel":"Wasseranalyse","uri":"http://purl.org/lobid/rpb#n142382"}
-{"prefLabel":"Wasserstatistik","uri":"http://purl.org/lobid/rpb#n142390"}
-{"prefLabel":"Klima","uri":"http://purl.org/lobid/rpb#n142500"}
-{"prefLabel":"Klimaelement","uri":"http://purl.org/lobid/rpb#n142520"}
-{"prefLabel":"Sonnenstrahlung","uri":"http://purl.org/lobid/rpb#n142522"}
-{"prefLabel":"Lufttemperatur","uri":"http://purl.org/lobid/rpb#n142523"}
-{"prefLabel":"Luftfeuchtigkeit","uri":"http://purl.org/lobid/rpb#n142524"}
-{"prefLabel":"Luftdruck","uri":"http://purl.org/lobid/rpb#n142525"}
-{"prefLabel":"Luftbewegung","uri":"http://purl.org/lobid/rpb#n142526"}
-{"prefLabel":"Luftelektrizität","uri":"http://purl.org/lobid/rpb#n142527"}
-{"prefLabel":"Klimatologie","uri":"http://purl.org/lobid/rpb#n142530"}
-{"prefLabel":"Wetterdienst","uri":"http://purl.org/lobid/rpb#n142540"}
-{"prefLabel":"Wetterlage","uri":"http://purl.org/lobid/rpb#n142541"}
-{"prefLabel":"Klimafaktor","uri":"http://purl.org/lobid/rpb#n142550"}
-{"prefLabel":"Klimaschwankung","uri":"http://purl.org/lobid/rpb#n142560"}
-{"prefLabel":"Paläoklimatologie","uri":"http://purl.org/lobid/rpb#n142570"}
-{"prefLabel":"Geoökologie","uri":"http://purl.org/lobid/rpb#n146000"}
+{"prefLabel":"Geowissenschaften allgemein","uri":"http://purl.org/lobid/rpb#n140100","definition":"Geowissenschaften (n140000) > Geowissenschaften allgemein (n140100)"}
+{"prefLabel":"Geophysik","uri":"http://purl.org/lobid/rpb#n141000","definition":"Geowissenschaften (n140000) > Geophysik (n141000)"}
+{"prefLabel":"Erdmagnetismus","uri":"http://purl.org/lobid/rpb#n141020","definition":"Geowissenschaften (n140000) > Geophysik (n141000) > Erdmagnetismus (n141020)"}
+{"prefLabel":"Schwere","uri":"http://purl.org/lobid/rpb#n141030","definition":"Geowissenschaften (n140000) > Geophysik (n141000) > Schwere (n141030)"}
+{"prefLabel":"Erdbeben","uri":"http://purl.org/lobid/rpb#n141040","definition":"Geowissenschaften (n140000) > Geophysik (n141000) > Erdbeben (n141040)"}
+{"prefLabel":"Geologie","uri":"http://purl.org/lobid/rpb#n141200","definition":"Geowissenschaften (n140000) > Geologie (n141200)"}
+{"prefLabel":"Tektonik","uri":"http://purl.org/lobid/rpb#n141220","definition":"Geowissenschaften (n140000) > Geologie (n141200) > Tektonik (n141220)"}
+{"prefLabel":"Ingenieurgeologie","uri":"http://purl.org/lobid/rpb#n141230","definition":"Geowissenschaften (n140000) > Geologie (n141200) > Ingenieurgeologie (n141230)"}
+{"prefLabel":"Stratigraphie","uri":"http://purl.org/lobid/rpb#n141240","definition":"Geowissenschaften (n140000) > Geologie (n141200) > Stratigraphie (n141240)"}
+{"prefLabel":"Mineralogie. Gesteinskunde","uri":"http://purl.org/lobid/rpb#n141400","definition":"Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400)"}
+{"prefLabel":"Mineralogie","uri":"http://purl.org/lobid/rpb#n141420","definition":"Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Mineralogie (n141420)"}
+{"prefLabel":"Gesteinskunde","uri":"http://purl.org/lobid/rpb#n141430","definition":"Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Gesteinskunde (n141430)"}
+{"prefLabel":"Geochemie","uri":"http://purl.org/lobid/rpb#n141440","definition":"Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Geochemie (n141440)"}
+{"prefLabel":"Lagerstättenkunde","uri":"http://purl.org/lobid/rpb#n141450","definition":"Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Lagerstättenkunde (n141450)"}
+{"prefLabel":"Mineralquelle. Thermalquelle","uri":"http://purl.org/lobid/rpb#n141460","definition":"Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Mineralquelle. Thermalquelle (n141460)"}
+{"prefLabel":"Paläontologie","uri":"http://purl.org/lobid/rpb#n141600","definition":"Geowissenschaften (n140000) > Paläontologie (n141600)"}
+{"prefLabel":"Paläobotanik","uri":"http://purl.org/lobid/rpb#n141620","definition":"Geowissenschaften (n140000) > Paläontologie (n141600) > Paläobotanik (n141620)"}
+{"prefLabel":"Fossile Sporenpflanzen","uri":"http://purl.org/lobid/rpb#n141622","definition":"Geowissenschaften (n140000) > Paläontologie (n141600) > Paläobotanik (n141620) > Fossile Sporenpflanzen (n141622)"}
+{"prefLabel":"Fossile Samenpflanzen","uri":"http://purl.org/lobid/rpb#n141624","definition":"Geowissenschaften (n140000) > Paläontologie (n141600) > Paläobotanik (n141620) > Fossile Samenpflanzen (n141624)"}
+{"prefLabel":"Paläozoologie","uri":"http://purl.org/lobid/rpb#n141630","definition":"Geowissenschaften (n140000) > Paläontologie (n141600) > Paläozoologie (n141630)"}
+{"prefLabel":"Fossile Wirbellose","uri":"http://purl.org/lobid/rpb#n141632","definition":"Geowissenschaften (n140000) > Paläontologie (n141600) > Paläozoologie (n141630) > Fossile Wirbellose (n141632)"}
+{"prefLabel":"Fossile Wirbeltiere","uri":"http://purl.org/lobid/rpb#n141634","definition":"Geowissenschaften (n140000) > Paläontologie (n141600) > Paläozoologie (n141630) > Fossile Wirbeltiere (n141634)"}
+{"prefLabel":"Mikropaläontologie","uri":"http://purl.org/lobid/rpb#n141640","definition":"Geowissenschaften (n140000) > Paläontologie (n141600) > Mikropaläontologie (n141640)"}
+{"prefLabel":"Bodenkunde","uri":"http://purl.org/lobid/rpb#n142000","definition":"Geowissenschaften (n140000) > Bodenkunde (n142000)"}
+{"prefLabel":"Bodenentwicklung","uri":"http://purl.org/lobid/rpb#n142020","definition":"Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenentwicklung (n142020)"}
+{"prefLabel":"Bodenphysik","uri":"http://purl.org/lobid/rpb#n142030","definition":"Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenphysik (n142030)"}
+{"prefLabel":"Bodenbiologie","uri":"http://purl.org/lobid/rpb#n142040","definition":"Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenbiologie (n142040)"}
+{"prefLabel":"Bodenmechanik","uri":"http://purl.org/lobid/rpb#n142050","definition":"Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenmechanik (n142050)"}
+{"prefLabel":"Bodenchemie","uri":"http://purl.org/lobid/rpb#n142060","definition":"Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenchemie (n142060)"}
+{"prefLabel":"Geomorphologie","uri":"http://purl.org/lobid/rpb#n142100","definition":"Geowissenschaften (n140000) > Geomorphologie (n142100)"}
+{"prefLabel":"Relief / Geografie","uri":"http://purl.org/lobid/rpb#n142110","definition":"Geowissenschaften (n140000) > Geomorphologie (n142100) > Relief / Geografie (n142110)"}
+{"prefLabel":"Abtragung","uri":"http://purl.org/lobid/rpb#n142120","definition":"Geowissenschaften (n140000) > Geomorphologie (n142100) > Abtragung (n142120)"}
+{"prefLabel":"Klimamorphologie","uri":"http://purl.org/lobid/rpb#n142130","definition":"Geowissenschaften (n140000) > Geomorphologie (n142100) > Klimamorphologie (n142130)"}
+{"prefLabel":"Glazialmorphologie. Periglazialgeomorphologie","uri":"http://purl.org/lobid/rpb#n142140","definition":"Geowissenschaften (n140000) > Geomorphologie (n142100) > Glazialmorphologie. Periglazialgeomorphologie (n142140)"}
+{"prefLabel":"Vulkanismus","uri":"http://purl.org/lobid/rpb#n142150","definition":"Geowissenschaften (n140000) > Geomorphologie (n142100) > Vulkanismus (n142150)"}
+{"prefLabel":"Karst","uri":"http://purl.org/lobid/rpb#n142170","definition":"Geowissenschaften (n140000) > Geomorphologie (n142100) > Karst (n142170)"}
+{"prefLabel":"Höhle","uri":"http://purl.org/lobid/rpb#n142180","definition":"Geowissenschaften (n140000) > Geomorphologie (n142100) > Höhle (n142180)"}
+{"prefLabel":"Angewandte Geomorphologie","uri":"http://purl.org/lobid/rpb#n142190","definition":"Geowissenschaften (n140000) > Geomorphologie (n142100) > Angewandte Geomorphologie (n142190)"}
+{"prefLabel":"Wasser","uri":"http://purl.org/lobid/rpb#n142300","definition":"Geowissenschaften (n140000) > Wasser (n142300)"}
+{"prefLabel":"Wasserrecht","uri":"http://purl.org/lobid/rpb#n142310","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Wasserrecht (n142310)"}
+{"prefLabel":"Fließgewässer","uri":"http://purl.org/lobid/rpb#n142320","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Fließgewässer (n142320)"}
+{"prefLabel":"Hochwasser","uri":"http://purl.org/lobid/rpb#n142323","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Fließgewässer (n142320) > Hochwasser (n142323)"}
+{"prefLabel":"Niedrigwasser","uri":"http://purl.org/lobid/rpb#n142325","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Fließgewässer (n142320) > Niedrigwasser (n142325)"}
+{"prefLabel":"See","uri":"http://purl.org/lobid/rpb#n142330","definition":"Geowissenschaften (n140000) > Wasser (n142300) > See (n142330)"}
+{"prefLabel":"Moor","uri":"http://purl.org/lobid/rpb#n142340","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Moor (n142340)"}
+{"prefLabel":"Hydrogeologie","uri":"http://purl.org/lobid/rpb#n142350","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Hydrogeologie (n142350)"}
+{"prefLabel":"Bodenwasser","uri":"http://purl.org/lobid/rpb#n142352","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Hydrogeologie (n142350) > Bodenwasser (n142352)"}
+{"prefLabel":"Wasserhaushalt","uri":"http://purl.org/lobid/rpb#n142360","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Wasserhaushalt (n142360)"}
+{"prefLabel":"Wasserwirtschaft","uri":"http://purl.org/lobid/rpb#n142370","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Wasserwirtschaft (n142370)"}
+{"prefLabel":"Trinkwasserversorgung","uri":"http://purl.org/lobid/rpb#n142372","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Wasserwirtschaft (n142370) > Trinkwasserversorgung (n142372)"}
+{"prefLabel":"Brauchwasser","uri":"http://purl.org/lobid/rpb#n142375","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Wasserwirtschaft (n142370) > Brauchwasser (n142375)"}
+{"prefLabel":"Hydroökologie","uri":"http://purl.org/lobid/rpb#n142380","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Hydroökologie (n142380)"}
+{"prefLabel":"Wasseranalyse","uri":"http://purl.org/lobid/rpb#n142382","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Hydroökologie (n142380) > Wasseranalyse (n142382)"}
+{"prefLabel":"Wasserstatistik","uri":"http://purl.org/lobid/rpb#n142390","definition":"Geowissenschaften (n140000) > Wasser (n142300) > Wasserstatistik (n142390)"}
+{"prefLabel":"Klima","uri":"http://purl.org/lobid/rpb#n142500","definition":"Geowissenschaften (n140000) > Klima (n142500)"}
+{"prefLabel":"Klimaelement","uri":"http://purl.org/lobid/rpb#n142520","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520)"}
+{"prefLabel":"Sonnenstrahlung","uri":"http://purl.org/lobid/rpb#n142522","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Sonnenstrahlung (n142522)"}
+{"prefLabel":"Lufttemperatur","uri":"http://purl.org/lobid/rpb#n142523","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Lufttemperatur (n142523)"}
+{"prefLabel":"Luftfeuchtigkeit","uri":"http://purl.org/lobid/rpb#n142524","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Luftfeuchtigkeit (n142524)"}
+{"prefLabel":"Luftdruck","uri":"http://purl.org/lobid/rpb#n142525","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Luftdruck (n142525)"}
+{"prefLabel":"Luftbewegung","uri":"http://purl.org/lobid/rpb#n142526","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Luftbewegung (n142526)"}
+{"prefLabel":"Luftelektrizität","uri":"http://purl.org/lobid/rpb#n142527","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Luftelektrizität (n142527)"}
+{"prefLabel":"Klimatologie","uri":"http://purl.org/lobid/rpb#n142530","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimatologie (n142530)"}
+{"prefLabel":"Wetterdienst","uri":"http://purl.org/lobid/rpb#n142540","definition":"Geowissenschaften (n140000) > Klima (n142500) > Wetterdienst (n142540)"}
+{"prefLabel":"Wetterlage","uri":"http://purl.org/lobid/rpb#n142541","definition":"Geowissenschaften (n140000) > Klima (n142500) > Wetterlage (n142541)"}
+{"prefLabel":"Klimafaktor","uri":"http://purl.org/lobid/rpb#n142550","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimafaktor (n142550)"}
+{"prefLabel":"Klimaschwankung","uri":"http://purl.org/lobid/rpb#n142560","definition":"Geowissenschaften (n140000) > Klima (n142500) > Klimaschwankung (n142560)"}
+{"prefLabel":"Paläoklimatologie","uri":"http://purl.org/lobid/rpb#n142570","definition":"Geowissenschaften (n140000) > Klima (n142500) > Paläoklimatologie (n142570)"}
+{"prefLabel":"Geoökologie","uri":"http://purl.org/lobid/rpb#n146000","definition":"Geowissenschaften (n140000) > Geoökologie (n146000)"}
 {"prefLabel":"Biowissenschaften","uri":"http://purl.org/lobid/rpb#n160000"}
-{"prefLabel":"Biowissenschaften allgemein","uri":"http://purl.org/lobid/rpb#n160100"}
-{"prefLabel":"Biologie","uri":"http://purl.org/lobid/rpb#n161000"}
-{"prefLabel":"Ökologie","uri":"http://purl.org/lobid/rpb#n161030"}
-{"prefLabel":"Biozönose","uri":"http://purl.org/lobid/rpb#n161040"}
-{"prefLabel":"Mikrobiologie","uri":"http://purl.org/lobid/rpb#n161050"}
-{"prefLabel":"Pflanzen","uri":"http://purl.org/lobid/rpb#n162000"}
-{"prefLabel":"Kryptogamen","uri":"http://purl.org/lobid/rpb#n162030"}
-{"prefLabel":"Samenpflanzen","uri":"http://purl.org/lobid/rpb#n162040"}
-{"prefLabel":"Tiere","uri":"http://purl.org/lobid/rpb#n163000"}
-{"prefLabel":"Wirbellose","uri":"http://purl.org/lobid/rpb#n163020"}
-{"prefLabel":"Insekten","uri":"http://purl.org/lobid/rpb#n163030"}
-{"prefLabel":"Wirbeltiere","uri":"http://purl.org/lobid/rpb#n163040"}
-{"prefLabel":"Fische","uri":"http://purl.org/lobid/rpb#n163050"}
-{"prefLabel":"Lurche","uri":"http://purl.org/lobid/rpb#n163060"}
-{"prefLabel":"Reptilien","uri":"http://purl.org/lobid/rpb#n163070"}
-{"prefLabel":"Vögel","uri":"http://purl.org/lobid/rpb#n163080"}
-{"prefLabel":"Säugetiere","uri":"http://purl.org/lobid/rpb#n163090"}
-{"prefLabel":"Humanbiologie","uri":"http://purl.org/lobid/rpb#n164000"}
-{"prefLabel":"Menschenrasse","uri":"http://purl.org/lobid/rpb#n164020"}
-{"prefLabel":"Skelettfund","uri":"http://purl.org/lobid/rpb#n164030"}
-{"prefLabel":"Paläoanthropologie","uri":"http://purl.org/lobid/rpb#n164040"}
+{"prefLabel":"Biowissenschaften allgemein","uri":"http://purl.org/lobid/rpb#n160100","definition":"Biowissenschaften (n160000) > Biowissenschaften allgemein (n160100)"}
+{"prefLabel":"Biologie","uri":"http://purl.org/lobid/rpb#n161000","definition":"Biowissenschaften (n160000) > Biologie (n161000)"}
+{"prefLabel":"Ökologie","uri":"http://purl.org/lobid/rpb#n161030","definition":"Biowissenschaften (n160000) > Biologie (n161000) > Ökologie (n161030)"}
+{"prefLabel":"Biozönose","uri":"http://purl.org/lobid/rpb#n161040","definition":"Biowissenschaften (n160000) > Biologie (n161000) > Biozönose (n161040)"}
+{"prefLabel":"Mikrobiologie","uri":"http://purl.org/lobid/rpb#n161050","definition":"Biowissenschaften (n160000) > Biologie (n161000) > Mikrobiologie (n161050)"}
+{"prefLabel":"Pflanzen","uri":"http://purl.org/lobid/rpb#n162000","definition":"Biowissenschaften (n160000) > Pflanzen (n162000)"}
+{"prefLabel":"Kryptogamen","uri":"http://purl.org/lobid/rpb#n162030","definition":"Biowissenschaften (n160000) > Pflanzen (n162000) > Kryptogamen (n162030)"}
+{"prefLabel":"Samenpflanzen","uri":"http://purl.org/lobid/rpb#n162040","definition":"Biowissenschaften (n160000) > Pflanzen (n162000) > Samenpflanzen (n162040)"}
+{"prefLabel":"Tiere","uri":"http://purl.org/lobid/rpb#n163000","definition":"Biowissenschaften (n160000) > Tiere (n163000)"}
+{"prefLabel":"Wirbellose","uri":"http://purl.org/lobid/rpb#n163020","definition":"Biowissenschaften (n160000) > Tiere (n163000) > Wirbellose (n163020)"}
+{"prefLabel":"Insekten","uri":"http://purl.org/lobid/rpb#n163030","definition":"Biowissenschaften (n160000) > Tiere (n163000) > Insekten (n163030)"}
+{"prefLabel":"Wirbeltiere","uri":"http://purl.org/lobid/rpb#n163040","definition":"Biowissenschaften (n160000) > Tiere (n163000) > Wirbeltiere (n163040)"}
+{"prefLabel":"Fische","uri":"http://purl.org/lobid/rpb#n163050","definition":"Biowissenschaften (n160000) > Tiere (n163000) > Fische (n163050)"}
+{"prefLabel":"Lurche","uri":"http://purl.org/lobid/rpb#n163060","definition":"Biowissenschaften (n160000) > Tiere (n163000) > Lurche (n163060)"}
+{"prefLabel":"Reptilien","uri":"http://purl.org/lobid/rpb#n163070","definition":"Biowissenschaften (n160000) > Tiere (n163000) > Reptilien (n163070)"}
+{"prefLabel":"Vögel","uri":"http://purl.org/lobid/rpb#n163080","definition":"Biowissenschaften (n160000) > Tiere (n163000) > Vögel (n163080)"}
+{"prefLabel":"Säugetiere","uri":"http://purl.org/lobid/rpb#n163090","definition":"Biowissenschaften (n160000) > Tiere (n163000) > Säugetiere (n163090)"}
+{"prefLabel":"Humanbiologie","uri":"http://purl.org/lobid/rpb#n164000","definition":"Biowissenschaften (n160000) > Humanbiologie (n164000)"}
+{"prefLabel":"Menschenrasse","uri":"http://purl.org/lobid/rpb#n164020","definition":"Biowissenschaften (n160000) > Humanbiologie (n164000) > Menschenrasse (n164020)"}
+{"prefLabel":"Skelettfund","uri":"http://purl.org/lobid/rpb#n164030","definition":"Biowissenschaften (n160000) > Humanbiologie (n164000) > Skelettfund (n164030)"}
+{"prefLabel":"Paläoanthropologie","uri":"http://purl.org/lobid/rpb#n164040","definition":"Biowissenschaften (n160000) > Humanbiologie (n164000) > Paläoanthropologie (n164040)"}
 {"prefLabel":"Historische Hilfswissenschaften","uri":"http://purl.org/lobid/rpb#n200000"}
-{"prefLabel":"Historische Hilfswissenschaften allgemein","uri":"http://purl.org/lobid/rpb#n200100"}
-{"prefLabel":"Chronologie","uri":"http://purl.org/lobid/rpb#n202000"}
-{"prefLabel":"Metrologie","uri":"http://purl.org/lobid/rpb#n202500"}
-{"prefLabel":"Urkundenlehre","uri":"http://purl.org/lobid/rpb#n203000"}
-{"prefLabel":"Paläografie","uri":"http://purl.org/lobid/rpb#n203500"}
-{"prefLabel":"Siegelkunde","uri":"http://purl.org/lobid/rpb#n204000"}
-{"prefLabel":"Numismatik","uri":"http://purl.org/lobid/rpb#n205000"}
-{"prefLabel":"Münze","uri":"http://purl.org/lobid/rpb#n205020"}
-{"prefLabel":"Papiergeld","uri":"http://purl.org/lobid/rpb#n205030"}
-{"prefLabel":"Epigraphik","uri":"http://purl.org/lobid/rpb#n206000"}
-{"prefLabel":"Genealogie","uri":"http://purl.org/lobid/rpb#n207000"}
-{"prefLabel":"Familie","uri":"http://purl.org/lobid/rpb#n207020"}
-{"prefLabel":"Heraldik","uri":"http://purl.org/lobid/rpb#n208000"}
-{"prefLabel":"Flagge","uri":"http://purl.org/lobid/rpb#n208500"}
-{"prefLabel":"Orden / Ehrenzeichen","uri":"http://purl.org/lobid/rpb#n209000"}
+{"prefLabel":"Historische Hilfswissenschaften allgemein","uri":"http://purl.org/lobid/rpb#n200100","definition":"Historische Hilfswissenschaften (n200000) > Historische Hilfswissenschaften allgemein (n200100)"}
+{"prefLabel":"Chronologie","uri":"http://purl.org/lobid/rpb#n202000","definition":"Historische Hilfswissenschaften (n200000) > Chronologie (n202000)"}
+{"prefLabel":"Metrologie","uri":"http://purl.org/lobid/rpb#n202500","definition":"Historische Hilfswissenschaften (n200000) > Metrologie (n202500)"}
+{"prefLabel":"Urkundenlehre","uri":"http://purl.org/lobid/rpb#n203000","definition":"Historische Hilfswissenschaften (n200000) > Urkundenlehre (n203000)"}
+{"prefLabel":"Paläografie","uri":"http://purl.org/lobid/rpb#n203500","definition":"Historische Hilfswissenschaften (n200000) > Paläografie (n203500)"}
+{"prefLabel":"Siegelkunde","uri":"http://purl.org/lobid/rpb#n204000","definition":"Historische Hilfswissenschaften (n200000) > Siegelkunde (n204000)"}
+{"prefLabel":"Numismatik","uri":"http://purl.org/lobid/rpb#n205000","definition":"Historische Hilfswissenschaften (n200000) > Numismatik (n205000)"}
+{"prefLabel":"Münze","uri":"http://purl.org/lobid/rpb#n205020","definition":"Historische Hilfswissenschaften (n200000) > Numismatik (n205000) > Münze (n205020)"}
+{"prefLabel":"Papiergeld","uri":"http://purl.org/lobid/rpb#n205030","definition":"Historische Hilfswissenschaften (n200000) > Numismatik (n205000) > Papiergeld (n205030)"}
+{"prefLabel":"Epigraphik","uri":"http://purl.org/lobid/rpb#n206000","definition":"Historische Hilfswissenschaften (n200000) > Epigraphik (n206000)"}
+{"prefLabel":"Genealogie","uri":"http://purl.org/lobid/rpb#n207000","definition":"Historische Hilfswissenschaften (n200000) > Genealogie (n207000)"}
+{"prefLabel":"Familie","uri":"http://purl.org/lobid/rpb#n207020","definition":"Historische Hilfswissenschaften (n200000) > Genealogie (n207000) > Familie (n207020)"}
+{"prefLabel":"Heraldik","uri":"http://purl.org/lobid/rpb#n208000","definition":"Historische Hilfswissenschaften (n200000) > Heraldik (n208000)"}
+{"prefLabel":"Flagge","uri":"http://purl.org/lobid/rpb#n208500","definition":"Historische Hilfswissenschaften (n200000) > Heraldik (n208000) > Flagge (n208500)"}
+{"prefLabel":"Orden / Ehrenzeichen","uri":"http://purl.org/lobid/rpb#n209000","definition":"Historische Hilfswissenschaften (n200000) > Orden / Ehrenzeichen (n209000)"}
 {"prefLabel":"Archiv. Museum","uri":"http://purl.org/lobid/rpb#n210000"}
-{"prefLabel":"Archiv. Museum allgemein","uri":"http://purl.org/lobid/rpb#n210100"}
-{"prefLabel":"Archiv","uri":"http://purl.org/lobid/rpb#n213000"}
-{"prefLabel":"Bundesarchiv Koblenz","uri":"http://purl.org/lobid/rpb#n213010"}
-{"prefLabel":"Staatsarchiv","uri":"http://purl.org/lobid/rpb#n213020"}
-{"prefLabel":"Kreisarchiv. Gemeindearchiv","uri":"http://purl.org/lobid/rpb#n213030"}
-{"prefLabel":"Kreisarchiv","uri":"http://purl.org/lobid/rpb#n213031"}
-{"prefLabel":"Gemeindearchiv","uri":"http://purl.org/lobid/rpb#n213033"}
-{"prefLabel":"Kirchenarchiv","uri":"http://purl.org/lobid/rpb#n213040"}
-{"prefLabel":"Archiv für Literatur, Kunst und Wissenschaft","uri":"http://purl.org/lobid/rpb#n213050"}
-{"prefLabel":"Literaturarchiv","uri":"http://purl.org/lobid/rpb#n213052"}
-{"prefLabel":"Kunstarchiv","uri":"http://purl.org/lobid/rpb#n213053"}
-{"prefLabel":"Wissenschaftsarchiv","uri":"http://purl.org/lobid/rpb#n213054"}
-{"prefLabel":"Parteiarchiv","uri":"http://purl.org/lobid/rpb#n213060"}
-{"prefLabel":"Medienarchiv","uri":"http://purl.org/lobid/rpb#n213070"}
-{"prefLabel":"Rundfunkarchiv","uri":"http://purl.org/lobid/rpb#n213072"}
-{"prefLabel":"Pressearchiv","uri":"http://purl.org/lobid/rpb#n213073"}
-{"prefLabel":"Filmarchiv","uri":"http://purl.org/lobid/rpb#n213074"}
-{"prefLabel":"Wirtschaftsarchiv","uri":"http://purl.org/lobid/rpb#n213080"}
-{"prefLabel":"Firmenarchiv","uri":"http://purl.org/lobid/rpb#n213082"}
-{"prefLabel":"Familienarchiv","uri":"http://purl.org/lobid/rpb#n213090"}
-{"prefLabel":"Sonstige Archive","uri":"http://purl.org/lobid/rpb#n213092"}
-{"prefLabel":"Museum","uri":"http://purl.org/lobid/rpb#n217000"}
-{"prefLabel":"Museumspädagogik","uri":"http://purl.org/lobid/rpb#n217010"}
-{"prefLabel":"Naturkundemuseum","uri":"http://purl.org/lobid/rpb#n217020"}
-{"prefLabel":"Technisches Museum","uri":"http://purl.org/lobid/rpb#n217030"}
-{"prefLabel":"Historisches Museum. Heimatmuseum","uri":"http://purl.org/lobid/rpb#n217040"}
-{"prefLabel":"Volkskundemuseum","uri":"http://purl.org/lobid/rpb#n217050"}
-{"prefLabel":"Sonstige Museen","uri":"http://purl.org/lobid/rpb#n217090"}
+{"prefLabel":"Archiv. Museum allgemein","uri":"http://purl.org/lobid/rpb#n210100","definition":"Archiv. Museum (n210000) > Archiv. Museum allgemein (n210100)"}
+{"prefLabel":"Archiv","uri":"http://purl.org/lobid/rpb#n213000","definition":"Archiv. Museum (n210000) > Archiv (n213000)"}
+{"prefLabel":"Bundesarchiv Koblenz","uri":"http://purl.org/lobid/rpb#n213010","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Bundesarchiv Koblenz (n213010)"}
+{"prefLabel":"Staatsarchiv","uri":"http://purl.org/lobid/rpb#n213020","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Staatsarchiv (n213020)"}
+{"prefLabel":"Kreisarchiv. Gemeindearchiv","uri":"http://purl.org/lobid/rpb#n213030","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Kreisarchiv. Gemeindearchiv (n213030)"}
+{"prefLabel":"Kreisarchiv","uri":"http://purl.org/lobid/rpb#n213031","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Kreisarchiv. Gemeindearchiv (n213030) > Kreisarchiv (n213031)"}
+{"prefLabel":"Gemeindearchiv","uri":"http://purl.org/lobid/rpb#n213033","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Kreisarchiv. Gemeindearchiv (n213030) > Gemeindearchiv (n213033)"}
+{"prefLabel":"Kirchenarchiv","uri":"http://purl.org/lobid/rpb#n213040","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Kirchenarchiv (n213040)"}
+{"prefLabel":"Archiv für Literatur, Kunst und Wissenschaft","uri":"http://purl.org/lobid/rpb#n213050","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Archiv für Literatur, Kunst und Wissenschaft (n213050)"}
+{"prefLabel":"Literaturarchiv","uri":"http://purl.org/lobid/rpb#n213052","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Archiv für Literatur, Kunst und Wissenschaft (n213050) > Literaturarchiv (n213052)"}
+{"prefLabel":"Kunstarchiv","uri":"http://purl.org/lobid/rpb#n213053","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Archiv für Literatur, Kunst und Wissenschaft (n213050) > Kunstarchiv (n213053)"}
+{"prefLabel":"Wissenschaftsarchiv","uri":"http://purl.org/lobid/rpb#n213054","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Archiv für Literatur, Kunst und Wissenschaft (n213050) > Wissenschaftsarchiv (n213054)"}
+{"prefLabel":"Parteiarchiv","uri":"http://purl.org/lobid/rpb#n213060","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Parteiarchiv (n213060)"}
+{"prefLabel":"Medienarchiv","uri":"http://purl.org/lobid/rpb#n213070","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Medienarchiv (n213070)"}
+{"prefLabel":"Rundfunkarchiv","uri":"http://purl.org/lobid/rpb#n213072","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Medienarchiv (n213070) > Rundfunkarchiv (n213072)"}
+{"prefLabel":"Pressearchiv","uri":"http://purl.org/lobid/rpb#n213073","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Medienarchiv (n213070) > Pressearchiv (n213073)"}
+{"prefLabel":"Filmarchiv","uri":"http://purl.org/lobid/rpb#n213074","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Medienarchiv (n213070) > Filmarchiv (n213074)"}
+{"prefLabel":"Wirtschaftsarchiv","uri":"http://purl.org/lobid/rpb#n213080","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Wirtschaftsarchiv (n213080)"}
+{"prefLabel":"Firmenarchiv","uri":"http://purl.org/lobid/rpb#n213082","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Wirtschaftsarchiv (n213080) > Firmenarchiv (n213082)"}
+{"prefLabel":"Familienarchiv","uri":"http://purl.org/lobid/rpb#n213090","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Familienarchiv (n213090)"}
+{"prefLabel":"Sonstige Archive","uri":"http://purl.org/lobid/rpb#n213092","definition":"Archiv. Museum (n210000) > Archiv (n213000) > Sonstige Archive (n213092)"}
+{"prefLabel":"Museum","uri":"http://purl.org/lobid/rpb#n217000","definition":"Archiv. Museum (n210000) > Museum (n217000)"}
+{"prefLabel":"Museumspädagogik","uri":"http://purl.org/lobid/rpb#n217010","definition":"Archiv. Museum (n210000) > Museum (n217000) > Museumspädagogik (n217010)"}
+{"prefLabel":"Naturkundemuseum","uri":"http://purl.org/lobid/rpb#n217020","definition":"Archiv. Museum (n210000) > Museum (n217000) > Naturkundemuseum (n217020)"}
+{"prefLabel":"Technisches Museum","uri":"http://purl.org/lobid/rpb#n217030","definition":"Archiv. Museum (n210000) > Museum (n217000) > Technisches Museum (n217030)"}
+{"prefLabel":"Historisches Museum. Heimatmuseum","uri":"http://purl.org/lobid/rpb#n217040","definition":"Archiv. Museum (n210000) > Museum (n217000) > Historisches Museum. Heimatmuseum (n217040)"}
+{"prefLabel":"Volkskundemuseum","uri":"http://purl.org/lobid/rpb#n217050","definition":"Archiv. Museum (n210000) > Museum (n217000) > Volkskundemuseum (n217050)"}
+{"prefLabel":"Sonstige Museen","uri":"http://purl.org/lobid/rpb#n217090","definition":"Archiv. Museum (n210000) > Museum (n217000) > Sonstige Museen (n217090)"}
 {"prefLabel":"Vor- und Frühgeschichte. Archäologie","uri":"http://purl.org/lobid/rpb#n220000"}
-{"prefLabel":"Vor- und Frühgeschichte. Archäologie allgemein","uri":"http://purl.org/lobid/rpb#n220100"}
-{"prefLabel":"Archäologie","uri":"http://purl.org/lobid/rpb#n220500"}
-{"prefLabel":"Vor- und Frühgeschichte","uri":"http://purl.org/lobid/rpb#n221000"}
-{"prefLabel":"Paläolithikum. Mesolithikum","uri":"http://purl.org/lobid/rpb#n222000"}
-{"prefLabel":"Neolithikum","uri":"http://purl.org/lobid/rpb#n223000"}
-{"prefLabel":"Bandkeramik","uri":"http://purl.org/lobid/rpb#n223020"}
-{"prefLabel":"Rössener Kultur","uri":"http://purl.org/lobid/rpb#n223030"}
-{"prefLabel":"Michelsberger Kultur","uri":"http://purl.org/lobid/rpb#n223040"}
-{"prefLabel":"Megalithkultur","uri":"http://purl.org/lobid/rpb#n223050"}
-{"prefLabel":"Schnurkeramik","uri":"http://purl.org/lobid/rpb#n223060"}
-{"prefLabel":"Glockenbecherkultur","uri":"http://purl.org/lobid/rpb#n223070"}
-{"prefLabel":"Bronzezeit","uri":"http://purl.org/lobid/rpb#n224000"}
-{"prefLabel":"Hügelgräberkultur","uri":"http://purl.org/lobid/rpb#n224050"}
-{"prefLabel":"Urnenfelderkultur","uri":"http://purl.org/lobid/rpb#n224060"}
-{"prefLabel":"Vorrömische Eisenzeit","uri":"http://purl.org/lobid/rpb#n225000"}
-{"prefLabel":"Hallstattkultur","uri":"http://purl.org/lobid/rpb#n225020"}
-{"prefLabel":"Hunsrück-Eifel-Kultur","uri":"http://purl.org/lobid/rpb#n225025"}
-{"prefLabel":"Latène-Zeit","uri":"http://purl.org/lobid/rpb#n225030"}
-{"prefLabel":"Kelten","uri":"http://purl.org/lobid/rpb#n225040"}
-{"prefLabel":"Germanen","uri":"http://purl.org/lobid/rpb#n225050"}
-{"prefLabel":"Römerzeit","uri":"http://purl.org/lobid/rpb#n226000"}
-{"prefLabel":"Kelten","uri":"http://purl.org/lobid/rpb#n226020"}
-{"prefLabel":"Römer","uri":"http://purl.org/lobid/rpb#n226030"}
-{"prefLabel":"Germanen","uri":"http://purl.org/lobid/rpb#n226040"}
-{"prefLabel":"Franken <Volk>","uri":"http://purl.org/lobid/rpb#n226050"}
-{"prefLabel":"Völkerwanderung","uri":"http://purl.org/lobid/rpb#n227000"}
-{"prefLabel":"Römer","uri":"http://purl.org/lobid/rpb#n227020"}
-{"prefLabel":"Germanen","uri":"http://purl.org/lobid/rpb#n227030"}
-{"prefLabel":"Franken <Volk>","uri":"http://purl.org/lobid/rpb#n227040"}
-{"prefLabel":"Mittelalterliche Archäologie. Neuzeitliche Archäologie","uri":"http://purl.org/lobid/rpb#n228000"}
-{"prefLabel":"Bestattung","uri":"http://purl.org/lobid/rpb#n228020"}
-{"prefLabel":"Funde","uri":"http://purl.org/lobid/rpb#n228030"}
-{"prefLabel":"Industriearchäologie","uri":"http://purl.org/lobid/rpb#n228080"}
+{"prefLabel":"Vor- und Frühgeschichte. Archäologie allgemein","uri":"http://purl.org/lobid/rpb#n220100","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Vor- und Frühgeschichte. Archäologie allgemein (n220100)"}
+{"prefLabel":"Archäologie","uri":"http://purl.org/lobid/rpb#n220500","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Archäologie (n220500)"}
+{"prefLabel":"Vor- und Frühgeschichte","uri":"http://purl.org/lobid/rpb#n221000","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Vor- und Frühgeschichte (n221000)"}
+{"prefLabel":"Paläolithikum. Mesolithikum","uri":"http://purl.org/lobid/rpb#n222000","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Paläolithikum. Mesolithikum (n222000)"}
+{"prefLabel":"Neolithikum","uri":"http://purl.org/lobid/rpb#n223000","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000)"}
+{"prefLabel":"Bandkeramik","uri":"http://purl.org/lobid/rpb#n223020","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Bandkeramik (n223020)"}
+{"prefLabel":"Rössener Kultur","uri":"http://purl.org/lobid/rpb#n223030","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Rössener Kultur (n223030)"}
+{"prefLabel":"Michelsberger Kultur","uri":"http://purl.org/lobid/rpb#n223040","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Michelsberger Kultur (n223040)"}
+{"prefLabel":"Megalithkultur","uri":"http://purl.org/lobid/rpb#n223050","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Megalithkultur (n223050)"}
+{"prefLabel":"Schnurkeramik","uri":"http://purl.org/lobid/rpb#n223060","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Schnurkeramik (n223060)"}
+{"prefLabel":"Glockenbecherkultur","uri":"http://purl.org/lobid/rpb#n223070","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Glockenbecherkultur (n223070)"}
+{"prefLabel":"Bronzezeit","uri":"http://purl.org/lobid/rpb#n224000","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Bronzezeit (n224000)"}
+{"prefLabel":"Hügelgräberkultur","uri":"http://purl.org/lobid/rpb#n224050","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Bronzezeit (n224000) > Hügelgräberkultur (n224050)"}
+{"prefLabel":"Urnenfelderkultur","uri":"http://purl.org/lobid/rpb#n224060","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Bronzezeit (n224000) > Urnenfelderkultur (n224060)"}
+{"prefLabel":"Vorrömische Eisenzeit","uri":"http://purl.org/lobid/rpb#n225000","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000)"}
+{"prefLabel":"Hallstattkultur","uri":"http://purl.org/lobid/rpb#n225020","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Hallstattkultur (n225020)"}
+{"prefLabel":"Hunsrück-Eifel-Kultur","uri":"http://purl.org/lobid/rpb#n225025","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Hunsrück-Eifel-Kultur (n225025)"}
+{"prefLabel":"Latène-Zeit","uri":"http://purl.org/lobid/rpb#n225030","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Latène-Zeit (n225030)"}
+{"prefLabel":"Kelten","uri":"http://purl.org/lobid/rpb#n225040","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Kelten (n225040)"}
+{"prefLabel":"Germanen","uri":"http://purl.org/lobid/rpb#n225050","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Germanen (n225050)"}
+{"prefLabel":"Römerzeit","uri":"http://purl.org/lobid/rpb#n226000","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000)"}
+{"prefLabel":"Kelten","uri":"http://purl.org/lobid/rpb#n226020","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000) > Kelten (n226020)"}
+{"prefLabel":"Römer","uri":"http://purl.org/lobid/rpb#n226030","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000) > Römer (n226030)"}
+{"prefLabel":"Germanen","uri":"http://purl.org/lobid/rpb#n226040","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000) > Germanen (n226040)"}
+{"prefLabel":"Franken <Volk>","uri":"http://purl.org/lobid/rpb#n226050","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000) > Franken &lt;Volk&gt; (n226050)"}
+{"prefLabel":"Völkerwanderung","uri":"http://purl.org/lobid/rpb#n227000","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Völkerwanderung (n227000)"}
+{"prefLabel":"Römer","uri":"http://purl.org/lobid/rpb#n227020","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Völkerwanderung (n227000) > Römer (n227020)"}
+{"prefLabel":"Germanen","uri":"http://purl.org/lobid/rpb#n227030","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Völkerwanderung (n227000) > Germanen (n227030)"}
+{"prefLabel":"Franken <Volk>","uri":"http://purl.org/lobid/rpb#n227040","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Völkerwanderung (n227000) > Franken &lt;Volk&gt; (n227040)"}
+{"prefLabel":"Mittelalterliche Archäologie. Neuzeitliche Archäologie","uri":"http://purl.org/lobid/rpb#n228000","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Mittelalterliche Archäologie. Neuzeitliche Archäologie (n228000)"}
+{"prefLabel":"Bestattung","uri":"http://purl.org/lobid/rpb#n228020","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Mittelalterliche Archäologie. Neuzeitliche Archäologie (n228000) > Bestattung (n228020)"}
+{"prefLabel":"Funde","uri":"http://purl.org/lobid/rpb#n228030","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Mittelalterliche Archäologie. Neuzeitliche Archäologie (n228000) > Funde (n228030)"}
+{"prefLabel":"Industriearchäologie","uri":"http://purl.org/lobid/rpb#n228080","definition":"Vor- und Frühgeschichte. Archäologie (n220000) > Mittelalterliche Archäologie. Neuzeitliche Archäologie (n228000) > Industriearchäologie (n228080)"}
 {"prefLabel":"Geschichte","uri":"http://purl.org/lobid/rpb#n240000"}
-{"prefLabel":"Quelle","uri":"http://purl.org/lobid/rpb#n240100"}
-{"prefLabel":"Geschichtsschreibung","uri":"http://purl.org/lobid/rpb#n240200"}
-{"prefLabel":"Regionalgeschichte","uri":"http://purl.org/lobid/rpb#n240300"}
-{"prefLabel":"Verbandsgemeindegeschichte","uri":"http://purl.org/lobid/rpb#n240350"}
-{"prefLabel":"Ortsgeschichte","uri":"http://purl.org/lobid/rpb#n240400"}
-{"prefLabel":"Historische Ausstellung","uri":"http://purl.org/lobid/rpb#n240500"}
-{"prefLabel":"Gedenkstätte","uri":"http://purl.org/lobid/rpb#n240600"}
-{"prefLabel":"Rheinland-Pfalz (gesamt) / Geschichte Anfänge-1945","uri":"http://purl.org/lobid/rpb#n241050"}
-{"prefLabel":"Rheinland / Geschichte Anfänge-1945","uri":"http://purl.org/lobid/rpb#n241100"}
-{"prefLabel":"Pfalz / Geschichte Anfänge-1945","uri":"http://purl.org/lobid/rpb#n241200"}
-{"prefLabel":"Rheinhessen / Geschichte Anfänge-1945","uri":"http://purl.org/lobid/rpb#n241400"}
-{"prefLabel":"Kurpfalz","uri":"http://purl.org/lobid/rpb#n242100"}
-{"prefLabel":"Hochstift Trier","uri":"http://purl.org/lobid/rpb#n242200"}
-{"prefLabel":"Hochstift Mainz","uri":"http://purl.org/lobid/rpb#n242300"}
-{"prefLabel":"Hochstift Speyer","uri":"http://purl.org/lobid/rpb#n242500"}
-{"prefLabel":"Hochstift Worms","uri":"http://purl.org/lobid/rpb#n242600"}
-{"prefLabel":"Reichsterritorium. Reichsbeziehung","uri":"http://purl.org/lobid/rpb#n242700"}
-{"prefLabel":"Reichstag","uri":"http://purl.org/lobid/rpb#n242720"}
-{"prefLabel":"Reichsrecht","uri":"http://purl.org/lobid/rpb#n242730"}
-{"prefLabel":"Reichsgut","uri":"http://purl.org/lobid/rpb#n242740"}
-{"prefLabel":"Königshof","uri":"http://purl.org/lobid/rpb#n242743"}
-{"prefLabel":"Königspfalz","uri":"http://purl.org/lobid/rpb#n242744"}
-{"prefLabel":"Reichsabtei","uri":"http://purl.org/lobid/rpb#n242746"}
-{"prefLabel":"Reichsstadt","uri":"http://purl.org/lobid/rpb#n242747"}
-{"prefLabel":"Reichsritterschaft","uri":"http://purl.org/lobid/rpb#n242760"}
-{"prefLabel":"Kleinere Territorien und Teile auswärtiger Territorien","uri":"http://purl.org/lobid/rpb#n242800"}
-{"prefLabel":"Luxemburg","uri":"http://purl.org/lobid/rpb#n242810"}
-{"prefLabel":"Hochstift Köln","uri":"http://purl.org/lobid/rpb#n242812"}
-{"prefLabel":"Grafschaft Homburg, Saar","uri":"http://purl.org/lobid/rpb#n242814"}
-{"prefLabel":"Grafschaft Saarbrücken","uri":"http://purl.org/lobid/rpb#n242816"}
-{"prefLabel":"Staat Leiningen","uri":"http://purl.org/lobid/rpb#n242818"}
-{"prefLabel":"Grafschaft Virneburg","uri":"http://purl.org/lobid/rpb#n242830"}
-{"prefLabel":"Grafschaft Manderscheid","uri":"http://purl.org/lobid/rpb#n242832"}
-{"prefLabel":"Herzogtum Arenberg","uri":"http://purl.org/lobid/rpb#n242834"}
-{"prefLabel":"Fürstentum Löwenstein-Wertheim","uri":"http://purl.org/lobid/rpb#n242836"}
-{"prefLabel":"Grafschaft Wied","uri":"http://purl.org/lobid/rpb#n242850"}
-{"prefLabel":"Fürstentum Isenburg. Grafschaft Isenburg","uri":"http://purl.org/lobid/rpb#n242852"}
-{"prefLabel":"Grafschaft Sayn","uri":"http://purl.org/lobid/rpb#n242854"}
-{"prefLabel":"Grafschaft Katzenelnbogen","uri":"http://purl.org/lobid/rpb#n242856"}
-{"prefLabel":"Grafschaft Veldenz","uri":"http://purl.org/lobid/rpb#n242870"}
-{"prefLabel":"Grafschaft Sponheim","uri":"http://purl.org/lobid/rpb#n242872"}
-{"prefLabel":"Wild- und Rheingrafen","uri":"http://purl.org/lobid/rpb#n242874"}
-{"prefLabel":"Pfalz-Simmern","uri":"http://purl.org/lobid/rpb#n242876"}
-{"prefLabel":"Hanau-Lichtenberg","uri":"http://purl.org/lobid/rpb#n242878"}
-{"prefLabel":"Pfalz-Zweibrücken","uri":"http://purl.org/lobid/rpb#n243100"}
-{"prefLabel":"Staat Nassau","uri":"http://purl.org/lobid/rpb#n243400"}
-{"prefLabel":"Französische Besetzung / 1792-1815","uri":"http://purl.org/lobid/rpb#n245100"}
-{"prefLabel":"Mainzer Republik","uri":"http://purl.org/lobid/rpb#n245120"}
-{"prefLabel":"Wälderdepartement","uri":"http://purl.org/lobid/rpb#n245130"}
-{"prefLabel":"Rhein-Mosel-Département","uri":"http://purl.org/lobid/rpb#n245140"}
-{"prefLabel":"Département Donnersberg","uri":"http://purl.org/lobid/rpb#n245160"}
-{"prefLabel":"Saardepartement","uri":"http://purl.org/lobid/rpb#n245180"}
-{"prefLabel":"Rheinbund / 1806-1813","uri":"http://purl.org/lobid/rpb#n245300"}
-{"prefLabel":"Rheinprovinz","uri":"http://purl.org/lobid/rpb#n246100"}
-{"prefLabel":"Hessen-Darmstadt","uri":"http://purl.org/lobid/rpb#n246200"}
-{"prefLabel":"Hessen-Nassau","uri":"http://purl.org/lobid/rpb#n246300"}
-{"prefLabel":"Bayerische Pfalz","uri":"http://purl.org/lobid/rpb#n246500"}
-{"prefLabel":"Kleinere Territorien des 19. Jahrhunderts","uri":"http://purl.org/lobid/rpb#n246700"}
-{"prefLabel":"Fürstentum Birkenfeld","uri":"http://purl.org/lobid/rpb#n246720"}
-{"prefLabel":"Fürstentum Lichtenberg","uri":"http://purl.org/lobid/rpb#n246740"}
-{"prefLabel":"Oberamt Meisenheim","uri":"http://purl.org/lobid/rpb#n246760"}
-{"prefLabel":"Rheinland-Pfalz / Geschichte 1945-1947","uri":"http://purl.org/lobid/rpb#n248000"}
-{"prefLabel":"Rheinland / Geschichte 1945-","uri":"http://purl.org/lobid/rpb#n248100"}
-{"prefLabel":"Rheinhessen / Geschichte 1945-","uri":"http://purl.org/lobid/rpb#n248300"}
-{"prefLabel":"Pfalz / Geschichte 1945-","uri":"http://purl.org/lobid/rpb#n248500"}
-{"prefLabel":"Rheinland-Pfalz / Geschichte 1947-","uri":"http://purl.org/lobid/rpb#n249100"}
+{"prefLabel":"Quelle","uri":"http://purl.org/lobid/rpb#n240100","definition":"Geschichte (n240000) > Quelle (n240100)"}
+{"prefLabel":"Geschichtsschreibung","uri":"http://purl.org/lobid/rpb#n240200","definition":"Geschichte (n240000) > Geschichtsschreibung (n240200)"}
+{"prefLabel":"Regionalgeschichte","uri":"http://purl.org/lobid/rpb#n240300","definition":"Geschichte (n240000) > Regionalgeschichte (n240300)"}
+{"prefLabel":"Verbandsgemeindegeschichte","uri":"http://purl.org/lobid/rpb#n240350","definition":"Geschichte (n240000) > Verbandsgemeindegeschichte (n240350)"}
+{"prefLabel":"Ortsgeschichte","uri":"http://purl.org/lobid/rpb#n240400","definition":"Geschichte (n240000) > Ortsgeschichte (n240400)"}
+{"prefLabel":"Historische Ausstellung","uri":"http://purl.org/lobid/rpb#n240500","definition":"Geschichte (n240000) > Historische Ausstellung (n240500)"}
+{"prefLabel":"Gedenkstätte","uri":"http://purl.org/lobid/rpb#n240600","definition":"Geschichte (n240000) > Gedenkstätte (n240600)"}
+{"prefLabel":"Rheinland-Pfalz (gesamt) / Geschichte Anfänge-1945","uri":"http://purl.org/lobid/rpb#n241050","definition":"Geschichte (n240000) > Rheinland-Pfalz (gesamt) / Geschichte Anfänge-1945 (n241050)"}
+{"prefLabel":"Rheinland / Geschichte Anfänge-1945","uri":"http://purl.org/lobid/rpb#n241100","definition":"Geschichte (n240000) > Rheinland / Geschichte Anfänge-1945 (n241100)"}
+{"prefLabel":"Pfalz / Geschichte Anfänge-1945","uri":"http://purl.org/lobid/rpb#n241200","definition":"Geschichte (n240000) > Pfalz / Geschichte Anfänge-1945 (n241200)"}
+{"prefLabel":"Rheinhessen / Geschichte Anfänge-1945","uri":"http://purl.org/lobid/rpb#n241400","definition":"Geschichte (n240000) > Rheinhessen / Geschichte Anfänge-1945 (n241400)"}
+{"prefLabel":"Kurpfalz","uri":"http://purl.org/lobid/rpb#n242100","definition":"Geschichte (n240000) > Kurpfalz (n242100)"}
+{"prefLabel":"Hochstift Trier","uri":"http://purl.org/lobid/rpb#n242200","definition":"Geschichte (n240000) > Hochstift Trier (n242200)"}
+{"prefLabel":"Hochstift Mainz","uri":"http://purl.org/lobid/rpb#n242300","definition":"Geschichte (n240000) > Hochstift Mainz (n242300)"}
+{"prefLabel":"Hochstift Speyer","uri":"http://purl.org/lobid/rpb#n242500","definition":"Geschichte (n240000) > Hochstift Speyer (n242500)"}
+{"prefLabel":"Hochstift Worms","uri":"http://purl.org/lobid/rpb#n242600","definition":"Geschichte (n240000) > Hochstift Worms (n242600)"}
+{"prefLabel":"Reichsterritorium. Reichsbeziehung","uri":"http://purl.org/lobid/rpb#n242700","definition":"Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700)"}
+{"prefLabel":"Reichstag","uri":"http://purl.org/lobid/rpb#n242720","definition":"Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichstag (n242720)"}
+{"prefLabel":"Reichsrecht","uri":"http://purl.org/lobid/rpb#n242730","definition":"Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsrecht (n242730)"}
+{"prefLabel":"Reichsgut","uri":"http://purl.org/lobid/rpb#n242740","definition":"Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740)"}
+{"prefLabel":"Königshof","uri":"http://purl.org/lobid/rpb#n242743","definition":"Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740) > Königshof (n242743)"}
+{"prefLabel":"Königspfalz","uri":"http://purl.org/lobid/rpb#n242744","definition":"Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740) > Königspfalz (n242744)"}
+{"prefLabel":"Reichsabtei","uri":"http://purl.org/lobid/rpb#n242746","definition":"Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740) > Reichsabtei (n242746)"}
+{"prefLabel":"Reichsstadt","uri":"http://purl.org/lobid/rpb#n242747","definition":"Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740) > Reichsstadt (n242747)"}
+{"prefLabel":"Reichsritterschaft","uri":"http://purl.org/lobid/rpb#n242760","definition":"Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsritterschaft (n242760)"}
+{"prefLabel":"Kleinere Territorien und Teile auswärtiger Territorien","uri":"http://purl.org/lobid/rpb#n242800","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800)"}
+{"prefLabel":"Luxemburg","uri":"http://purl.org/lobid/rpb#n242810","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Luxemburg (n242810)"}
+{"prefLabel":"Hochstift Köln","uri":"http://purl.org/lobid/rpb#n242812","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Hochstift Köln (n242812)"}
+{"prefLabel":"Grafschaft Homburg, Saar","uri":"http://purl.org/lobid/rpb#n242814","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Homburg, Saar (n242814)"}
+{"prefLabel":"Grafschaft Saarbrücken","uri":"http://purl.org/lobid/rpb#n242816","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Saarbrücken (n242816)"}
+{"prefLabel":"Staat Leiningen","uri":"http://purl.org/lobid/rpb#n242818","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Staat Leiningen (n242818)"}
+{"prefLabel":"Grafschaft Virneburg","uri":"http://purl.org/lobid/rpb#n242830","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Virneburg (n242830)"}
+{"prefLabel":"Grafschaft Manderscheid","uri":"http://purl.org/lobid/rpb#n242832","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Manderscheid (n242832)"}
+{"prefLabel":"Herzogtum Arenberg","uri":"http://purl.org/lobid/rpb#n242834","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Herzogtum Arenberg (n242834)"}
+{"prefLabel":"Fürstentum Löwenstein-Wertheim","uri":"http://purl.org/lobid/rpb#n242836","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Fürstentum Löwenstein-Wertheim (n242836)"}
+{"prefLabel":"Grafschaft Wied","uri":"http://purl.org/lobid/rpb#n242850","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Wied (n242850)"}
+{"prefLabel":"Fürstentum Isenburg. Grafschaft Isenburg","uri":"http://purl.org/lobid/rpb#n242852","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Fürstentum Isenburg. Grafschaft Isenburg (n242852)"}
+{"prefLabel":"Grafschaft Sayn","uri":"http://purl.org/lobid/rpb#n242854","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Sayn (n242854)"}
+{"prefLabel":"Grafschaft Katzenelnbogen","uri":"http://purl.org/lobid/rpb#n242856","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Katzenelnbogen (n242856)"}
+{"prefLabel":"Grafschaft Veldenz","uri":"http://purl.org/lobid/rpb#n242870","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Veldenz (n242870)"}
+{"prefLabel":"Grafschaft Sponheim","uri":"http://purl.org/lobid/rpb#n242872","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Sponheim (n242872)"}
+{"prefLabel":"Wild- und Rheingrafen","uri":"http://purl.org/lobid/rpb#n242874","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Wild- und Rheingrafen (n242874)"}
+{"prefLabel":"Pfalz-Simmern","uri":"http://purl.org/lobid/rpb#n242876","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Pfalz-Simmern (n242876)"}
+{"prefLabel":"Hanau-Lichtenberg","uri":"http://purl.org/lobid/rpb#n242878","definition":"Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Hanau-Lichtenberg (n242878)"}
+{"prefLabel":"Pfalz-Zweibrücken","uri":"http://purl.org/lobid/rpb#n243100","definition":"Geschichte (n240000) > Pfalz-Zweibrücken (n243100)"}
+{"prefLabel":"Staat Nassau","uri":"http://purl.org/lobid/rpb#n243400","definition":"Geschichte (n240000) > Staat Nassau (n243400)"}
+{"prefLabel":"Französische Besetzung / 1792-1815","uri":"http://purl.org/lobid/rpb#n245100","definition":"Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100)"}
+{"prefLabel":"Mainzer Republik","uri":"http://purl.org/lobid/rpb#n245120","definition":"Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Mainzer Republik (n245120)"}
+{"prefLabel":"Wälderdepartement","uri":"http://purl.org/lobid/rpb#n245130","definition":"Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Wälderdepartement (n245130)"}
+{"prefLabel":"Rhein-Mosel-Département","uri":"http://purl.org/lobid/rpb#n245140","definition":"Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Rhein-Mosel-Département (n245140)"}
+{"prefLabel":"Département Donnersberg","uri":"http://purl.org/lobid/rpb#n245160","definition":"Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Département Donnersberg (n245160)"}
+{"prefLabel":"Saardepartement","uri":"http://purl.org/lobid/rpb#n245180","definition":"Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Saardepartement (n245180)"}
+{"prefLabel":"Rheinbund / 1806-1813","uri":"http://purl.org/lobid/rpb#n245300","definition":"Geschichte (n240000) > Rheinbund / 1806-1813 (n245300)"}
+{"prefLabel":"Rheinprovinz","uri":"http://purl.org/lobid/rpb#n246100","definition":"Geschichte (n240000) > Rheinprovinz (n246100)"}
+{"prefLabel":"Hessen-Darmstadt","uri":"http://purl.org/lobid/rpb#n246200","definition":"Geschichte (n240000) > Hessen-Darmstadt (n246200)"}
+{"prefLabel":"Hessen-Nassau","uri":"http://purl.org/lobid/rpb#n246300","definition":"Geschichte (n240000) > Hessen-Nassau (n246300)"}
+{"prefLabel":"Bayerische Pfalz","uri":"http://purl.org/lobid/rpb#n246500","definition":"Geschichte (n240000) > Bayerische Pfalz (n246500)"}
+{"prefLabel":"Kleinere Territorien des 19. Jahrhunderts","uri":"http://purl.org/lobid/rpb#n246700","definition":"Geschichte (n240000) > Kleinere Territorien des 19. Jahrhunderts (n246700)"}
+{"prefLabel":"Fürstentum Birkenfeld","uri":"http://purl.org/lobid/rpb#n246720","definition":"Geschichte (n240000) > Kleinere Territorien des 19. Jahrhunderts (n246700) > Fürstentum Birkenfeld (n246720)"}
+{"prefLabel":"Fürstentum Lichtenberg","uri":"http://purl.org/lobid/rpb#n246740","definition":"Geschichte (n240000) > Kleinere Territorien des 19. Jahrhunderts (n246700) > Fürstentum Lichtenberg (n246740)"}
+{"prefLabel":"Oberamt Meisenheim","uri":"http://purl.org/lobid/rpb#n246760","definition":"Geschichte (n240000) > Kleinere Territorien des 19. Jahrhunderts (n246700) > Oberamt Meisenheim (n246760)"}
+{"prefLabel":"Rheinland-Pfalz / Geschichte 1945-1947","uri":"http://purl.org/lobid/rpb#n248000","definition":"Geschichte (n240000) > Rheinland-Pfalz / Geschichte 1945-1947 (n248000)"}
+{"prefLabel":"Rheinland / Geschichte 1945-","uri":"http://purl.org/lobid/rpb#n248100","definition":"Geschichte (n240000) > Rheinland / Geschichte 1945- (n248100)"}
+{"prefLabel":"Rheinhessen / Geschichte 1945-","uri":"http://purl.org/lobid/rpb#n248300","definition":"Geschichte (n240000) > Rheinhessen / Geschichte 1945- (n248300)"}
+{"prefLabel":"Pfalz / Geschichte 1945-","uri":"http://purl.org/lobid/rpb#n248500","definition":"Geschichte (n240000) > Pfalz / Geschichte 1945- (n248500)"}
+{"prefLabel":"Rheinland-Pfalz / Geschichte 1947-","uri":"http://purl.org/lobid/rpb#n249100","definition":"Geschichte (n240000) > Rheinland-Pfalz / Geschichte 1947- (n249100)"}
 {"prefLabel":"Militär- und Wehrwesen","uri":"http://purl.org/lobid/rpb#n260000"}
-{"prefLabel":"Militär- und Wehrwesen allgemein","uri":"http://purl.org/lobid/rpb#n260100"}
-{"prefLabel":"Militär","uri":"http://purl.org/lobid/rpb#n262000"}
-{"prefLabel":"Militärbau","uri":"http://purl.org/lobid/rpb#n262010"}
-{"prefLabel":"Burg","uri":"http://purl.org/lobid/rpb#n262011"}
-{"prefLabel":"Festung","uri":"http://purl.org/lobid/rpb#n262012"}
-{"prefLabel":"Schanze","uri":"http://purl.org/lobid/rpb#n262014"}
-{"prefLabel":"Standort","uri":"http://purl.org/lobid/rpb#n262016"}
-{"prefLabel":"Militär / Ausrüstung","uri":"http://purl.org/lobid/rpb#n262020"}
-{"prefLabel":"Kriegswaffe","uri":"http://purl.org/lobid/rpb#n262022"}
-{"prefLabel":"Rüstung","uri":"http://purl.org/lobid/rpb#n262023"}
-{"prefLabel":"Uniform","uri":"http://purl.org/lobid/rpb#n262024"}
-{"prefLabel":"Feldzeichen","uri":"http://purl.org/lobid/rpb#n262025"}
-{"prefLabel":"Orden / Ehrenzeichen","uri":"http://purl.org/lobid/rpb#n262026"}
-{"prefLabel":"Wehrwesen","uri":"http://purl.org/lobid/rpb#n263000"}
-{"prefLabel":"Bürgerwehr","uri":"http://purl.org/lobid/rpb#n263010"}
-{"prefLabel":"Militär / Geschichte Anfänge-1918","uri":"http://purl.org/lobid/rpb#n263020"}
-{"prefLabel":"Deutschland / Reichswehr","uri":"http://purl.org/lobid/rpb#n263030"}
-{"prefLabel":"Deutschland / Wehrmacht","uri":"http://purl.org/lobid/rpb#n263040"}
-{"prefLabel":"Ausländisches Militär","uri":"http://purl.org/lobid/rpb#n263050"}
-{"prefLabel":"Deutschland / Bundeswehr","uri":"http://purl.org/lobid/rpb#n263060"}
-{"prefLabel":"Soldat","uri":"http://purl.org/lobid/rpb#n263090"}
+{"prefLabel":"Militär- und Wehrwesen allgemein","uri":"http://purl.org/lobid/rpb#n260100","definition":"Militär- und Wehrwesen (n260000) > Militär- und Wehrwesen allgemein (n260100)"}
+{"prefLabel":"Militär","uri":"http://purl.org/lobid/rpb#n262000","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000)"}
+{"prefLabel":"Militärbau","uri":"http://purl.org/lobid/rpb#n262010","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010)"}
+{"prefLabel":"Burg","uri":"http://purl.org/lobid/rpb#n262011","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010) > Burg (n262011)"}
+{"prefLabel":"Festung","uri":"http://purl.org/lobid/rpb#n262012","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010) > Festung (n262012)"}
+{"prefLabel":"Schanze","uri":"http://purl.org/lobid/rpb#n262014","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010) > Schanze (n262014)"}
+{"prefLabel":"Standort","uri":"http://purl.org/lobid/rpb#n262016","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010) > Standort (n262016)"}
+{"prefLabel":"Militär / Ausrüstung","uri":"http://purl.org/lobid/rpb#n262020","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020)"}
+{"prefLabel":"Kriegswaffe","uri":"http://purl.org/lobid/rpb#n262022","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Kriegswaffe (n262022)"}
+{"prefLabel":"Rüstung","uri":"http://purl.org/lobid/rpb#n262023","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Rüstung (n262023)"}
+{"prefLabel":"Uniform","uri":"http://purl.org/lobid/rpb#n262024","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Uniform (n262024)"}
+{"prefLabel":"Feldzeichen","uri":"http://purl.org/lobid/rpb#n262025","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Feldzeichen (n262025)"}
+{"prefLabel":"Orden / Ehrenzeichen","uri":"http://purl.org/lobid/rpb#n262026","definition":"Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Orden / Ehrenzeichen (n262026)"}
+{"prefLabel":"Wehrwesen","uri":"http://purl.org/lobid/rpb#n263000","definition":"Militär- und Wehrwesen (n260000) > Wehrwesen (n263000)"}
+{"prefLabel":"Bürgerwehr","uri":"http://purl.org/lobid/rpb#n263010","definition":"Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Bürgerwehr (n263010)"}
+{"prefLabel":"Militär / Geschichte Anfänge-1918","uri":"http://purl.org/lobid/rpb#n263020","definition":"Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Militär / Geschichte Anfänge-1918 (n263020)"}
+{"prefLabel":"Deutschland / Reichswehr","uri":"http://purl.org/lobid/rpb#n263030","definition":"Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Deutschland / Reichswehr (n263030)"}
+{"prefLabel":"Deutschland / Wehrmacht","uri":"http://purl.org/lobid/rpb#n263040","definition":"Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Deutschland / Wehrmacht (n263040)"}
+{"prefLabel":"Ausländisches Militär","uri":"http://purl.org/lobid/rpb#n263050","definition":"Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Ausländisches Militär (n263050)"}
+{"prefLabel":"Deutschland / Bundeswehr","uri":"http://purl.org/lobid/rpb#n263060","definition":"Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Deutschland / Bundeswehr (n263060)"}
+{"prefLabel":"Soldat","uri":"http://purl.org/lobid/rpb#n263090","definition":"Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Soldat (n263090)"}
 {"prefLabel":"Staat. Politik","uri":"http://purl.org/lobid/rpb#n400000"}
-{"prefLabel":"Staat. Politik allgemein","uri":"http://purl.org/lobid/rpb#n400100"}
-{"prefLabel":"Staatsgrundlage","uri":"http://purl.org/lobid/rpb#n402000"}
-{"prefLabel":"Staatsrecht","uri":"http://purl.org/lobid/rpb#n402020"}
-{"prefLabel":"Staatsangehörigkeit","uri":"http://purl.org/lobid/rpb#n402030"}
-{"prefLabel":"Staatsgebiet","uri":"http://purl.org/lobid/rpb#n402040"}
-{"prefLabel":"Hoheitsrecht","uri":"http://purl.org/lobid/rpb#n402050"}
-{"prefLabel":"Staatsform","uri":"http://purl.org/lobid/rpb#n402060"}
-{"prefLabel":"Föderalismus","uri":"http://purl.org/lobid/rpb#n402070"}
-{"prefLabel":"Verfassung","uri":"http://purl.org/lobid/rpb#n402300"}
-{"prefLabel":"Verfassung / Geschichte","uri":"http://purl.org/lobid/rpb#n402330"}
-{"prefLabel":"Grundrecht","uri":"http://purl.org/lobid/rpb#n402340"}
-{"prefLabel":"Datenschutz","uri":"http://purl.org/lobid/rpb#n402344"}
-{"prefLabel":"Gewaltenteilung","uri":"http://purl.org/lobid/rpb#n402350"}
-{"prefLabel":"Politisches System","uri":"http://purl.org/lobid/rpb#n404000"}
-{"prefLabel":"Regierungsbildung","uri":"http://purl.org/lobid/rpb#n404030"}
-{"prefLabel":"Regierungschef","uri":"http://purl.org/lobid/rpb#n404040"}
-{"prefLabel":"Regierung","uri":"http://purl.org/lobid/rpb#n404050"}
-{"prefLabel":"Ministerium","uri":"http://purl.org/lobid/rpb#n404060"}
-{"prefLabel":"Regierungspolitik","uri":"http://purl.org/lobid/rpb#n404070"}
-{"prefLabel":"Landespartnerschaft","uri":"http://purl.org/lobid/rpb#n404090"}
-{"prefLabel":"Parlament","uri":"http://purl.org/lobid/rpb#n404300"}
-{"prefLabel":"Parlament / Geschichte","uri":"http://purl.org/lobid/rpb#n404320"}
-{"prefLabel":"Regierungspartei","uri":"http://purl.org/lobid/rpb#n404340"}
-{"prefLabel":"Opposition","uri":"http://purl.org/lobid/rpb#n404350"}
-{"prefLabel":"Parlamentsorganisation","uri":"http://purl.org/lobid/rpb#n404360"}
-{"prefLabel":"Parlamentsausschuss","uri":"http://purl.org/lobid/rpb#n404361"}
-{"prefLabel":"Ombudsmann","uri":"http://purl.org/lobid/rpb#n404365"}
-{"prefLabel":"Abgeordneter","uri":"http://purl.org/lobid/rpb#n404380"}
-{"prefLabel":"Politische Willensbildung","uri":"http://purl.org/lobid/rpb#n406000"}
-{"prefLabel":"Öffentlichkeitsarbeit","uri":"http://purl.org/lobid/rpb#n406020"}
-{"prefLabel":"Politische Bildung","uri":"http://purl.org/lobid/rpb#n406030"}
-{"prefLabel":"Öffentliche Meinung","uri":"http://purl.org/lobid/rpb#n406040"}
-{"prefLabel":"Politische Bewegung","uri":"http://purl.org/lobid/rpb#n406060"}
-{"prefLabel":"Parteistiftung","uri":"http://purl.org/lobid/rpb#n406080"}
-{"prefLabel":"Partei. Politikerin. Politiker","uri":"http://purl.org/lobid/rpb#n406100"}
-{"prefLabel":"Partei","uri":"http://purl.org/lobid/rpb#n406120"}
-{"prefLabel":"Politikerin. Politiker","uri":"http://purl.org/lobid/rpb#n406130"}
-{"prefLabel":"Politische Gruppe","uri":"http://purl.org/lobid/rpb#n406200"}
-{"prefLabel":"Politischer Verein","uri":"http://purl.org/lobid/rpb#n406230"}
-{"prefLabel":"Bürgerinitiative","uri":"http://purl.org/lobid/rpb#n406250"}
-{"prefLabel":"Projektgruppe","uri":"http://purl.org/lobid/rpb#n406270"}
-{"prefLabel":"Wahl","uri":"http://purl.org/lobid/rpb#n406300"}
-{"prefLabel":"Wahlrecht","uri":"http://purl.org/lobid/rpb#n406310"}
-{"prefLabel":"Wahlkreiseinteilung","uri":"http://purl.org/lobid/rpb#n406320"}
-{"prefLabel":"Volksabstimmung","uri":"http://purl.org/lobid/rpb#n406330"}
-{"prefLabel":"Europawahl","uri":"http://purl.org/lobid/rpb#n406340"}
-{"prefLabel":"Bundestagswahl","uri":"http://purl.org/lobid/rpb#n406350"}
-{"prefLabel":"Landtagswahl","uri":"http://purl.org/lobid/rpb#n406360"}
-{"prefLabel":"Kreistag / Wahl","uri":"http://purl.org/lobid/rpb#n406370"}
-{"prefLabel":"Bezirkstag / Wahl","uri":"http://purl.org/lobid/rpb#n406380"}
-{"prefLabel":"Kommunalwahl","uri":"http://purl.org/lobid/rpb#n406390"}
+{"prefLabel":"Staat. Politik allgemein","uri":"http://purl.org/lobid/rpb#n400100","definition":"Staat. Politik (n400000) > Staat. Politik allgemein (n400100)"}
+{"prefLabel":"Staatsgrundlage","uri":"http://purl.org/lobid/rpb#n402000","definition":"Staat. Politik (n400000) > Staatsgrundlage (n402000)"}
+{"prefLabel":"Staatsrecht","uri":"http://purl.org/lobid/rpb#n402020","definition":"Staat. Politik (n400000) > Staatsgrundlage (n402000) > Staatsrecht (n402020)"}
+{"prefLabel":"Staatsangehörigkeit","uri":"http://purl.org/lobid/rpb#n402030","definition":"Staat. Politik (n400000) > Staatsgrundlage (n402000) > Staatsangehörigkeit (n402030)"}
+{"prefLabel":"Staatsgebiet","uri":"http://purl.org/lobid/rpb#n402040","definition":"Staat. Politik (n400000) > Staatsgrundlage (n402000) > Staatsgebiet (n402040)"}
+{"prefLabel":"Hoheitsrecht","uri":"http://purl.org/lobid/rpb#n402050","definition":"Staat. Politik (n400000) > Staatsgrundlage (n402000) > Hoheitsrecht (n402050)"}
+{"prefLabel":"Staatsform","uri":"http://purl.org/lobid/rpb#n402060","definition":"Staat. Politik (n400000) > Staatsgrundlage (n402000) > Staatsform (n402060)"}
+{"prefLabel":"Föderalismus","uri":"http://purl.org/lobid/rpb#n402070","definition":"Staat. Politik (n400000) > Staatsgrundlage (n402000) > Föderalismus (n402070)"}
+{"prefLabel":"Verfassung","uri":"http://purl.org/lobid/rpb#n402300","definition":"Staat. Politik (n400000) > Verfassung (n402300)"}
+{"prefLabel":"Verfassung / Geschichte","uri":"http://purl.org/lobid/rpb#n402330","definition":"Staat. Politik (n400000) > Verfassung (n402300) > Verfassung / Geschichte (n402330)"}
+{"prefLabel":"Grundrecht","uri":"http://purl.org/lobid/rpb#n402340","definition":"Staat. Politik (n400000) > Verfassung (n402300) > Grundrecht (n402340)"}
+{"prefLabel":"Datenschutz","uri":"http://purl.org/lobid/rpb#n402344","definition":"Staat. Politik (n400000) > Verfassung (n402300) > Grundrecht (n402340) > Datenschutz (n402344)"}
+{"prefLabel":"Gewaltenteilung","uri":"http://purl.org/lobid/rpb#n402350","definition":"Staat. Politik (n400000) > Verfassung (n402300) > Gewaltenteilung (n402350)"}
+{"prefLabel":"Politisches System","uri":"http://purl.org/lobid/rpb#n404000","definition":"Staat. Politik (n400000) > Politisches System (n404000)"}
+{"prefLabel":"Regierungsbildung","uri":"http://purl.org/lobid/rpb#n404030","definition":"Staat. Politik (n400000) > Politisches System (n404000) > Regierungsbildung (n404030)"}
+{"prefLabel":"Regierungschef","uri":"http://purl.org/lobid/rpb#n404040","definition":"Staat. Politik (n400000) > Politisches System (n404000) > Regierungschef (n404040)"}
+{"prefLabel":"Regierung","uri":"http://purl.org/lobid/rpb#n404050","definition":"Staat. Politik (n400000) > Politisches System (n404000) > Regierung (n404050)"}
+{"prefLabel":"Ministerium","uri":"http://purl.org/lobid/rpb#n404060","definition":"Staat. Politik (n400000) > Politisches System (n404000) > Ministerium (n404060)"}
+{"prefLabel":"Regierungspolitik","uri":"http://purl.org/lobid/rpb#n404070","definition":"Staat. Politik (n400000) > Politisches System (n404000) > Regierungspolitik (n404070)"}
+{"prefLabel":"Landespartnerschaft","uri":"http://purl.org/lobid/rpb#n404090","definition":"Staat. Politik (n400000) > Politisches System (n404000) > Landespartnerschaft (n404090)"}
+{"prefLabel":"Parlament","uri":"http://purl.org/lobid/rpb#n404300","definition":"Staat. Politik (n400000) > Parlament (n404300)"}
+{"prefLabel":"Parlament / Geschichte","uri":"http://purl.org/lobid/rpb#n404320","definition":"Staat. Politik (n400000) > Parlament (n404300) > Parlament / Geschichte (n404320)"}
+{"prefLabel":"Regierungspartei","uri":"http://purl.org/lobid/rpb#n404340","definition":"Staat. Politik (n400000) > Parlament (n404300) > Regierungspartei (n404340)"}
+{"prefLabel":"Opposition","uri":"http://purl.org/lobid/rpb#n404350","definition":"Staat. Politik (n400000) > Parlament (n404300) > Opposition (n404350)"}
+{"prefLabel":"Parlamentsorganisation","uri":"http://purl.org/lobid/rpb#n404360","definition":"Staat. Politik (n400000) > Parlament (n404300) > Parlamentsorganisation (n404360)"}
+{"prefLabel":"Parlamentsausschuss","uri":"http://purl.org/lobid/rpb#n404361","definition":"Staat. Politik (n400000) > Parlament (n404300) > Parlamentsorganisation (n404360) > Parlamentsausschuss (n404361)"}
+{"prefLabel":"Ombudsmann","uri":"http://purl.org/lobid/rpb#n404365","definition":"Staat. Politik (n400000) > Parlament (n404300) > Parlamentsorganisation (n404360) > Ombudsmann (n404365)"}
+{"prefLabel":"Abgeordneter","uri":"http://purl.org/lobid/rpb#n404380","definition":"Staat. Politik (n400000) > Parlament (n404300) > Abgeordneter (n404380)"}
+{"prefLabel":"Politische Willensbildung","uri":"http://purl.org/lobid/rpb#n406000","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000)"}
+{"prefLabel":"Öffentlichkeitsarbeit","uri":"http://purl.org/lobid/rpb#n406020","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Öffentlichkeitsarbeit (n406020)"}
+{"prefLabel":"Politische Bildung","uri":"http://purl.org/lobid/rpb#n406030","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Bildung (n406030)"}
+{"prefLabel":"Öffentliche Meinung","uri":"http://purl.org/lobid/rpb#n406040","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Öffentliche Meinung (n406040)"}
+{"prefLabel":"Politische Bewegung","uri":"http://purl.org/lobid/rpb#n406060","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Bewegung (n406060)"}
+{"prefLabel":"Parteistiftung","uri":"http://purl.org/lobid/rpb#n406080","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Parteistiftung (n406080)"}
+{"prefLabel":"Partei. Politikerin. Politiker","uri":"http://purl.org/lobid/rpb#n406100","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Partei. Politikerin. Politiker (n406100)"}
+{"prefLabel":"Partei","uri":"http://purl.org/lobid/rpb#n406120","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Partei. Politikerin. Politiker (n406100) > Partei (n406120)"}
+{"prefLabel":"Politikerin. Politiker","uri":"http://purl.org/lobid/rpb#n406130","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Partei. Politikerin. Politiker (n406100) > Politikerin. Politiker (n406130)"}
+{"prefLabel":"Politische Gruppe","uri":"http://purl.org/lobid/rpb#n406200","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Gruppe (n406200)"}
+{"prefLabel":"Politischer Verein","uri":"http://purl.org/lobid/rpb#n406230","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Gruppe (n406200) > Politischer Verein (n406230)"}
+{"prefLabel":"Bürgerinitiative","uri":"http://purl.org/lobid/rpb#n406250","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Gruppe (n406200) > Bürgerinitiative (n406250)"}
+{"prefLabel":"Projektgruppe","uri":"http://purl.org/lobid/rpb#n406270","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Gruppe (n406200) > Projektgruppe (n406270)"}
+{"prefLabel":"Wahl","uri":"http://purl.org/lobid/rpb#n406300","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300)"}
+{"prefLabel":"Wahlrecht","uri":"http://purl.org/lobid/rpb#n406310","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Wahlrecht (n406310)"}
+{"prefLabel":"Wahlkreiseinteilung","uri":"http://purl.org/lobid/rpb#n406320","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Wahlkreiseinteilung (n406320)"}
+{"prefLabel":"Volksabstimmung","uri":"http://purl.org/lobid/rpb#n406330","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Volksabstimmung (n406330)"}
+{"prefLabel":"Europawahl","uri":"http://purl.org/lobid/rpb#n406340","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Europawahl (n406340)"}
+{"prefLabel":"Bundestagswahl","uri":"http://purl.org/lobid/rpb#n406350","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Bundestagswahl (n406350)"}
+{"prefLabel":"Landtagswahl","uri":"http://purl.org/lobid/rpb#n406360","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Landtagswahl (n406360)"}
+{"prefLabel":"Kreistag / Wahl","uri":"http://purl.org/lobid/rpb#n406370","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Kreistag / Wahl (n406370)"}
+{"prefLabel":"Bezirkstag / Wahl","uri":"http://purl.org/lobid/rpb#n406380","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Bezirkstag / Wahl (n406380)"}
+{"prefLabel":"Kommunalwahl","uri":"http://purl.org/lobid/rpb#n406390","definition":"Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Kommunalwahl (n406390)"}
 {"prefLabel":"Verwaltung","uri":"http://purl.org/lobid/rpb#n420000"}
-{"prefLabel":"Verwaltung allgemein","uri":"http://purl.org/lobid/rpb#n420100"}
-{"prefLabel":"Verwaltungsrecht","uri":"http://purl.org/lobid/rpb#n421000"}
-{"prefLabel":"Verwaltungskontrolle","uri":"http://purl.org/lobid/rpb#n421400"}
-{"prefLabel":"Verwaltung / Geschichte","uri":"http://purl.org/lobid/rpb#n422000"}
-{"prefLabel":"Allgemeine Verwaltung","uri":"http://purl.org/lobid/rpb#n423000"}
-{"prefLabel":"Verwaltung / Struktur","uri":"http://purl.org/lobid/rpb#n423020"}
-{"prefLabel":"Behörde / Organisation","uri":"http://purl.org/lobid/rpb#n423030"}
-{"prefLabel":"Behörde / Datenverarbeitung","uri":"http://purl.org/lobid/rpb#n423050"}
-{"prefLabel":"Verwaltungsreform","uri":"http://purl.org/lobid/rpb#n423400"}
-{"prefLabel":"Länderneugliederung","uri":"http://purl.org/lobid/rpb#n423420"}
-{"prefLabel":"Gebietsreform","uri":"http://purl.org/lobid/rpb#n423430"}
-{"prefLabel":"Funktionalreform","uri":"http://purl.org/lobid/rpb#n423440"}
-{"prefLabel":"Öffentlicher Dienst","uri":"http://purl.org/lobid/rpb#n423600"}
-{"prefLabel":"Dienstrecht","uri":"http://purl.org/lobid/rpb#n423610"}
-{"prefLabel":"Personalwesen","uri":"http://purl.org/lobid/rpb#n423620"}
-{"prefLabel":"Beamter","uri":"http://purl.org/lobid/rpb#n423640"}
-{"prefLabel":"Öffentlicher Haushalt","uri":"http://purl.org/lobid/rpb#n424000"}
-{"prefLabel":"Finanzverwaltung","uri":"http://purl.org/lobid/rpb#n424020"}
-{"prefLabel":"Finanzamt","uri":"http://purl.org/lobid/rpb#n424021"}
-{"prefLabel":"Finanzausgleich","uri":"http://purl.org/lobid/rpb#n424022"}
-{"prefLabel":"Finanzreform","uri":"http://purl.org/lobid/rpb#n424024"}
-{"prefLabel":"Öffentliche Beschaffung","uri":"http://purl.org/lobid/rpb#n424026"}
-{"prefLabel":"Rechnungshof","uri":"http://purl.org/lobid/rpb#n424028"}
-{"prefLabel":"Abgabe","uri":"http://purl.org/lobid/rpb#n424030"}
-{"prefLabel":"Steuer","uri":"http://purl.org/lobid/rpb#n424040"}
-{"prefLabel":"Steuerberatung","uri":"http://purl.org/lobid/rpb#n424042"}
-{"prefLabel":"Gebühr","uri":"http://purl.org/lobid/rpb#n424050"}
-{"prefLabel":"Zoll","uri":"http://purl.org/lobid/rpb#n424060"}
-{"prefLabel":"Bezirksverwaltung","uri":"http://purl.org/lobid/rpb#n425000"}
-{"prefLabel":"Regierungspräsident","uri":"http://purl.org/lobid/rpb#n425020"}
-{"prefLabel":"Regierungsbezirk Koblenz","uri":"http://purl.org/lobid/rpb#n425030"}
-{"prefLabel":"Regierungsbezirk Trier","uri":"http://purl.org/lobid/rpb#n425040"}
-{"prefLabel":"Regierungsbezirk Rheinhessen-Pfalz","uri":"http://purl.org/lobid/rpb#n425050"}
-{"prefLabel":"Bezirksverband Pfalz","uri":"http://purl.org/lobid/rpb#n425052"}
-{"prefLabel":"Kreisverwaltung","uri":"http://purl.org/lobid/rpb#n425200"}
-{"prefLabel":"Kreisrecht","uri":"http://purl.org/lobid/rpb#n425220"}
-{"prefLabel":"Kreisparlament","uri":"http://purl.org/lobid/rpb#n425230"}
-{"prefLabel":"Kreispartnerschaft","uri":"http://purl.org/lobid/rpb#n425290"}
-{"prefLabel":"Gemeindeverwaltung","uri":"http://purl.org/lobid/rpb#n426000"}
-{"prefLabel":"Ortsrecht","uri":"http://purl.org/lobid/rpb#n426020"}
-{"prefLabel":"Gemeinderat","uri":"http://purl.org/lobid/rpb#n426030"}
-{"prefLabel":"Kommunale Selbstverwaltung","uri":"http://purl.org/lobid/rpb#n426040"}
-{"prefLabel":"Auftragsverwaltung","uri":"http://purl.org/lobid/rpb#n426050"}
-{"prefLabel":"Kommunaler Spitzenverband","uri":"http://purl.org/lobid/rpb#n426060"}
-{"prefLabel":"Verbandsgemeinde","uri":"http://purl.org/lobid/rpb#n426070"}
-{"prefLabel":"Kommunale Partnerschaft","uri":"http://purl.org/lobid/rpb#n426090"}
-{"prefLabel":"Obere Landesbehörde","uri":"http://purl.org/lobid/rpb#n427000"}
-{"prefLabel":"Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Nord","uri":"http://purl.org/lobid/rpb#n427010"}
-{"prefLabel":"Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Süd","uri":"http://purl.org/lobid/rpb#n427020"}
-{"prefLabel":"Rheinland-Pfalz / Aufsichts- und Dienstleistungsdirektion","uri":"http://purl.org/lobid/rpb#n427030"}
-{"prefLabel":"Rheinland-Pfalz / Landesuntersuchungsamt","uri":"http://purl.org/lobid/rpb#n427040"}
-{"prefLabel":"Sicherheit und Ordnung","uri":"http://purl.org/lobid/rpb#n428000"}
-{"prefLabel":"Ordnungsrecht","uri":"http://purl.org/lobid/rpb#n428020"}
-{"prefLabel":"Polizei","uri":"http://purl.org/lobid/rpb#n428030"}
-{"prefLabel":"Polizeiorganisation","uri":"http://purl.org/lobid/rpb#n428032"}
-{"prefLabel":"Polizei / Ausrüstung","uri":"http://purl.org/lobid/rpb#n428033"}
-{"prefLabel":"Zivilschutz","uri":"http://purl.org/lobid/rpb#n428040"}
-{"prefLabel":"Staatsschutz","uri":"http://purl.org/lobid/rpb#n428050"}
-{"prefLabel":"Grenzschutz","uri":"http://purl.org/lobid/rpb#n428052"}
-{"prefLabel":"Verfassungsschutz","uri":"http://purl.org/lobid/rpb#n428054"}
-{"prefLabel":"Personenstandswesen","uri":"http://purl.org/lobid/rpb#n428060"}
-{"prefLabel":"Sicherheitsbehörde","uri":"http://purl.org/lobid/rpb#n428070"}
-{"prefLabel":"Technischer Überwachungsverein","uri":"http://purl.org/lobid/rpb#n428072"}
-{"prefLabel":"Feuerwehr","uri":"http://purl.org/lobid/rpb#n428074"}
-{"prefLabel":"Rettungswesen","uri":"http://purl.org/lobid/rpb#n428076"}
-{"prefLabel":"Katastrophe. Unfall","uri":"http://purl.org/lobid/rpb#n428078"}
-{"prefLabel":"Friedhofsordnung","uri":"http://purl.org/lobid/rpb#n428080"}
+{"prefLabel":"Verwaltung allgemein","uri":"http://purl.org/lobid/rpb#n420100","definition":"Verwaltung (n420000) > Verwaltung allgemein (n420100)"}
+{"prefLabel":"Verwaltungsrecht","uri":"http://purl.org/lobid/rpb#n421000","definition":"Verwaltung (n420000) > Verwaltungsrecht (n421000)"}
+{"prefLabel":"Verwaltungskontrolle","uri":"http://purl.org/lobid/rpb#n421400","definition":"Verwaltung (n420000) > Verwaltungskontrolle (n421400)"}
+{"prefLabel":"Verwaltung / Geschichte","uri":"http://purl.org/lobid/rpb#n422000","definition":"Verwaltung (n420000) > Verwaltung / Geschichte (n422000)"}
+{"prefLabel":"Allgemeine Verwaltung","uri":"http://purl.org/lobid/rpb#n423000","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000)"}
+{"prefLabel":"Verwaltung / Struktur","uri":"http://purl.org/lobid/rpb#n423020","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltung / Struktur (n423020)"}
+{"prefLabel":"Behörde / Organisation","uri":"http://purl.org/lobid/rpb#n423030","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Behörde / Organisation (n423030)"}
+{"prefLabel":"Behörde / Datenverarbeitung","uri":"http://purl.org/lobid/rpb#n423050","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Behörde / Datenverarbeitung (n423050)"}
+{"prefLabel":"Verwaltungsreform","uri":"http://purl.org/lobid/rpb#n423400","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltungsreform (n423400)"}
+{"prefLabel":"Länderneugliederung","uri":"http://purl.org/lobid/rpb#n423420","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltungsreform (n423400) > Länderneugliederung (n423420)"}
+{"prefLabel":"Gebietsreform","uri":"http://purl.org/lobid/rpb#n423430","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltungsreform (n423400) > Gebietsreform (n423430)"}
+{"prefLabel":"Funktionalreform","uri":"http://purl.org/lobid/rpb#n423440","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltungsreform (n423400) > Funktionalreform (n423440)"}
+{"prefLabel":"Öffentlicher Dienst","uri":"http://purl.org/lobid/rpb#n423600","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Öffentlicher Dienst (n423600)"}
+{"prefLabel":"Dienstrecht","uri":"http://purl.org/lobid/rpb#n423610","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Öffentlicher Dienst (n423600) > Dienstrecht (n423610)"}
+{"prefLabel":"Personalwesen","uri":"http://purl.org/lobid/rpb#n423620","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Öffentlicher Dienst (n423600) > Personalwesen (n423620)"}
+{"prefLabel":"Beamter","uri":"http://purl.org/lobid/rpb#n423640","definition":"Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Öffentlicher Dienst (n423600) > Beamter (n423640)"}
+{"prefLabel":"Öffentlicher Haushalt","uri":"http://purl.org/lobid/rpb#n424000","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000)"}
+{"prefLabel":"Finanzverwaltung","uri":"http://purl.org/lobid/rpb#n424020","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020)"}
+{"prefLabel":"Finanzamt","uri":"http://purl.org/lobid/rpb#n424021","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Finanzamt (n424021)"}
+{"prefLabel":"Finanzausgleich","uri":"http://purl.org/lobid/rpb#n424022","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Finanzausgleich (n424022)"}
+{"prefLabel":"Finanzreform","uri":"http://purl.org/lobid/rpb#n424024","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Finanzreform (n424024)"}
+{"prefLabel":"Öffentliche Beschaffung","uri":"http://purl.org/lobid/rpb#n424026","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Öffentliche Beschaffung (n424026)"}
+{"prefLabel":"Rechnungshof","uri":"http://purl.org/lobid/rpb#n424028","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Rechnungshof (n424028)"}
+{"prefLabel":"Abgabe","uri":"http://purl.org/lobid/rpb#n424030","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Abgabe (n424030)"}
+{"prefLabel":"Steuer","uri":"http://purl.org/lobid/rpb#n424040","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Steuer (n424040)"}
+{"prefLabel":"Steuerberatung","uri":"http://purl.org/lobid/rpb#n424042","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Steuer (n424040) > Steuerberatung (n424042)"}
+{"prefLabel":"Gebühr","uri":"http://purl.org/lobid/rpb#n424050","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Gebühr (n424050)"}
+{"prefLabel":"Zoll","uri":"http://purl.org/lobid/rpb#n424060","definition":"Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Zoll (n424060)"}
+{"prefLabel":"Bezirksverwaltung","uri":"http://purl.org/lobid/rpb#n425000","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000)"}
+{"prefLabel":"Regierungspräsident","uri":"http://purl.org/lobid/rpb#n425020","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungspräsident (n425020)"}
+{"prefLabel":"Regierungsbezirk Koblenz","uri":"http://purl.org/lobid/rpb#n425030","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungsbezirk Koblenz (n425030)"}
+{"prefLabel":"Regierungsbezirk Trier","uri":"http://purl.org/lobid/rpb#n425040","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungsbezirk Trier (n425040)"}
+{"prefLabel":"Regierungsbezirk Rheinhessen-Pfalz","uri":"http://purl.org/lobid/rpb#n425050","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungsbezirk Rheinhessen-Pfalz (n425050)"}
+{"prefLabel":"Bezirksverband Pfalz","uri":"http://purl.org/lobid/rpb#n425052","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungsbezirk Rheinhessen-Pfalz (n425050) > Bezirksverband Pfalz (n425052)"}
+{"prefLabel":"Kreisverwaltung","uri":"http://purl.org/lobid/rpb#n425200","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000) > Kreisverwaltung (n425200)"}
+{"prefLabel":"Kreisrecht","uri":"http://purl.org/lobid/rpb#n425220","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000) > Kreisverwaltung (n425200) > Kreisrecht (n425220)"}
+{"prefLabel":"Kreisparlament","uri":"http://purl.org/lobid/rpb#n425230","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000) > Kreisverwaltung (n425200) > Kreisparlament (n425230)"}
+{"prefLabel":"Kreispartnerschaft","uri":"http://purl.org/lobid/rpb#n425290","definition":"Verwaltung (n420000) > Bezirksverwaltung (n425000) > Kreisverwaltung (n425200) > Kreispartnerschaft (n425290)"}
+{"prefLabel":"Gemeindeverwaltung","uri":"http://purl.org/lobid/rpb#n426000","definition":"Verwaltung (n420000) > Gemeindeverwaltung (n426000)"}
+{"prefLabel":"Ortsrecht","uri":"http://purl.org/lobid/rpb#n426020","definition":"Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Ortsrecht (n426020)"}
+{"prefLabel":"Gemeinderat","uri":"http://purl.org/lobid/rpb#n426030","definition":"Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Gemeinderat (n426030)"}
+{"prefLabel":"Kommunale Selbstverwaltung","uri":"http://purl.org/lobid/rpb#n426040","definition":"Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Kommunale Selbstverwaltung (n426040)"}
+{"prefLabel":"Auftragsverwaltung","uri":"http://purl.org/lobid/rpb#n426050","definition":"Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Auftragsverwaltung (n426050)"}
+{"prefLabel":"Kommunaler Spitzenverband","uri":"http://purl.org/lobid/rpb#n426060","definition":"Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Kommunaler Spitzenverband (n426060)"}
+{"prefLabel":"Verbandsgemeinde","uri":"http://purl.org/lobid/rpb#n426070","definition":"Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Verbandsgemeinde (n426070)"}
+{"prefLabel":"Kommunale Partnerschaft","uri":"http://purl.org/lobid/rpb#n426090","definition":"Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Kommunale Partnerschaft (n426090)"}
+{"prefLabel":"Obere Landesbehörde","uri":"http://purl.org/lobid/rpb#n427000","definition":"Verwaltung (n420000) > Obere Landesbehörde (n427000)"}
+{"prefLabel":"Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Nord","uri":"http://purl.org/lobid/rpb#n427010","definition":"Verwaltung (n420000) > Obere Landesbehörde (n427000) > Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Nord (n427010)"}
+{"prefLabel":"Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Süd","uri":"http://purl.org/lobid/rpb#n427020","definition":"Verwaltung (n420000) > Obere Landesbehörde (n427000) > Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Süd (n427020)"}
+{"prefLabel":"Rheinland-Pfalz / Aufsichts- und Dienstleistungsdirektion","uri":"http://purl.org/lobid/rpb#n427030","definition":"Verwaltung (n420000) > Obere Landesbehörde (n427000) > Rheinland-Pfalz / Aufsichts- und Dienstleistungsdirektion (n427030)"}
+{"prefLabel":"Rheinland-Pfalz / Landesuntersuchungsamt","uri":"http://purl.org/lobid/rpb#n427040","definition":"Verwaltung (n420000) > Obere Landesbehörde (n427000) > Rheinland-Pfalz / Landesuntersuchungsamt (n427040)"}
+{"prefLabel":"Sicherheit und Ordnung","uri":"http://purl.org/lobid/rpb#n428000","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000)"}
+{"prefLabel":"Ordnungsrecht","uri":"http://purl.org/lobid/rpb#n428020","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Ordnungsrecht (n428020)"}
+{"prefLabel":"Polizei","uri":"http://purl.org/lobid/rpb#n428030","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Polizei (n428030)"}
+{"prefLabel":"Polizeiorganisation","uri":"http://purl.org/lobid/rpb#n428032","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Polizei (n428030) > Polizeiorganisation (n428032)"}
+{"prefLabel":"Polizei / Ausrüstung","uri":"http://purl.org/lobid/rpb#n428033","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Polizei (n428030) > Polizei / Ausrüstung (n428033)"}
+{"prefLabel":"Zivilschutz","uri":"http://purl.org/lobid/rpb#n428040","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Zivilschutz (n428040)"}
+{"prefLabel":"Staatsschutz","uri":"http://purl.org/lobid/rpb#n428050","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Staatsschutz (n428050)"}
+{"prefLabel":"Grenzschutz","uri":"http://purl.org/lobid/rpb#n428052","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Staatsschutz (n428050) > Grenzschutz (n428052)"}
+{"prefLabel":"Verfassungsschutz","uri":"http://purl.org/lobid/rpb#n428054","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Staatsschutz (n428050) > Verfassungsschutz (n428054)"}
+{"prefLabel":"Personenstandswesen","uri":"http://purl.org/lobid/rpb#n428060","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Personenstandswesen (n428060)"}
+{"prefLabel":"Sicherheitsbehörde","uri":"http://purl.org/lobid/rpb#n428070","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070)"}
+{"prefLabel":"Technischer Überwachungsverein","uri":"http://purl.org/lobid/rpb#n428072","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070) > Technischer Überwachungsverein (n428072)"}
+{"prefLabel":"Feuerwehr","uri":"http://purl.org/lobid/rpb#n428074","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070) > Feuerwehr (n428074)"}
+{"prefLabel":"Rettungswesen","uri":"http://purl.org/lobid/rpb#n428076","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070) > Rettungswesen (n428076)"}
+{"prefLabel":"Katastrophe. Unfall","uri":"http://purl.org/lobid/rpb#n428078","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070) > Katastrophe. Unfall (n428078)"}
+{"prefLabel":"Friedhofsordnung","uri":"http://purl.org/lobid/rpb#n428080","definition":"Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Friedhofsordnung (n428080)"}
 {"prefLabel":"Recht","uri":"http://purl.org/lobid/rpb#n440000"}
-{"prefLabel":"Recht allgemein","uri":"http://purl.org/lobid/rpb#n440100"}
-{"prefLabel":"Recht / Geschichte","uri":"http://purl.org/lobid/rpb#n442000"}
-{"prefLabel":"Recht / Geschichte / Quelle","uri":"http://purl.org/lobid/rpb#n442050"}
-{"prefLabel":"Privatrecht","uri":"http://purl.org/lobid/rpb#n443000"}
-{"prefLabel":"Strafrecht","uri":"http://purl.org/lobid/rpb#n444000"}
-{"prefLabel":"Strafvollzug","uri":"http://purl.org/lobid/rpb#n444030"}
-{"prefLabel":"Kriminalität","uri":"http://purl.org/lobid/rpb#n444050"}
-{"prefLabel":"Kriminalfall","uri":"http://purl.org/lobid/rpb#n444070"}
-{"prefLabel":"Gerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446000"}
-{"prefLabel":"Verfassungsgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446010"}
-{"prefLabel":"Ordentliche Gerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446030"}
-{"prefLabel":"Strafgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446032"}
-{"prefLabel":"Zivilgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446034"}
-{"prefLabel":"Verwaltungsgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446050"}
-{"prefLabel":"Finanzgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446060"}
-{"prefLabel":"Arbeitsgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446070"}
-{"prefLabel":"Sozialgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446080"}
-{"prefLabel":"Rechtsprechung","uri":"http://purl.org/lobid/rpb#n447000"}
-{"prefLabel":"Rechtspflege","uri":"http://purl.org/lobid/rpb#n448000"}
+{"prefLabel":"Recht allgemein","uri":"http://purl.org/lobid/rpb#n440100","definition":"Recht (n440000) > Recht allgemein (n440100)"}
+{"prefLabel":"Recht / Geschichte","uri":"http://purl.org/lobid/rpb#n442000","definition":"Recht (n440000) > Recht / Geschichte (n442000)"}
+{"prefLabel":"Recht / Geschichte / Quelle","uri":"http://purl.org/lobid/rpb#n442050","definition":"Recht (n440000) > Recht / Geschichte (n442000) > Recht / Geschichte / Quelle (n442050)"}
+{"prefLabel":"Privatrecht","uri":"http://purl.org/lobid/rpb#n443000","definition":"Recht (n440000) > Privatrecht (n443000)"}
+{"prefLabel":"Strafrecht","uri":"http://purl.org/lobid/rpb#n444000","definition":"Recht (n440000) > Strafrecht (n444000)"}
+{"prefLabel":"Strafvollzug","uri":"http://purl.org/lobid/rpb#n444030","definition":"Recht (n440000) > Strafrecht (n444000) > Strafvollzug (n444030)"}
+{"prefLabel":"Kriminalität","uri":"http://purl.org/lobid/rpb#n444050","definition":"Recht (n440000) > Strafrecht (n444000) > Kriminalität (n444050)"}
+{"prefLabel":"Kriminalfall","uri":"http://purl.org/lobid/rpb#n444070","definition":"Recht (n440000) > Strafrecht (n444000) > Kriminalfall (n444070)"}
+{"prefLabel":"Gerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446000","definition":"Recht (n440000) > Gerichtsbarkeit (n446000)"}
+{"prefLabel":"Verfassungsgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446010","definition":"Recht (n440000) > Gerichtsbarkeit (n446000) > Verfassungsgerichtsbarkeit (n446010)"}
+{"prefLabel":"Ordentliche Gerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446030","definition":"Recht (n440000) > Gerichtsbarkeit (n446000) > Ordentliche Gerichtsbarkeit (n446030)"}
+{"prefLabel":"Strafgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446032","definition":"Recht (n440000) > Gerichtsbarkeit (n446000) > Ordentliche Gerichtsbarkeit (n446030) > Strafgerichtsbarkeit (n446032)"}
+{"prefLabel":"Zivilgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446034","definition":"Recht (n440000) > Gerichtsbarkeit (n446000) > Ordentliche Gerichtsbarkeit (n446030) > Zivilgerichtsbarkeit (n446034)"}
+{"prefLabel":"Verwaltungsgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446050","definition":"Recht (n440000) > Gerichtsbarkeit (n446000) > Verwaltungsgerichtsbarkeit (n446050)"}
+{"prefLabel":"Finanzgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446060","definition":"Recht (n440000) > Gerichtsbarkeit (n446000) > Finanzgerichtsbarkeit (n446060)"}
+{"prefLabel":"Arbeitsgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446070","definition":"Recht (n440000) > Gerichtsbarkeit (n446000) > Arbeitsgerichtsbarkeit (n446070)"}
+{"prefLabel":"Sozialgerichtsbarkeit","uri":"http://purl.org/lobid/rpb#n446080","definition":"Recht (n440000) > Gerichtsbarkeit (n446000) > Sozialgerichtsbarkeit (n446080)"}
+{"prefLabel":"Rechtsprechung","uri":"http://purl.org/lobid/rpb#n447000","definition":"Recht (n440000) > Rechtsprechung (n447000)"}
+{"prefLabel":"Rechtspflege","uri":"http://purl.org/lobid/rpb#n448000","definition":"Recht (n440000) > Rechtspflege (n448000)"}
 {"prefLabel":"Bevölkerung","uri":"http://purl.org/lobid/rpb#n500000"}
-{"prefLabel":"Bevölkerung allgemein","uri":"http://purl.org/lobid/rpb#n500100"}
-{"prefLabel":"Bevölkerung / Geschichte","uri":"http://purl.org/lobid/rpb#n502000"}
-{"prefLabel":"Bevölkerungsstruktur","uri":"http://purl.org/lobid/rpb#n503000"}
-{"prefLabel":"Altersstruktur","uri":"http://purl.org/lobid/rpb#n503020"}
-{"prefLabel":"Geschlechtsverhältnis","uri":"http://purl.org/lobid/rpb#n503030"}
-{"prefLabel":"Volkszählung","uri":"http://purl.org/lobid/rpb#n503040"}
-{"prefLabel":"Einwohnerverzeichnis","uri":"http://purl.org/lobid/rpb#n503050"}
-{"prefLabel":"Haushaltsgrösse","uri":"http://purl.org/lobid/rpb#n503060"}
-{"prefLabel":"Wohnstandard","uri":"http://purl.org/lobid/rpb#n503070"}
-{"prefLabel":"Einkommensstatistik","uri":"http://purl.org/lobid/rpb#n503080"}
-{"prefLabel":"Denomination / Religion","uri":"http://purl.org/lobid/rpb#n503090"}
-{"prefLabel":"Bevölkerungsentwicklung","uri":"http://purl.org/lobid/rpb#n503200"}
-{"prefLabel":"Bevölkerungspolitik","uri":"http://purl.org/lobid/rpb#n503220"}
-{"prefLabel":"Geburt / Statistik","uri":"http://purl.org/lobid/rpb#n503230"}
-{"prefLabel":"Heirat / Statistik","uri":"http://purl.org/lobid/rpb#n503240"}
-{"prefLabel":"Tod / Statistik","uri":"http://purl.org/lobid/rpb#n503250"}
-{"prefLabel":"Bevölkerungsentwicklung / Prognose","uri":"http://purl.org/lobid/rpb#n503260"}
-{"prefLabel":"Migration","uri":"http://purl.org/lobid/rpb#n503400"}
-{"prefLabel":"Binnenwanderung","uri":"http://purl.org/lobid/rpb#n503420"}
-{"prefLabel":"Berufspendlerin. Berufspendler","uri":"http://purl.org/lobid/rpb#n503424"}
-{"prefLabel":"Auswanderung","uri":"http://purl.org/lobid/rpb#n503430"}
-{"prefLabel":"Einwanderung","uri":"http://purl.org/lobid/rpb#n503440"}
-{"prefLabel":"Bevölkerungsdichte","uri":"http://purl.org/lobid/rpb#n503600"}
+{"prefLabel":"Bevölkerung allgemein","uri":"http://purl.org/lobid/rpb#n500100","definition":"Bevölkerung (n500000) > Bevölkerung allgemein (n500100)"}
+{"prefLabel":"Bevölkerung / Geschichte","uri":"http://purl.org/lobid/rpb#n502000","definition":"Bevölkerung (n500000) > Bevölkerung / Geschichte (n502000)"}
+{"prefLabel":"Bevölkerungsstruktur","uri":"http://purl.org/lobid/rpb#n503000","definition":"Bevölkerung (n500000) > Bevölkerungsstruktur (n503000)"}
+{"prefLabel":"Altersstruktur","uri":"http://purl.org/lobid/rpb#n503020","definition":"Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Altersstruktur (n503020)"}
+{"prefLabel":"Geschlechtsverhältnis","uri":"http://purl.org/lobid/rpb#n503030","definition":"Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Geschlechtsverhältnis (n503030)"}
+{"prefLabel":"Volkszählung","uri":"http://purl.org/lobid/rpb#n503040","definition":"Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Volkszählung (n503040)"}
+{"prefLabel":"Einwohnerverzeichnis","uri":"http://purl.org/lobid/rpb#n503050","definition":"Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Einwohnerverzeichnis (n503050)"}
+{"prefLabel":"Haushaltsgrösse","uri":"http://purl.org/lobid/rpb#n503060","definition":"Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Haushaltsgrösse (n503060)"}
+{"prefLabel":"Wohnstandard","uri":"http://purl.org/lobid/rpb#n503070","definition":"Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Wohnstandard (n503070)"}
+{"prefLabel":"Einkommensstatistik","uri":"http://purl.org/lobid/rpb#n503080","definition":"Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Einkommensstatistik (n503080)"}
+{"prefLabel":"Denomination / Religion","uri":"http://purl.org/lobid/rpb#n503090","definition":"Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Denomination / Religion (n503090)"}
+{"prefLabel":"Bevölkerungsentwicklung","uri":"http://purl.org/lobid/rpb#n503200","definition":"Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200)"}
+{"prefLabel":"Bevölkerungspolitik","uri":"http://purl.org/lobid/rpb#n503220","definition":"Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Bevölkerungspolitik (n503220)"}
+{"prefLabel":"Geburt / Statistik","uri":"http://purl.org/lobid/rpb#n503230","definition":"Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Geburt / Statistik (n503230)"}
+{"prefLabel":"Heirat / Statistik","uri":"http://purl.org/lobid/rpb#n503240","definition":"Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Heirat / Statistik (n503240)"}
+{"prefLabel":"Tod / Statistik","uri":"http://purl.org/lobid/rpb#n503250","definition":"Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Tod / Statistik (n503250)"}
+{"prefLabel":"Bevölkerungsentwicklung / Prognose","uri":"http://purl.org/lobid/rpb#n503260","definition":"Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Bevölkerungsentwicklung / Prognose (n503260)"}
+{"prefLabel":"Migration","uri":"http://purl.org/lobid/rpb#n503400","definition":"Bevölkerung (n500000) > Migration (n503400)"}
+{"prefLabel":"Binnenwanderung","uri":"http://purl.org/lobid/rpb#n503420","definition":"Bevölkerung (n500000) > Migration (n503400) > Binnenwanderung (n503420)"}
+{"prefLabel":"Berufspendlerin. Berufspendler","uri":"http://purl.org/lobid/rpb#n503424","definition":"Bevölkerung (n500000) > Migration (n503400) > Binnenwanderung (n503420) > Berufspendlerin. Berufspendler (n503424)"}
+{"prefLabel":"Auswanderung","uri":"http://purl.org/lobid/rpb#n503430","definition":"Bevölkerung (n500000) > Migration (n503400) > Auswanderung (n503430)"}
+{"prefLabel":"Einwanderung","uri":"http://purl.org/lobid/rpb#n503440","definition":"Bevölkerung (n500000) > Migration (n503400) > Einwanderung (n503440)"}
+{"prefLabel":"Bevölkerungsdichte","uri":"http://purl.org/lobid/rpb#n503600","definition":"Bevölkerung (n500000) > Bevölkerungsdichte (n503600)"}
 {"prefLabel":"Sozialwesen","uri":"http://purl.org/lobid/rpb#n520000"}
-{"prefLabel":"Sozialwesen allgemein","uri":"http://purl.org/lobid/rpb#n520100"}
-{"prefLabel":"Sozialpolitik","uri":"http://purl.org/lobid/rpb#n521000"}
-{"prefLabel":"Sozialrecht","uri":"http://purl.org/lobid/rpb#n521200"}
-{"prefLabel":"Sozialversicherung","uri":"http://purl.org/lobid/rpb#n521400"}
-{"prefLabel":"Krankenversicherung","uri":"http://purl.org/lobid/rpb#n521410"}
-{"prefLabel":"Unfallversicherung","uri":"http://purl.org/lobid/rpb#n521420"}
-{"prefLabel":"Rentenversicherung","uri":"http://purl.org/lobid/rpb#n521430"}
-{"prefLabel":"Arbeitslosenversicherung","uri":"http://purl.org/lobid/rpb#n521450"}
-{"prefLabel":"Sozialhilfe / Kostenträger","uri":"http://purl.org/lobid/rpb#n522000"}
-{"prefLabel":"Öffentlicher Träger","uri":"http://purl.org/lobid/rpb#n522010"}
-{"prefLabel":"Kirchlicher Träger","uri":"http://purl.org/lobid/rpb#n522020"}
-{"prefLabel":"Privater Träger","uri":"http://purl.org/lobid/rpb#n522030"}
-{"prefLabel":"Karitative Stiftung","uri":"http://purl.org/lobid/rpb#n522050"}
-{"prefLabel":"Sozialhilfe","uri":"http://purl.org/lobid/rpb#n523000"}
-{"prefLabel":"Arbeitslosenunterstützung","uri":"http://purl.org/lobid/rpb#n523010"}
-{"prefLabel":"Fürsorge","uri":"http://purl.org/lobid/rpb#n523030"}
-{"prefLabel":"Obdachlosenhilfe","uri":"http://purl.org/lobid/rpb#n523035"}
-{"prefLabel":"Unfallfürsorge","uri":"http://purl.org/lobid/rpb#n523040"}
-{"prefLabel":"Krankenfürsorge","uri":"http://purl.org/lobid/rpb#n523050"}
-{"prefLabel":"Behindertenhilfe","uri":"http://purl.org/lobid/rpb#n523060"}
-{"prefLabel":"Kriegsopferfürsorge","uri":"http://purl.org/lobid/rpb#n523070"}
-{"prefLabel":"Gefangenenfürsorge","uri":"http://purl.org/lobid/rpb#n523075"}
-{"prefLabel":"Waisenfürsorge","uri":"http://purl.org/lobid/rpb#n523080"}
-{"prefLabel":"Altenhilfe","uri":"http://purl.org/lobid/rpb#n523090"}
-{"prefLabel":"Sozialpädagogik","uri":"http://purl.org/lobid/rpb#n524000"}
-{"prefLabel":"Jugendhilfe","uri":"http://purl.org/lobid/rpb#n524010"}
-{"prefLabel":"Bewährungshilfe","uri":"http://purl.org/lobid/rpb#n524050"}
-{"prefLabel":"Erziehungsberatung","uri":"http://purl.org/lobid/rpb#n524060"}
-{"prefLabel":"Familienfürsorge","uri":"http://purl.org/lobid/rpb#n524070"}
-{"prefLabel":"Berufsbetreuung","uri":"http://purl.org/lobid/rpb#n524080"}
+{"prefLabel":"Sozialwesen allgemein","uri":"http://purl.org/lobid/rpb#n520100","definition":"Sozialwesen (n520000) > Sozialwesen allgemein (n520100)"}
+{"prefLabel":"Sozialpolitik","uri":"http://purl.org/lobid/rpb#n521000","definition":"Sozialwesen (n520000) > Sozialpolitik (n521000)"}
+{"prefLabel":"Sozialrecht","uri":"http://purl.org/lobid/rpb#n521200","definition":"Sozialwesen (n520000) > Sozialrecht (n521200)"}
+{"prefLabel":"Sozialversicherung","uri":"http://purl.org/lobid/rpb#n521400","definition":"Sozialwesen (n520000) > Sozialversicherung (n521400)"}
+{"prefLabel":"Krankenversicherung","uri":"http://purl.org/lobid/rpb#n521410","definition":"Sozialwesen (n520000) > Sozialversicherung (n521400) > Krankenversicherung (n521410)"}
+{"prefLabel":"Unfallversicherung","uri":"http://purl.org/lobid/rpb#n521420","definition":"Sozialwesen (n520000) > Sozialversicherung (n521400) > Unfallversicherung (n521420)"}
+{"prefLabel":"Rentenversicherung","uri":"http://purl.org/lobid/rpb#n521430","definition":"Sozialwesen (n520000) > Sozialversicherung (n521400) > Rentenversicherung (n521430)"}
+{"prefLabel":"Arbeitslosenversicherung","uri":"http://purl.org/lobid/rpb#n521450","definition":"Sozialwesen (n520000) > Sozialversicherung (n521400) > Arbeitslosenversicherung (n521450)"}
+{"prefLabel":"Sozialhilfe / Kostenträger","uri":"http://purl.org/lobid/rpb#n522000","definition":"Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000)"}
+{"prefLabel":"Öffentlicher Träger","uri":"http://purl.org/lobid/rpb#n522010","definition":"Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000) > Öffentlicher Träger (n522010)"}
+{"prefLabel":"Kirchlicher Träger","uri":"http://purl.org/lobid/rpb#n522020","definition":"Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000) > Kirchlicher Träger (n522020)"}
+{"prefLabel":"Privater Träger","uri":"http://purl.org/lobid/rpb#n522030","definition":"Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000) > Privater Träger (n522030)"}
+{"prefLabel":"Karitative Stiftung","uri":"http://purl.org/lobid/rpb#n522050","definition":"Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000) > Karitative Stiftung (n522050)"}
+{"prefLabel":"Sozialhilfe","uri":"http://purl.org/lobid/rpb#n523000","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000)"}
+{"prefLabel":"Arbeitslosenunterstützung","uri":"http://purl.org/lobid/rpb#n523010","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Arbeitslosenunterstützung (n523010)"}
+{"prefLabel":"Fürsorge","uri":"http://purl.org/lobid/rpb#n523030","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Fürsorge (n523030)"}
+{"prefLabel":"Obdachlosenhilfe","uri":"http://purl.org/lobid/rpb#n523035","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Fürsorge (n523030) > Obdachlosenhilfe (n523035)"}
+{"prefLabel":"Unfallfürsorge","uri":"http://purl.org/lobid/rpb#n523040","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Unfallfürsorge (n523040)"}
+{"prefLabel":"Krankenfürsorge","uri":"http://purl.org/lobid/rpb#n523050","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Krankenfürsorge (n523050)"}
+{"prefLabel":"Behindertenhilfe","uri":"http://purl.org/lobid/rpb#n523060","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Behindertenhilfe (n523060)"}
+{"prefLabel":"Kriegsopferfürsorge","uri":"http://purl.org/lobid/rpb#n523070","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Kriegsopferfürsorge (n523070)"}
+{"prefLabel":"Gefangenenfürsorge","uri":"http://purl.org/lobid/rpb#n523075","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Gefangenenfürsorge (n523075)"}
+{"prefLabel":"Waisenfürsorge","uri":"http://purl.org/lobid/rpb#n523080","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Waisenfürsorge (n523080)"}
+{"prefLabel":"Altenhilfe","uri":"http://purl.org/lobid/rpb#n523090","definition":"Sozialwesen (n520000) > Sozialhilfe (n523000) > Altenhilfe (n523090)"}
+{"prefLabel":"Sozialpädagogik","uri":"http://purl.org/lobid/rpb#n524000","definition":"Sozialwesen (n520000) > Sozialpädagogik (n524000)"}
+{"prefLabel":"Jugendhilfe","uri":"http://purl.org/lobid/rpb#n524010","definition":"Sozialwesen (n520000) > Sozialpädagogik (n524000) > Jugendhilfe (n524010)"}
+{"prefLabel":"Bewährungshilfe","uri":"http://purl.org/lobid/rpb#n524050","definition":"Sozialwesen (n520000) > Sozialpädagogik (n524000) > Bewährungshilfe (n524050)"}
+{"prefLabel":"Erziehungsberatung","uri":"http://purl.org/lobid/rpb#n524060","definition":"Sozialwesen (n520000) > Sozialpädagogik (n524000) > Erziehungsberatung (n524060)"}
+{"prefLabel":"Familienfürsorge","uri":"http://purl.org/lobid/rpb#n524070","definition":"Sozialwesen (n520000) > Sozialpädagogik (n524000) > Familienfürsorge (n524070)"}
+{"prefLabel":"Berufsbetreuung","uri":"http://purl.org/lobid/rpb#n524080","definition":"Sozialwesen (n520000) > Sozialpädagogik (n524000) > Berufsbetreuung (n524080)"}
 {"prefLabel":"Gesundheitswesen","uri":"http://purl.org/lobid/rpb#n530000"}
-{"prefLabel":"Gesundheitswesen allgemein","uri":"http://purl.org/lobid/rpb#n530100"}
-{"prefLabel":"Medizin","uri":"http://purl.org/lobid/rpb#n532000"}
-{"prefLabel":"Medizin / Geschichte","uri":"http://purl.org/lobid/rpb#n532010"}
-{"prefLabel":"Medizinische Versorgung","uri":"http://purl.org/lobid/rpb#n532030"}
-{"prefLabel":"Ärztin. Arzt. Heilberuf","uri":"http://purl.org/lobid/rpb#n532050"}
-{"prefLabel":"Gesundheitsvorsorge","uri":"http://purl.org/lobid/rpb#n532070"}
-{"prefLabel":"Apotheke","uri":"http://purl.org/lobid/rpb#n533000"}
-{"prefLabel":"Krankenversorgung","uri":"http://purl.org/lobid/rpb#n534000"}
-{"prefLabel":"Krankenpflege","uri":"http://purl.org/lobid/rpb#n534010"}
-{"prefLabel":"Krankenpflege / Beruf","uri":"http://purl.org/lobid/rpb#n534020"}
-{"prefLabel":"Krankenhaus","uri":"http://purl.org/lobid/rpb#n534030"}
-{"prefLabel":"Sanatorium","uri":"http://purl.org/lobid/rpb#n534050"}
-{"prefLabel":"Suchtkrankenhilfe","uri":"http://purl.org/lobid/rpb#n534060"}
-{"prefLabel":"Psychiatrie","uri":"http://purl.org/lobid/rpb#n534080"}
-{"prefLabel":"Hygiene","uri":"http://purl.org/lobid/rpb#n535000"}
-{"prefLabel":"Veterinärwesen","uri":"http://purl.org/lobid/rpb#n537000"}
+{"prefLabel":"Gesundheitswesen allgemein","uri":"http://purl.org/lobid/rpb#n530100","definition":"Gesundheitswesen (n530000) > Gesundheitswesen allgemein (n530100)"}
+{"prefLabel":"Medizin","uri":"http://purl.org/lobid/rpb#n532000","definition":"Gesundheitswesen (n530000) > Medizin (n532000)"}
+{"prefLabel":"Medizin / Geschichte","uri":"http://purl.org/lobid/rpb#n532010","definition":"Gesundheitswesen (n530000) > Medizin (n532000) > Medizin / Geschichte (n532010)"}
+{"prefLabel":"Medizinische Versorgung","uri":"http://purl.org/lobid/rpb#n532030","definition":"Gesundheitswesen (n530000) > Medizin (n532000) > Medizinische Versorgung (n532030)"}
+{"prefLabel":"Ärztin. Arzt. Heilberuf","uri":"http://purl.org/lobid/rpb#n532050","definition":"Gesundheitswesen (n530000) > Medizin (n532000) > Ärztin. Arzt. Heilberuf (n532050)"}
+{"prefLabel":"Gesundheitsvorsorge","uri":"http://purl.org/lobid/rpb#n532070","definition":"Gesundheitswesen (n530000) > Medizin (n532000) > Gesundheitsvorsorge (n532070)"}
+{"prefLabel":"Apotheke","uri":"http://purl.org/lobid/rpb#n533000","definition":"Gesundheitswesen (n530000) > Apotheke (n533000)"}
+{"prefLabel":"Krankenversorgung","uri":"http://purl.org/lobid/rpb#n534000","definition":"Gesundheitswesen (n530000) > Krankenversorgung (n534000)"}
+{"prefLabel":"Krankenpflege","uri":"http://purl.org/lobid/rpb#n534010","definition":"Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Krankenpflege (n534010)"}
+{"prefLabel":"Krankenpflege / Beruf","uri":"http://purl.org/lobid/rpb#n534020","definition":"Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Krankenpflege / Beruf (n534020)"}
+{"prefLabel":"Krankenhaus","uri":"http://purl.org/lobid/rpb#n534030","definition":"Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Krankenhaus (n534030)"}
+{"prefLabel":"Sanatorium","uri":"http://purl.org/lobid/rpb#n534050","definition":"Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Sanatorium (n534050)"}
+{"prefLabel":"Suchtkrankenhilfe","uri":"http://purl.org/lobid/rpb#n534060","definition":"Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Suchtkrankenhilfe (n534060)"}
+{"prefLabel":"Psychiatrie","uri":"http://purl.org/lobid/rpb#n534080","definition":"Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Psychiatrie (n534080)"}
+{"prefLabel":"Hygiene","uri":"http://purl.org/lobid/rpb#n535000","definition":"Gesundheitswesen (n530000) > Hygiene (n535000)"}
+{"prefLabel":"Veterinärwesen","uri":"http://purl.org/lobid/rpb#n537000","definition":"Gesundheitswesen (n530000) > Veterinärwesen (n537000)"}
 {"prefLabel":"Wirtschaft","uri":"http://purl.org/lobid/rpb#n540000"}
-{"prefLabel":"Wirtschaft allgemein","uri":"http://purl.org/lobid/rpb#n540100"}
-{"prefLabel":"Wirtschaftspolitik","uri":"http://purl.org/lobid/rpb#n541000"}
-{"prefLabel":"Wirtschaftsrecht","uri":"http://purl.org/lobid/rpb#n541500"}
-{"prefLabel":"Wirtschaft / Geschichte","uri":"http://purl.org/lobid/rpb#n542000"}
-{"prefLabel":"Wirtschaftsstruktur","uri":"http://purl.org/lobid/rpb#n543000"}
-{"prefLabel":"Wirtschaftsförderung","uri":"http://purl.org/lobid/rpb#n543010"}
-{"prefLabel":"Bruttoinlandsprodukt","uri":"http://purl.org/lobid/rpb#n543040"}
-{"prefLabel":"Außenwirtschaft","uri":"http://purl.org/lobid/rpb#n543060"}
-{"prefLabel":"Wirtschaftsstatistik","uri":"http://purl.org/lobid/rpb#n543080"}
-{"prefLabel":"Wirtschaftsverfassung","uri":"http://purl.org/lobid/rpb#n543200"}
-{"prefLabel":"Wirtschaftsverband","uri":"http://purl.org/lobid/rpb#n543400"}
-{"prefLabel":"Industrie- und Handelskammer","uri":"http://purl.org/lobid/rpb#n543430"}
-{"prefLabel":"Verbraucherverband","uri":"http://purl.org/lobid/rpb#n543440"}
-{"prefLabel":"Arbeitgeberverband","uri":"http://purl.org/lobid/rpb#n543460"}
-{"prefLabel":"Gewerkschaft","uri":"http://purl.org/lobid/rpb#n543480"}
-{"prefLabel":"Arbeitsmarkt","uri":"http://purl.org/lobid/rpb#n543600"}
-{"prefLabel":"Unternehmerin. Unternehmer","uri":"http://purl.org/lobid/rpb#n543620"}
-{"prefLabel":"Arbeitnehmerin. Arbeitnehmer","uri":"http://purl.org/lobid/rpb#n543630"}
-{"prefLabel":"Freier Beruf","uri":"http://purl.org/lobid/rpb#n543640"}
-{"prefLabel":"Lohn","uri":"http://purl.org/lobid/rpb#n543660"}
-{"prefLabel":"Arbeitslosigkeit","uri":"http://purl.org/lobid/rpb#n543680"}
-{"prefLabel":"Marketing","uri":"http://purl.org/lobid/rpb#n543800"}
-{"prefLabel":"Landwirtschaft","uri":"http://purl.org/lobid/rpb#n544000"}
-{"prefLabel":"Agrarpolitik","uri":"http://purl.org/lobid/rpb#n544010"}
-{"prefLabel":"Landwirtschaft / Geschichte","uri":"http://purl.org/lobid/rpb#n544020"}
-{"prefLabel":"Bauernhof / Geschichte","uri":"http://purl.org/lobid/rpb#n544030"}
-{"prefLabel":"Flurform","uri":"http://purl.org/lobid/rpb#n544040"}
-{"prefLabel":"Landwirtschaft / Beruf","uri":"http://purl.org/lobid/rpb#n544050"}
-{"prefLabel":"Bäuerin. Bauer","uri":"http://purl.org/lobid/rpb#n544052"}
-{"prefLabel":"Landfrau","uri":"http://purl.org/lobid/rpb#n544054"}
-{"prefLabel":"Landarbeiterin. Landarbeiter","uri":"http://purl.org/lobid/rpb#n544056"}
-{"prefLabel":"Landwirtschaftliche Betriebslehre","uri":"http://purl.org/lobid/rpb#n544060"}
-{"prefLabel":"Landwirtschaftsgenossenschaft","uri":"http://purl.org/lobid/rpb#n544090"}
-{"prefLabel":"Agrarproduktion","uri":"http://purl.org/lobid/rpb#n544200"}
-{"prefLabel":"Ackerbau","uri":"http://purl.org/lobid/rpb#n544220"}
-{"prefLabel":"Grünlandwirtschaft","uri":"http://purl.org/lobid/rpb#n544230"}
-{"prefLabel":"Gartenbau","uri":"http://purl.org/lobid/rpb#n544240"}
-{"prefLabel":"Baumschule","uri":"http://purl.org/lobid/rpb#n544245"}
-{"prefLabel":"Obstbau","uri":"http://purl.org/lobid/rpb#n544250"}
-{"prefLabel":"Tierzucht","uri":"http://purl.org/lobid/rpb#n544280"}
-{"prefLabel":"Weinbau","uri":"http://purl.org/lobid/rpb#n544300"}
-{"prefLabel":"Weinbau / Geschichte","uri":"http://purl.org/lobid/rpb#n544310"}
-{"prefLabel":"Weinbaugebiet","uri":"http://purl.org/lobid/rpb#n544320"}
-{"prefLabel":"Großlage","uri":"http://purl.org/lobid/rpb#n544322"}
-{"prefLabel":"Weingut","uri":"http://purl.org/lobid/rpb#n544325"}
-{"prefLabel":"Weinherstellung","uri":"http://purl.org/lobid/rpb#n544340"}
-{"prefLabel":"Schaumweinherstellung","uri":"http://purl.org/lobid/rpb#n544341"}
-{"prefLabel":"Branntweinherstellung","uri":"http://purl.org/lobid/rpb#n544344"}
-{"prefLabel":"Weinhandel","uri":"http://purl.org/lobid/rpb#n544360"}
-{"prefLabel":"Schaumwein / Handel","uri":"http://purl.org/lobid/rpb#n544361"}
-{"prefLabel":"Forstwirtschaft","uri":"http://purl.org/lobid/rpb#n544400"}
-{"prefLabel":"Forstrecht","uri":"http://purl.org/lobid/rpb#n544410"}
-{"prefLabel":"Forstwirtschaft / Geschichte","uri":"http://purl.org/lobid/rpb#n544420"}
-{"prefLabel":"Forstproduktion","uri":"http://purl.org/lobid/rpb#n544440"}
-{"prefLabel":"Baumart","uri":"http://purl.org/lobid/rpb#n544450"}
-{"prefLabel":"Forst","uri":"http://purl.org/lobid/rpb#n544460"}
-{"prefLabel":"Försterin. Förster","uri":"http://purl.org/lobid/rpb#n544490"}
-{"prefLabel":"Jagd. Fischfang","uri":"http://purl.org/lobid/rpb#n544600"}
-{"prefLabel":"Jagd","uri":"http://purl.org/lobid/rpb#n544610"}
-{"prefLabel":"Jagdrecht","uri":"http://purl.org/lobid/rpb#n544620"}
-{"prefLabel":"Wild","uri":"http://purl.org/lobid/rpb#n544640"}
-{"prefLabel":"Fischfang","uri":"http://purl.org/lobid/rpb#n544650"}
-{"prefLabel":"Fischereirecht","uri":"http://purl.org/lobid/rpb#n544660"}
-{"prefLabel":"Fischzucht","uri":"http://purl.org/lobid/rpb#n544670"}
-{"prefLabel":"Bergbau","uri":"http://purl.org/lobid/rpb#n545000"}
-{"prefLabel":"Bergrecht","uri":"http://purl.org/lobid/rpb#n545010"}
-{"prefLabel":"Bergbau / Geschichte","uri":"http://purl.org/lobid/rpb#n545020"}
-{"prefLabel":"Kohlenbergbau","uri":"http://purl.org/lobid/rpb#n545030"}
-{"prefLabel":"Gesteinsabbau","uri":"http://purl.org/lobid/rpb#n545040"}
-{"prefLabel":"Erzbergbau","uri":"http://purl.org/lobid/rpb#n545050"}
-{"prefLabel":"Salzbergbau. Kalibergbau","uri":"http://purl.org/lobid/rpb#n545060"}
-{"prefLabel":"Erdöl","uri":"http://purl.org/lobid/rpb#n545070"}
-{"prefLabel":"Erdgas","uri":"http://purl.org/lobid/rpb#n545080"}
-{"prefLabel":"Energiewirtschaft","uri":"http://purl.org/lobid/rpb#n546000"}
-{"prefLabel":"Elektrizitätsversorgung","uri":"http://purl.org/lobid/rpb#n546020"}
-{"prefLabel":"Wasserkraftwerk","uri":"http://purl.org/lobid/rpb#n546022"}
-{"prefLabel":"Wärmekraftwerk","uri":"http://purl.org/lobid/rpb#n546024"}
-{"prefLabel":"Kernkraftwerk","uri":"http://purl.org/lobid/rpb#n546026"}
-{"prefLabel":"Alternative Energiequelle","uri":"http://purl.org/lobid/rpb#n546028"}
-{"prefLabel":"Gasversorgung","uri":"http://purl.org/lobid/rpb#n546040"}
-{"prefLabel":"Verbundwirtschaft","uri":"http://purl.org/lobid/rpb#n546060"}
-{"prefLabel":"Handwerk","uri":"http://purl.org/lobid/rpb#n547000"}
-{"prefLabel":"Handwerk / Geschichte","uri":"http://purl.org/lobid/rpb#n547020"}
-{"prefLabel":"Handwerk / Beruf","uri":"http://purl.org/lobid/rpb#n547030"}
-{"prefLabel":"Handwerksbetrieb","uri":"http://purl.org/lobid/rpb#n547035"}
-{"prefLabel":"Handwerksorganisation","uri":"http://purl.org/lobid/rpb#n547040"}
-{"prefLabel":"Handwerkskammer","uri":"http://purl.org/lobid/rpb#n547042"}
-{"prefLabel":"Innung","uri":"http://purl.org/lobid/rpb#n547044"}
-{"prefLabel":"Industrie","uri":"http://purl.org/lobid/rpb#n547400"}
-{"prefLabel":"Industrie / Geschichte","uri":"http://purl.org/lobid/rpb#n547420"}
-{"prefLabel":"Industriezweig","uri":"http://purl.org/lobid/rpb#n547440"}
-{"prefLabel":"Industriebetrieb","uri":"http://purl.org/lobid/rpb#n547460"}
-{"prefLabel":"Technik. Technologie","uri":"http://purl.org/lobid/rpb#n547600"}
-{"prefLabel":"Handel","uri":"http://purl.org/lobid/rpb#n548000"}
-{"prefLabel":"Handelsrecht","uri":"http://purl.org/lobid/rpb#n548010"}
-{"prefLabel":"Handel / Geschichte","uri":"http://purl.org/lobid/rpb#n548020"}
-{"prefLabel":"Handelsform","uri":"http://purl.org/lobid/rpb#n548030"}
-{"prefLabel":"Messe / Wirtschaft","uri":"http://purl.org/lobid/rpb#n548040"}
-{"prefLabel":"Markt","uri":"http://purl.org/lobid/rpb#n548045"}
-{"prefLabel":"Firma","uri":"http://purl.org/lobid/rpb#n548050"}
-{"prefLabel":"Handelsgut","uri":"http://purl.org/lobid/rpb#n548060"}
-{"prefLabel":"Handelsgenossenschaft","uri":"http://purl.org/lobid/rpb#n548090"}
-{"prefLabel":"Dienstleistungssektor","uri":"http://purl.org/lobid/rpb#n548200"}
-{"prefLabel":"Dienstleistungsbetrieb","uri":"http://purl.org/lobid/rpb#n548250"}
-{"prefLabel":"Öffentliches Unternehmen","uri":"http://purl.org/lobid/rpb#n548300"}
-{"prefLabel":"Bank","uri":"http://purl.org/lobid/rpb#n548400"}
-{"prefLabel":"Versicherung","uri":"http://purl.org/lobid/rpb#n548600"}
-{"prefLabel":"Tourismus","uri":"http://purl.org/lobid/rpb#n548800"}
-{"prefLabel":"Kurort","uri":"http://purl.org/lobid/rpb#n548820"}
-{"prefLabel":"Naherholung","uri":"http://purl.org/lobid/rpb#n548830"}
-{"prefLabel":"Gastgewerbe","uri":"http://purl.org/lobid/rpb#n548840"}
-{"prefLabel":"Jugendherberge","uri":"http://purl.org/lobid/rpb#n548870"}
+{"prefLabel":"Wirtschaft allgemein","uri":"http://purl.org/lobid/rpb#n540100","definition":"Wirtschaft (n540000) > Wirtschaft allgemein (n540100)"}
+{"prefLabel":"Wirtschaftspolitik","uri":"http://purl.org/lobid/rpb#n541000","definition":"Wirtschaft (n540000) > Wirtschaftspolitik (n541000)"}
+{"prefLabel":"Wirtschaftsrecht","uri":"http://purl.org/lobid/rpb#n541500","definition":"Wirtschaft (n540000) > Wirtschaftsrecht (n541500)"}
+{"prefLabel":"Wirtschaft / Geschichte","uri":"http://purl.org/lobid/rpb#n542000","definition":"Wirtschaft (n540000) > Wirtschaft / Geschichte (n542000)"}
+{"prefLabel":"Wirtschaftsstruktur","uri":"http://purl.org/lobid/rpb#n543000","definition":"Wirtschaft (n540000) > Wirtschaftsstruktur (n543000)"}
+{"prefLabel":"Wirtschaftsförderung","uri":"http://purl.org/lobid/rpb#n543010","definition":"Wirtschaft (n540000) > Wirtschaftsstruktur (n543000) > Wirtschaftsförderung (n543010)"}
+{"prefLabel":"Bruttoinlandsprodukt","uri":"http://purl.org/lobid/rpb#n543040","definition":"Wirtschaft (n540000) > Wirtschaftsstruktur (n543000) > Bruttoinlandsprodukt (n543040)"}
+{"prefLabel":"Außenwirtschaft","uri":"http://purl.org/lobid/rpb#n543060","definition":"Wirtschaft (n540000) > Wirtschaftsstruktur (n543000) > Außenwirtschaft (n543060)"}
+{"prefLabel":"Wirtschaftsstatistik","uri":"http://purl.org/lobid/rpb#n543080","definition":"Wirtschaft (n540000) > Wirtschaftsstruktur (n543000) > Wirtschaftsstatistik (n543080)"}
+{"prefLabel":"Wirtschaftsverfassung","uri":"http://purl.org/lobid/rpb#n543200","definition":"Wirtschaft (n540000) > Wirtschaftsverfassung (n543200)"}
+{"prefLabel":"Wirtschaftsverband","uri":"http://purl.org/lobid/rpb#n543400","definition":"Wirtschaft (n540000) > Wirtschaftsverband (n543400)"}
+{"prefLabel":"Industrie- und Handelskammer","uri":"http://purl.org/lobid/rpb#n543430","definition":"Wirtschaft (n540000) > Wirtschaftsverband (n543400) > Industrie- und Handelskammer (n543430)"}
+{"prefLabel":"Verbraucherverband","uri":"http://purl.org/lobid/rpb#n543440","definition":"Wirtschaft (n540000) > Wirtschaftsverband (n543400) > Verbraucherverband (n543440)"}
+{"prefLabel":"Arbeitgeberverband","uri":"http://purl.org/lobid/rpb#n543460","definition":"Wirtschaft (n540000) > Wirtschaftsverband (n543400) > Arbeitgeberverband (n543460)"}
+{"prefLabel":"Gewerkschaft","uri":"http://purl.org/lobid/rpb#n543480","definition":"Wirtschaft (n540000) > Wirtschaftsverband (n543400) > Gewerkschaft (n543480)"}
+{"prefLabel":"Arbeitsmarkt","uri":"http://purl.org/lobid/rpb#n543600","definition":"Wirtschaft (n540000) > Arbeitsmarkt (n543600)"}
+{"prefLabel":"Unternehmerin. Unternehmer","uri":"http://purl.org/lobid/rpb#n543620","definition":"Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Unternehmerin. Unternehmer (n543620)"}
+{"prefLabel":"Arbeitnehmerin. Arbeitnehmer","uri":"http://purl.org/lobid/rpb#n543630","definition":"Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Arbeitnehmerin. Arbeitnehmer (n543630)"}
+{"prefLabel":"Freier Beruf","uri":"http://purl.org/lobid/rpb#n543640","definition":"Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Freier Beruf (n543640)"}
+{"prefLabel":"Lohn","uri":"http://purl.org/lobid/rpb#n543660","definition":"Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Lohn (n543660)"}
+{"prefLabel":"Arbeitslosigkeit","uri":"http://purl.org/lobid/rpb#n543680","definition":"Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Arbeitslosigkeit (n543680)"}
+{"prefLabel":"Marketing","uri":"http://purl.org/lobid/rpb#n543800","definition":"Wirtschaft (n540000) > Marketing (n543800)"}
+{"prefLabel":"Landwirtschaft","uri":"http://purl.org/lobid/rpb#n544000","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000)"}
+{"prefLabel":"Agrarpolitik","uri":"http://purl.org/lobid/rpb#n544010","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Agrarpolitik (n544010)"}
+{"prefLabel":"Landwirtschaft / Geschichte","uri":"http://purl.org/lobid/rpb#n544020","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Geschichte (n544020)"}
+{"prefLabel":"Bauernhof / Geschichte","uri":"http://purl.org/lobid/rpb#n544030","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Bauernhof / Geschichte (n544030)"}
+{"prefLabel":"Flurform","uri":"http://purl.org/lobid/rpb#n544040","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Flurform (n544040)"}
+{"prefLabel":"Landwirtschaft / Beruf","uri":"http://purl.org/lobid/rpb#n544050","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Beruf (n544050)"}
+{"prefLabel":"Bäuerin. Bauer","uri":"http://purl.org/lobid/rpb#n544052","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Beruf (n544050) > Bäuerin. Bauer (n544052)"}
+{"prefLabel":"Landfrau","uri":"http://purl.org/lobid/rpb#n544054","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Beruf (n544050) > Landfrau (n544054)"}
+{"prefLabel":"Landarbeiterin. Landarbeiter","uri":"http://purl.org/lobid/rpb#n544056","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Beruf (n544050) > Landarbeiterin. Landarbeiter (n544056)"}
+{"prefLabel":"Landwirtschaftliche Betriebslehre","uri":"http://purl.org/lobid/rpb#n544060","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaftliche Betriebslehre (n544060)"}
+{"prefLabel":"Landwirtschaftsgenossenschaft","uri":"http://purl.org/lobid/rpb#n544090","definition":"Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaftsgenossenschaft (n544090)"}
+{"prefLabel":"Agrarproduktion","uri":"http://purl.org/lobid/rpb#n544200","definition":"Wirtschaft (n540000) > Agrarproduktion (n544200)"}
+{"prefLabel":"Ackerbau","uri":"http://purl.org/lobid/rpb#n544220","definition":"Wirtschaft (n540000) > Agrarproduktion (n544200) > Ackerbau (n544220)"}
+{"prefLabel":"Grünlandwirtschaft","uri":"http://purl.org/lobid/rpb#n544230","definition":"Wirtschaft (n540000) > Agrarproduktion (n544200) > Grünlandwirtschaft (n544230)"}
+{"prefLabel":"Gartenbau","uri":"http://purl.org/lobid/rpb#n544240","definition":"Wirtschaft (n540000) > Agrarproduktion (n544200) > Gartenbau (n544240)"}
+{"prefLabel":"Baumschule","uri":"http://purl.org/lobid/rpb#n544245","definition":"Wirtschaft (n540000) > Agrarproduktion (n544200) > Gartenbau (n544240) > Baumschule (n544245)"}
+{"prefLabel":"Obstbau","uri":"http://purl.org/lobid/rpb#n544250","definition":"Wirtschaft (n540000) > Agrarproduktion (n544200) > Obstbau (n544250)"}
+{"prefLabel":"Tierzucht","uri":"http://purl.org/lobid/rpb#n544280","definition":"Wirtschaft (n540000) > Agrarproduktion (n544200) > Tierzucht (n544280)"}
+{"prefLabel":"Weinbau","uri":"http://purl.org/lobid/rpb#n544300","definition":"Wirtschaft (n540000) > Weinbau (n544300)"}
+{"prefLabel":"Weinbau / Geschichte","uri":"http://purl.org/lobid/rpb#n544310","definition":"Wirtschaft (n540000) > Weinbau / Geschichte (n544310)"}
+{"prefLabel":"Weinbaugebiet","uri":"http://purl.org/lobid/rpb#n544320","definition":"Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinbaugebiet (n544320)"}
+{"prefLabel":"Großlage","uri":"http://purl.org/lobid/rpb#n544322","definition":"Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinbaugebiet (n544320) > Großlage (n544322)"}
+{"prefLabel":"Weingut","uri":"http://purl.org/lobid/rpb#n544325","definition":"Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinbaugebiet (n544320) > Weingut (n544325)"}
+{"prefLabel":"Weinherstellung","uri":"http://purl.org/lobid/rpb#n544340","definition":"Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinherstellung (n544340)"}
+{"prefLabel":"Schaumweinherstellung","uri":"http://purl.org/lobid/rpb#n544341","definition":"Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinherstellung (n544340) > Schaumweinherstellung (n544341)"}
+{"prefLabel":"Branntweinherstellung","uri":"http://purl.org/lobid/rpb#n544344","definition":"Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinherstellung (n544340) > Branntweinherstellung (n544344)"}
+{"prefLabel":"Weinhandel","uri":"http://purl.org/lobid/rpb#n544360","definition":"Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinhandel (n544360)"}
+{"prefLabel":"Schaumwein / Handel","uri":"http://purl.org/lobid/rpb#n544361","definition":"Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinhandel (n544360) > Schaumwein / Handel (n544361)"}
+{"prefLabel":"Forstwirtschaft","uri":"http://purl.org/lobid/rpb#n544400","definition":"Wirtschaft (n540000) > Forstwirtschaft (n544400)"}
+{"prefLabel":"Forstrecht","uri":"http://purl.org/lobid/rpb#n544410","definition":"Wirtschaft (n540000) > Forstwirtschaft (n544400) > Forstrecht (n544410)"}
+{"prefLabel":"Forstwirtschaft / Geschichte","uri":"http://purl.org/lobid/rpb#n544420","definition":"Wirtschaft (n540000) > Forstwirtschaft (n544400) > Forstwirtschaft / Geschichte (n544420)"}
+{"prefLabel":"Forstproduktion","uri":"http://purl.org/lobid/rpb#n544440","definition":"Wirtschaft (n540000) > Forstwirtschaft (n544400) > Forstproduktion (n544440)"}
+{"prefLabel":"Baumart","uri":"http://purl.org/lobid/rpb#n544450","definition":"Wirtschaft (n540000) > Forstwirtschaft (n544400) > Baumart (n544450)"}
+{"prefLabel":"Forst","uri":"http://purl.org/lobid/rpb#n544460","definition":"Wirtschaft (n540000) > Forstwirtschaft (n544400) > Forst (n544460)"}
+{"prefLabel":"Försterin. Förster","uri":"http://purl.org/lobid/rpb#n544490","definition":"Wirtschaft (n540000) > Forstwirtschaft (n544400) > Försterin. Förster (n544490)"}
+{"prefLabel":"Jagd. Fischfang","uri":"http://purl.org/lobid/rpb#n544600","definition":"Wirtschaft (n540000) > Jagd. Fischfang (n544600)"}
+{"prefLabel":"Jagd","uri":"http://purl.org/lobid/rpb#n544610","definition":"Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Jagd (n544610)"}
+{"prefLabel":"Jagdrecht","uri":"http://purl.org/lobid/rpb#n544620","definition":"Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Jagdrecht (n544620)"}
+{"prefLabel":"Wild","uri":"http://purl.org/lobid/rpb#n544640","definition":"Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Wild (n544640)"}
+{"prefLabel":"Fischfang","uri":"http://purl.org/lobid/rpb#n544650","definition":"Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Fischfang (n544650)"}
+{"prefLabel":"Fischereirecht","uri":"http://purl.org/lobid/rpb#n544660","definition":"Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Fischereirecht (n544660)"}
+{"prefLabel":"Fischzucht","uri":"http://purl.org/lobid/rpb#n544670","definition":"Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Fischzucht (n544670)"}
+{"prefLabel":"Bergbau","uri":"http://purl.org/lobid/rpb#n545000","definition":"Wirtschaft (n540000) > Bergbau (n545000)"}
+{"prefLabel":"Bergrecht","uri":"http://purl.org/lobid/rpb#n545010","definition":"Wirtschaft (n540000) > Bergbau (n545000) > Bergrecht (n545010)"}
+{"prefLabel":"Bergbau / Geschichte","uri":"http://purl.org/lobid/rpb#n545020","definition":"Wirtschaft (n540000) > Bergbau (n545000) > Bergbau / Geschichte (n545020)"}
+{"prefLabel":"Kohlenbergbau","uri":"http://purl.org/lobid/rpb#n545030","definition":"Wirtschaft (n540000) > Bergbau (n545000) > Kohlenbergbau (n545030)"}
+{"prefLabel":"Gesteinsabbau","uri":"http://purl.org/lobid/rpb#n545040","definition":"Wirtschaft (n540000) > Bergbau (n545000) > Gesteinsabbau (n545040)"}
+{"prefLabel":"Erzbergbau","uri":"http://purl.org/lobid/rpb#n545050","definition":"Wirtschaft (n540000) > Bergbau (n545000) > Erzbergbau (n545050)"}
+{"prefLabel":"Salzbergbau. Kalibergbau","uri":"http://purl.org/lobid/rpb#n545060","definition":"Wirtschaft (n540000) > Bergbau (n545000) > Salzbergbau. Kalibergbau (n545060)"}
+{"prefLabel":"Erdöl","uri":"http://purl.org/lobid/rpb#n545070","definition":"Wirtschaft (n540000) > Bergbau (n545000) > Erdöl (n545070)"}
+{"prefLabel":"Erdgas","uri":"http://purl.org/lobid/rpb#n545080","definition":"Wirtschaft (n540000) > Bergbau (n545000) > Erdgas (n545080)"}
+{"prefLabel":"Energiewirtschaft","uri":"http://purl.org/lobid/rpb#n546000","definition":"Wirtschaft (n540000) > Energiewirtschaft (n546000)"}
+{"prefLabel":"Elektrizitätsversorgung","uri":"http://purl.org/lobid/rpb#n546020","definition":"Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020)"}
+{"prefLabel":"Wasserkraftwerk","uri":"http://purl.org/lobid/rpb#n546022","definition":"Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020) > Wasserkraftwerk (n546022)"}
+{"prefLabel":"Wärmekraftwerk","uri":"http://purl.org/lobid/rpb#n546024","definition":"Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020) > Wärmekraftwerk (n546024)"}
+{"prefLabel":"Kernkraftwerk","uri":"http://purl.org/lobid/rpb#n546026","definition":"Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020) > Kernkraftwerk (n546026)"}
+{"prefLabel":"Alternative Energiequelle","uri":"http://purl.org/lobid/rpb#n546028","definition":"Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020) > Alternative Energiequelle (n546028)"}
+{"prefLabel":"Gasversorgung","uri":"http://purl.org/lobid/rpb#n546040","definition":"Wirtschaft (n540000) > Energiewirtschaft (n546000) > Gasversorgung (n546040)"}
+{"prefLabel":"Verbundwirtschaft","uri":"http://purl.org/lobid/rpb#n546060","definition":"Wirtschaft (n540000) > Energiewirtschaft (n546000) > Verbundwirtschaft (n546060)"}
+{"prefLabel":"Handwerk","uri":"http://purl.org/lobid/rpb#n547000","definition":"Wirtschaft (n540000) > Handwerk (n547000)"}
+{"prefLabel":"Handwerk / Geschichte","uri":"http://purl.org/lobid/rpb#n547020","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Handwerk / Geschichte (n547020)"}
+{"prefLabel":"Handwerk / Beruf","uri":"http://purl.org/lobid/rpb#n547030","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Handwerk / Beruf (n547030)"}
+{"prefLabel":"Handwerksbetrieb","uri":"http://purl.org/lobid/rpb#n547035","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Handwerk / Beruf (n547030) > Handwerksbetrieb (n547035)"}
+{"prefLabel":"Handwerksorganisation","uri":"http://purl.org/lobid/rpb#n547040","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Handwerksorganisation (n547040)"}
+{"prefLabel":"Handwerkskammer","uri":"http://purl.org/lobid/rpb#n547042","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Handwerksorganisation (n547040) > Handwerkskammer (n547042)"}
+{"prefLabel":"Innung","uri":"http://purl.org/lobid/rpb#n547044","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Handwerksorganisation (n547040) > Innung (n547044)"}
+{"prefLabel":"Industrie","uri":"http://purl.org/lobid/rpb#n547400","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Industrie (n547400)"}
+{"prefLabel":"Industrie / Geschichte","uri":"http://purl.org/lobid/rpb#n547420","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Industrie (n547400) > Industrie / Geschichte (n547420)"}
+{"prefLabel":"Industriezweig","uri":"http://purl.org/lobid/rpb#n547440","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Industrie (n547400) > Industriezweig (n547440)"}
+{"prefLabel":"Industriebetrieb","uri":"http://purl.org/lobid/rpb#n547460","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Industrie (n547400) > Industriebetrieb (n547460)"}
+{"prefLabel":"Technik. Technologie","uri":"http://purl.org/lobid/rpb#n547600","definition":"Wirtschaft (n540000) > Handwerk (n547000) > Technik. Technologie (n547600)"}
+{"prefLabel":"Handel","uri":"http://purl.org/lobid/rpb#n548000","definition":"Wirtschaft (n540000) > Handel (n548000)"}
+{"prefLabel":"Handelsrecht","uri":"http://purl.org/lobid/rpb#n548010","definition":"Wirtschaft (n540000) > Handel (n548000) > Handelsrecht (n548010)"}
+{"prefLabel":"Handel / Geschichte","uri":"http://purl.org/lobid/rpb#n548020","definition":"Wirtschaft (n540000) > Handel (n548000) > Handel / Geschichte (n548020)"}
+{"prefLabel":"Handelsform","uri":"http://purl.org/lobid/rpb#n548030","definition":"Wirtschaft (n540000) > Handel (n548000) > Handelsform (n548030)"}
+{"prefLabel":"Messe / Wirtschaft","uri":"http://purl.org/lobid/rpb#n548040","definition":"Wirtschaft (n540000) > Handel (n548000) > Messe / Wirtschaft (n548040)"}
+{"prefLabel":"Markt","uri":"http://purl.org/lobid/rpb#n548045","definition":"Wirtschaft (n540000) > Handel (n548000) > Messe / Wirtschaft (n548040) > Markt (n548045)"}
+{"prefLabel":"Firma","uri":"http://purl.org/lobid/rpb#n548050","definition":"Wirtschaft (n540000) > Handel (n548000) > Firma (n548050)"}
+{"prefLabel":"Handelsgut","uri":"http://purl.org/lobid/rpb#n548060","definition":"Wirtschaft (n540000) > Handel (n548000) > Handelsgut (n548060)"}
+{"prefLabel":"Handelsgenossenschaft","uri":"http://purl.org/lobid/rpb#n548090","definition":"Wirtschaft (n540000) > Handel (n548000) > Handelsgenossenschaft (n548090)"}
+{"prefLabel":"Dienstleistungssektor","uri":"http://purl.org/lobid/rpb#n548200","definition":"Wirtschaft (n540000) > Dienstleistungssektor (n548200)"}
+{"prefLabel":"Dienstleistungsbetrieb","uri":"http://purl.org/lobid/rpb#n548250","definition":"Wirtschaft (n540000) > Dienstleistungssektor (n548200) > Dienstleistungsbetrieb (n548250)"}
+{"prefLabel":"Öffentliches Unternehmen","uri":"http://purl.org/lobid/rpb#n548300","definition":"Wirtschaft (n540000) > Öffentliches Unternehmen (n548300)"}
+{"prefLabel":"Bank","uri":"http://purl.org/lobid/rpb#n548400","definition":"Wirtschaft (n540000) > Bank (n548400)"}
+{"prefLabel":"Versicherung","uri":"http://purl.org/lobid/rpb#n548600","definition":"Wirtschaft (n540000) > Versicherung (n548600)"}
+{"prefLabel":"Tourismus","uri":"http://purl.org/lobid/rpb#n548800","definition":"Wirtschaft (n540000) > Tourismus (n548800)"}
+{"prefLabel":"Kurort","uri":"http://purl.org/lobid/rpb#n548820","definition":"Wirtschaft (n540000) > Tourismus (n548800) > Kurort (n548820)"}
+{"prefLabel":"Naherholung","uri":"http://purl.org/lobid/rpb#n548830","definition":"Wirtschaft (n540000) > Tourismus (n548800) > Naherholung (n548830)"}
+{"prefLabel":"Gastgewerbe","uri":"http://purl.org/lobid/rpb#n548840","definition":"Wirtschaft (n540000) > Tourismus (n548800) > Gastgewerbe (n548840)"}
+{"prefLabel":"Jugendherberge","uri":"http://purl.org/lobid/rpb#n548870","definition":"Wirtschaft (n540000) > Tourismus (n548800) > Jugendherberge (n548870)"}
 {"prefLabel":"Verkehr","uri":"http://purl.org/lobid/rpb#n550000"}
-{"prefLabel":"Verkehr allgemein","uri":"http://purl.org/lobid/rpb#n550100"}
-{"prefLabel":"Verkehrsrecht","uri":"http://purl.org/lobid/rpb#n551000"}
-{"prefLabel":"Verkehr / Geschichte","uri":"http://purl.org/lobid/rpb#n552000"}
-{"prefLabel":"Straßenverkehr","uri":"http://purl.org/lobid/rpb#n553000"}
-{"prefLabel":"Öffentlicher Personennahverkehr","uri":"http://purl.org/lobid/rpb#n554000"}
-{"prefLabel":"Eisenbahn","uri":"http://purl.org/lobid/rpb#n555000"}
-{"prefLabel":"Eisenbahn / Geschichte","uri":"http://purl.org/lobid/rpb#n555020"}
-{"prefLabel":"Luftverkehr","uri":"http://purl.org/lobid/rpb#n556000"}
-{"prefLabel":"Schifffahrt","uri":"http://purl.org/lobid/rpb#n557000"}
-{"prefLabel":"Schifffahrt / Geschichte","uri":"http://purl.org/lobid/rpb#n557020"}
-{"prefLabel":"Kanal","uri":"http://purl.org/lobid/rpb#n557040"}
-{"prefLabel":"Hafen","uri":"http://purl.org/lobid/rpb#n557060"}
-{"prefLabel":"Post. Fernmeldewesen","uri":"http://purl.org/lobid/rpb#n558000"}
-{"prefLabel":"Post / Geschichte","uri":"http://purl.org/lobid/rpb#n558020"}
-{"prefLabel":"Briefmarke","uri":"http://purl.org/lobid/rpb#n558040"}
-{"prefLabel":"Fernmeldewesen","uri":"http://purl.org/lobid/rpb#n558050"}
+{"prefLabel":"Verkehr allgemein","uri":"http://purl.org/lobid/rpb#n550100","definition":"Verkehr (n550000) > Verkehr allgemein (n550100)"}
+{"prefLabel":"Verkehrsrecht","uri":"http://purl.org/lobid/rpb#n551000","definition":"Verkehr (n550000) > Verkehrsrecht (n551000)"}
+{"prefLabel":"Verkehr / Geschichte","uri":"http://purl.org/lobid/rpb#n552000","definition":"Verkehr (n550000) > Verkehr / Geschichte (n552000)"}
+{"prefLabel":"Straßenverkehr","uri":"http://purl.org/lobid/rpb#n553000","definition":"Verkehr (n550000) > Straßenverkehr (n553000)"}
+{"prefLabel":"Öffentlicher Personennahverkehr","uri":"http://purl.org/lobid/rpb#n554000","definition":"Verkehr (n550000) > Öffentlicher Personennahverkehr (n554000)"}
+{"prefLabel":"Eisenbahn","uri":"http://purl.org/lobid/rpb#n555000","definition":"Verkehr (n550000) > Eisenbahn (n555000)"}
+{"prefLabel":"Eisenbahn / Geschichte","uri":"http://purl.org/lobid/rpb#n555020","definition":"Verkehr (n550000) > Eisenbahn (n555000) > Eisenbahn / Geschichte (n555020)"}
+{"prefLabel":"Luftverkehr","uri":"http://purl.org/lobid/rpb#n556000","definition":"Verkehr (n550000) > Luftverkehr (n556000)"}
+{"prefLabel":"Schifffahrt","uri":"http://purl.org/lobid/rpb#n557000","definition":"Verkehr (n550000) > Schifffahrt (n557000)"}
+{"prefLabel":"Schifffahrt / Geschichte","uri":"http://purl.org/lobid/rpb#n557020","definition":"Verkehr (n550000) > Schifffahrt (n557000) > Schifffahrt / Geschichte (n557020)"}
+{"prefLabel":"Kanal","uri":"http://purl.org/lobid/rpb#n557040","definition":"Verkehr (n550000) > Schifffahrt (n557000) > Kanal (n557040)"}
+{"prefLabel":"Hafen","uri":"http://purl.org/lobid/rpb#n557060","definition":"Verkehr (n550000) > Schifffahrt (n557000) > Hafen (n557060)"}
+{"prefLabel":"Post. Fernmeldewesen","uri":"http://purl.org/lobid/rpb#n558000","definition":"Verkehr (n550000) > Post. Fernmeldewesen (n558000)"}
+{"prefLabel":"Post / Geschichte","uri":"http://purl.org/lobid/rpb#n558020","definition":"Verkehr (n550000) > Post. Fernmeldewesen (n558000) > Post / Geschichte (n558020)"}
+{"prefLabel":"Briefmarke","uri":"http://purl.org/lobid/rpb#n558040","definition":"Verkehr (n550000) > Post. Fernmeldewesen (n558000) > Briefmarke (n558040)"}
+{"prefLabel":"Fernmeldewesen","uri":"http://purl.org/lobid/rpb#n558050","definition":"Verkehr (n550000) > Post. Fernmeldewesen (n558000) > Fernmeldewesen (n558050)"}
 {"prefLabel":"Siedlung","uri":"http://purl.org/lobid/rpb#n560000"}
-{"prefLabel":"Siedlung allgemein","uri":"http://purl.org/lobid/rpb#n560100"}
-{"prefLabel":"Siedlung / Geschichte","uri":"http://purl.org/lobid/rpb#n562000"}
-{"prefLabel":"Wüstung","uri":"http://purl.org/lobid/rpb#n562040"}
-{"prefLabel":"Allmende","uri":"http://purl.org/lobid/rpb#n562060"}
-{"prefLabel":"Kulturlandschaft","uri":"http://purl.org/lobid/rpb#n562300"}
-{"prefLabel":"Siedlungsraum","uri":"http://purl.org/lobid/rpb#n562600"}
-{"prefLabel":"Siedlungsform","uri":"http://purl.org/lobid/rpb#n563000"}
-{"prefLabel":"Industriestadt","uri":"http://purl.org/lobid/rpb#n563020"}
-{"prefLabel":"Marktzentrum","uri":"http://purl.org/lobid/rpb#n563030"}
-{"prefLabel":"Wohnsiedlung","uri":"http://purl.org/lobid/rpb#n563040"}
-{"prefLabel":"Gewerbegebiet","uri":"http://purl.org/lobid/rpb#n563050"}
-{"prefLabel":"Ländliche Siedlung","uri":"http://purl.org/lobid/rpb#n564000"}
-{"prefLabel":"Ländliche Siedlungsform","uri":"http://purl.org/lobid/rpb#n564040"}
-{"prefLabel":"Dorf / Topographie","uri":"http://purl.org/lobid/rpb#n564050"}
-{"prefLabel":"Dorferneuerung","uri":"http://purl.org/lobid/rpb#n564080"}
-{"prefLabel":"Stadt","uri":"http://purl.org/lobid/rpb#n566000"}
-{"prefLabel":"Stadttyp","uri":"http://purl.org/lobid/rpb#n566010"}
-{"prefLabel":"Städtische Siedlungsform","uri":"http://purl.org/lobid/rpb#n566020"}
-{"prefLabel":"Stadtgliederung","uri":"http://purl.org/lobid/rpb#n566040"}
-{"prefLabel":"Stadtkern","uri":"http://purl.org/lobid/rpb#n566041"}
-{"prefLabel":"Vorort","uri":"http://purl.org/lobid/rpb#n566042"}
-{"prefLabel":"Geschäftsviertel","uri":"http://purl.org/lobid/rpb#n566043"}
-{"prefLabel":"Stadtteil","uri":"http://purl.org/lobid/rpb#n566045"}
-{"prefLabel":"Stadt / Erholungsgebiet","uri":"http://purl.org/lobid/rpb#n566046"}
-{"prefLabel":"Stadt / Topographie","uri":"http://purl.org/lobid/rpb#n566050"}
-{"prefLabel":"Platz","uri":"http://purl.org/lobid/rpb#n566051"}
-{"prefLabel":"Straße","uri":"http://purl.org/lobid/rpb#n566052"}
-{"prefLabel":"Öffentliches Gebäude","uri":"http://purl.org/lobid/rpb#n566053"}
-{"prefLabel":"Verstädterung","uri":"http://purl.org/lobid/rpb#n566060"}
-{"prefLabel":"Ballungsraum","uri":"http://purl.org/lobid/rpb#n566070"}
-{"prefLabel":"Stadt / Umland","uri":"http://purl.org/lobid/rpb#n566080"}
+{"prefLabel":"Siedlung allgemein","uri":"http://purl.org/lobid/rpb#n560100","definition":"Siedlung (n560000) > Siedlung allgemein (n560100)"}
+{"prefLabel":"Siedlung / Geschichte","uri":"http://purl.org/lobid/rpb#n562000","definition":"Siedlung (n560000) > Siedlung / Geschichte (n562000)"}
+{"prefLabel":"Wüstung","uri":"http://purl.org/lobid/rpb#n562040","definition":"Siedlung (n560000) > Siedlung / Geschichte (n562000) > Wüstung (n562040)"}
+{"prefLabel":"Allmende","uri":"http://purl.org/lobid/rpb#n562060","definition":"Siedlung (n560000) > Siedlung / Geschichte (n562000) > Allmende (n562060)"}
+{"prefLabel":"Kulturlandschaft","uri":"http://purl.org/lobid/rpb#n562300","definition":"Siedlung (n560000) > Kulturlandschaft (n562300)"}
+{"prefLabel":"Siedlungsraum","uri":"http://purl.org/lobid/rpb#n562600","definition":"Siedlung (n560000) > Siedlungsraum (n562600)"}
+{"prefLabel":"Siedlungsform","uri":"http://purl.org/lobid/rpb#n563000","definition":"Siedlung (n560000) > Siedlungsform (n563000)"}
+{"prefLabel":"Industriestadt","uri":"http://purl.org/lobid/rpb#n563020","definition":"Siedlung (n560000) > Siedlungsform (n563000) > Industriestadt (n563020)"}
+{"prefLabel":"Marktzentrum","uri":"http://purl.org/lobid/rpb#n563030","definition":"Siedlung (n560000) > Siedlungsform (n563000) > Marktzentrum (n563030)"}
+{"prefLabel":"Wohnsiedlung","uri":"http://purl.org/lobid/rpb#n563040","definition":"Siedlung (n560000) > Siedlungsform (n563000) > Wohnsiedlung (n563040)"}
+{"prefLabel":"Gewerbegebiet","uri":"http://purl.org/lobid/rpb#n563050","definition":"Siedlung (n560000) > Siedlungsform (n563000) > Gewerbegebiet (n563050)"}
+{"prefLabel":"Ländliche Siedlung","uri":"http://purl.org/lobid/rpb#n564000","definition":"Siedlung (n560000) > Ländliche Siedlung (n564000)"}
+{"prefLabel":"Ländliche Siedlungsform","uri":"http://purl.org/lobid/rpb#n564040","definition":"Siedlung (n560000) > Ländliche Siedlung (n564000) > Ländliche Siedlungsform (n564040)"}
+{"prefLabel":"Dorf / Topographie","uri":"http://purl.org/lobid/rpb#n564050","definition":"Siedlung (n560000) > Ländliche Siedlung (n564000) > Dorf / Topographie (n564050)"}
+{"prefLabel":"Dorferneuerung","uri":"http://purl.org/lobid/rpb#n564080","definition":"Siedlung (n560000) > Ländliche Siedlung (n564000) > Dorferneuerung (n564080)"}
+{"prefLabel":"Stadt","uri":"http://purl.org/lobid/rpb#n566000","definition":"Siedlung (n560000) > Stadt (n566000)"}
+{"prefLabel":"Stadttyp","uri":"http://purl.org/lobid/rpb#n566010","definition":"Siedlung (n560000) > Stadt (n566000) > Stadttyp (n566010)"}
+{"prefLabel":"Städtische Siedlungsform","uri":"http://purl.org/lobid/rpb#n566020","definition":"Siedlung (n560000) > Stadt (n566000) > Städtische Siedlungsform (n566020)"}
+{"prefLabel":"Stadtgliederung","uri":"http://purl.org/lobid/rpb#n566040","definition":"Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040)"}
+{"prefLabel":"Stadtkern","uri":"http://purl.org/lobid/rpb#n566041","definition":"Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Stadtkern (n566041)"}
+{"prefLabel":"Vorort","uri":"http://purl.org/lobid/rpb#n566042","definition":"Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Vorort (n566042)"}
+{"prefLabel":"Geschäftsviertel","uri":"http://purl.org/lobid/rpb#n566043","definition":"Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Geschäftsviertel (n566043)"}
+{"prefLabel":"Stadtteil","uri":"http://purl.org/lobid/rpb#n566045","definition":"Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Stadtteil (n566045)"}
+{"prefLabel":"Stadt / Erholungsgebiet","uri":"http://purl.org/lobid/rpb#n566046","definition":"Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Stadt / Erholungsgebiet (n566046)"}
+{"prefLabel":"Stadt / Topographie","uri":"http://purl.org/lobid/rpb#n566050","definition":"Siedlung (n560000) > Stadt (n566000) > Stadt / Topographie (n566050)"}
+{"prefLabel":"Platz","uri":"http://purl.org/lobid/rpb#n566051","definition":"Siedlung (n560000) > Stadt (n566000) > Stadt / Topographie (n566050) > Platz (n566051)"}
+{"prefLabel":"Straße","uri":"http://purl.org/lobid/rpb#n566052","definition":"Siedlung (n560000) > Stadt (n566000) > Stadt / Topographie (n566050) > Straße (n566052)"}
+{"prefLabel":"Öffentliches Gebäude","uri":"http://purl.org/lobid/rpb#n566053","definition":"Siedlung (n560000) > Stadt (n566000) > Stadt / Topographie (n566050) > Öffentliches Gebäude (n566053)"}
+{"prefLabel":"Verstädterung","uri":"http://purl.org/lobid/rpb#n566060","definition":"Siedlung (n560000) > Stadt (n566000) > Verstädterung (n566060)"}
+{"prefLabel":"Ballungsraum","uri":"http://purl.org/lobid/rpb#n566070","definition":"Siedlung (n560000) > Stadt (n566000) > Ballungsraum (n566070)"}
+{"prefLabel":"Stadt / Umland","uri":"http://purl.org/lobid/rpb#n566080","definition":"Siedlung (n560000) > Stadt (n566000) > Stadt / Umland (n566080)"}
 {"prefLabel":"Raumordnung und Städtebau","uri":"http://purl.org/lobid/rpb#n570000"}
-{"prefLabel":"Raumordnung und Städtebau allgemein","uri":"http://purl.org/lobid/rpb#n570100"}
-{"prefLabel":"Raumordnung","uri":"http://purl.org/lobid/rpb#n572000"}
-{"prefLabel":"Landesplanung","uri":"http://purl.org/lobid/rpb#n572020"}
-{"prefLabel":"Regionalplanung","uri":"http://purl.org/lobid/rpb#n572030"}
-{"prefLabel":"Kreisplanung","uri":"http://purl.org/lobid/rpb#n572040"}
-{"prefLabel":"Landschaftsplanung","uri":"http://purl.org/lobid/rpb#n572050"}
-{"prefLabel":"Gemeindeplanung","uri":"http://purl.org/lobid/rpb#n572060"}
-{"prefLabel":"Bauwesen","uri":"http://purl.org/lobid/rpb#n574000"}
-{"prefLabel":"Bau- und Bodenrecht","uri":"http://purl.org/lobid/rpb#n574020"}
-{"prefLabel":"Städtebau","uri":"http://purl.org/lobid/rpb#n574030"}
-{"prefLabel":"Straßenbau","uri":"http://purl.org/lobid/rpb#n574040"}
-{"prefLabel":"Wohnungsbau","uri":"http://purl.org/lobid/rpb#n574050"}
-{"prefLabel":"Wohnungswirtschaft","uri":"http://purl.org/lobid/rpb#n574060"}
+{"prefLabel":"Raumordnung und Städtebau allgemein","uri":"http://purl.org/lobid/rpb#n570100","definition":"Raumordnung und Städtebau (n570000) > Raumordnung und Städtebau allgemein (n570100)"}
+{"prefLabel":"Raumordnung","uri":"http://purl.org/lobid/rpb#n572000","definition":"Raumordnung und Städtebau (n570000) > Raumordnung (n572000)"}
+{"prefLabel":"Landesplanung","uri":"http://purl.org/lobid/rpb#n572020","definition":"Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Landesplanung (n572020)"}
+{"prefLabel":"Regionalplanung","uri":"http://purl.org/lobid/rpb#n572030","definition":"Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Regionalplanung (n572030)"}
+{"prefLabel":"Kreisplanung","uri":"http://purl.org/lobid/rpb#n572040","definition":"Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Kreisplanung (n572040)"}
+{"prefLabel":"Landschaftsplanung","uri":"http://purl.org/lobid/rpb#n572050","definition":"Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Landschaftsplanung (n572050)"}
+{"prefLabel":"Gemeindeplanung","uri":"http://purl.org/lobid/rpb#n572060","definition":"Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Gemeindeplanung (n572060)"}
+{"prefLabel":"Bauwesen","uri":"http://purl.org/lobid/rpb#n574000","definition":"Raumordnung und Städtebau (n570000) > Bauwesen (n574000)"}
+{"prefLabel":"Bau- und Bodenrecht","uri":"http://purl.org/lobid/rpb#n574020","definition":"Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Bau- und Bodenrecht (n574020)"}
+{"prefLabel":"Städtebau","uri":"http://purl.org/lobid/rpb#n574030","definition":"Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Städtebau (n574030)"}
+{"prefLabel":"Straßenbau","uri":"http://purl.org/lobid/rpb#n574040","definition":"Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Straßenbau (n574040)"}
+{"prefLabel":"Wohnungsbau","uri":"http://purl.org/lobid/rpb#n574050","definition":"Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Wohnungsbau (n574050)"}
+{"prefLabel":"Wohnungswirtschaft","uri":"http://purl.org/lobid/rpb#n574060","definition":"Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Wohnungswirtschaft (n574060)"}
 {"prefLabel":"Umwelt- und Naturschutz","uri":"http://purl.org/lobid/rpb#n580000"}
-{"prefLabel":"Umwelt- und Naturschutz allgemein","uri":"http://purl.org/lobid/rpb#n580100"}
-{"prefLabel":"Umweltschutz","uri":"http://purl.org/lobid/rpb#n582000"}
-{"prefLabel":"Klimaschutz","uri":"http://purl.org/lobid/rpb#n582010"}
-{"prefLabel":"Bodenschutz","uri":"http://purl.org/lobid/rpb#n582020"}
-{"prefLabel":"Luftverschmutzung","uri":"http://purl.org/lobid/rpb#n582030"}
-{"prefLabel":"Lärmbelastung","uri":"http://purl.org/lobid/rpb#n582040"}
-{"prefLabel":"Gewässerschutz","uri":"http://purl.org/lobid/rpb#n582050"}
-{"prefLabel":"Abwasser","uri":"http://purl.org/lobid/rpb#n582052"}
-{"prefLabel":"Kanalisation","uri":"http://purl.org/lobid/rpb#n582054"}
-{"prefLabel":"Abfallbeseitigung","uri":"http://purl.org/lobid/rpb#n582060"}
-{"prefLabel":"Strahlenbelastung","uri":"http://purl.org/lobid/rpb#n582070"}
-{"prefLabel":"Naturschutz. Landschaftspflege","uri":"http://purl.org/lobid/rpb#n584000"}
-{"prefLabel":"Naturdenkmal","uri":"http://purl.org/lobid/rpb#n584040"}
-{"prefLabel":"Pflanzen / Artenschutz","uri":"http://purl.org/lobid/rpb#n584050"}
-{"prefLabel":"Tierschutz","uri":"http://purl.org/lobid/rpb#n584060"}
-{"prefLabel":"Naturschutzgebiet","uri":"http://purl.org/lobid/rpb#n584070"}
-{"prefLabel":"Nationalpark","uri":"http://purl.org/lobid/rpb#n584075"}
-{"prefLabel":"Naturpark","uri":"http://purl.org/lobid/rpb#n584080"}
-{"prefLabel":"Landschaftsentwicklung","uri":"http://purl.org/lobid/rpb#n584090"}
-{"prefLabel":"Grünanlage","uri":"http://purl.org/lobid/rpb#n586000"}
-{"prefLabel":"Park","uri":"http://purl.org/lobid/rpb#n586020"}
-{"prefLabel":"Botanischer Garten","uri":"http://purl.org/lobid/rpb#n586030"}
-{"prefLabel":"Zoologischer Garten","uri":"http://purl.org/lobid/rpb#n586040"}
-{"prefLabel":"Gartenbauausstellung","uri":"http://purl.org/lobid/rpb#n586080"}
+{"prefLabel":"Umwelt- und Naturschutz allgemein","uri":"http://purl.org/lobid/rpb#n580100","definition":"Umwelt- und Naturschutz (n580000) > Umwelt- und Naturschutz allgemein (n580100)"}
+{"prefLabel":"Umweltschutz","uri":"http://purl.org/lobid/rpb#n582000","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000)"}
+{"prefLabel":"Klimaschutz","uri":"http://purl.org/lobid/rpb#n582010","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Klimaschutz (n582010)"}
+{"prefLabel":"Bodenschutz","uri":"http://purl.org/lobid/rpb#n582020","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Bodenschutz (n582020)"}
+{"prefLabel":"Luftverschmutzung","uri":"http://purl.org/lobid/rpb#n582030","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Luftverschmutzung (n582030)"}
+{"prefLabel":"Lärmbelastung","uri":"http://purl.org/lobid/rpb#n582040","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Lärmbelastung (n582040)"}
+{"prefLabel":"Gewässerschutz","uri":"http://purl.org/lobid/rpb#n582050","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Gewässerschutz (n582050)"}
+{"prefLabel":"Abwasser","uri":"http://purl.org/lobid/rpb#n582052","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Gewässerschutz (n582050) > Abwasser (n582052)"}
+{"prefLabel":"Kanalisation","uri":"http://purl.org/lobid/rpb#n582054","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Gewässerschutz (n582050) > Kanalisation (n582054)"}
+{"prefLabel":"Abfallbeseitigung","uri":"http://purl.org/lobid/rpb#n582060","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Abfallbeseitigung (n582060)"}
+{"prefLabel":"Strahlenbelastung","uri":"http://purl.org/lobid/rpb#n582070","definition":"Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Strahlenbelastung (n582070)"}
+{"prefLabel":"Naturschutz. Landschaftspflege","uri":"http://purl.org/lobid/rpb#n584000","definition":"Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000)"}
+{"prefLabel":"Naturdenkmal","uri":"http://purl.org/lobid/rpb#n584040","definition":"Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Naturdenkmal (n584040)"}
+{"prefLabel":"Pflanzen / Artenschutz","uri":"http://purl.org/lobid/rpb#n584050","definition":"Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Pflanzen / Artenschutz (n584050)"}
+{"prefLabel":"Tierschutz","uri":"http://purl.org/lobid/rpb#n584060","definition":"Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Tierschutz (n584060)"}
+{"prefLabel":"Naturschutzgebiet","uri":"http://purl.org/lobid/rpb#n584070","definition":"Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Naturschutzgebiet (n584070)"}
+{"prefLabel":"Nationalpark","uri":"http://purl.org/lobid/rpb#n584075","definition":"Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Nationalpark (n584075)"}
+{"prefLabel":"Naturpark","uri":"http://purl.org/lobid/rpb#n584080","definition":"Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Naturpark (n584080)"}
+{"prefLabel":"Landschaftsentwicklung","uri":"http://purl.org/lobid/rpb#n584090","definition":"Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Landschaftsentwicklung (n584090)"}
+{"prefLabel":"Grünanlage","uri":"http://purl.org/lobid/rpb#n586000","definition":"Umwelt- und Naturschutz (n580000) > Grünanlage (n586000)"}
+{"prefLabel":"Park","uri":"http://purl.org/lobid/rpb#n586020","definition":"Umwelt- und Naturschutz (n580000) > Grünanlage (n586000) > Park (n586020)"}
+{"prefLabel":"Botanischer Garten","uri":"http://purl.org/lobid/rpb#n586030","definition":"Umwelt- und Naturschutz (n580000) > Grünanlage (n586000) > Botanischer Garten (n586030)"}
+{"prefLabel":"Zoologischer Garten","uri":"http://purl.org/lobid/rpb#n586040","definition":"Umwelt- und Naturschutz (n580000) > Grünanlage (n586000) > Zoologischer Garten (n586040)"}
+{"prefLabel":"Gartenbauausstellung","uri":"http://purl.org/lobid/rpb#n586080","definition":"Umwelt- und Naturschutz (n580000) > Grünanlage (n586000) > Gartenbauausstellung (n586080)"}
 {"prefLabel":"Kirche","uri":"http://purl.org/lobid/rpb#n610000"}
-{"prefLabel":"Kirche allgemein","uri":"http://purl.org/lobid/rpb#n610100"}
-{"prefLabel":"Katholische Kirche","uri":"http://purl.org/lobid/rpb#n611000"}
-{"prefLabel":"Kirchengeschichte","uri":"http://purl.org/lobid/rpb#n611010"}
-{"prefLabel":"Kirchenrecht","uri":"http://purl.org/lobid/rpb#n611020"}
-{"prefLabel":"Kirchenverwaltung","uri":"http://purl.org/lobid/rpb#n611025"}
-{"prefLabel":"Kirchengemeinde","uri":"http://purl.org/lobid/rpb#n611030"}
-{"prefLabel":"Kirchliches Leben","uri":"http://purl.org/lobid/rpb#n611040"}
-{"prefLabel":"Seelsorge","uri":"http://purl.org/lobid/rpb#n611042"}
-{"prefLabel":"Laienamt","uri":"http://purl.org/lobid/rpb#n611043"}
-{"prefLabel":"Kirchlicher Verein","uri":"http://purl.org/lobid/rpb#n611044"}
-{"prefLabel":"Kirchliche Stiftung","uri":"http://purl.org/lobid/rpb#n611045"}
-{"prefLabel":"Geistlicher. Ordensleute","uri":"http://purl.org/lobid/rpb#n611050"}
-{"prefLabel":"Kloster. Stift","uri":"http://purl.org/lobid/rpb#n611060"}
-{"prefLabel":"Orden","uri":"http://purl.org/lobid/rpb#n611070"}
-{"prefLabel":"Gottesdienst","uri":"http://purl.org/lobid/rpb#n611080"}
-{"prefLabel":"Sakrament","uri":"http://purl.org/lobid/rpb#n611082"}
-{"prefLabel":"Kirchenfest","uri":"http://purl.org/lobid/rpb#n611083"}
-{"prefLabel":"Prozession","uri":"http://purl.org/lobid/rpb#n611084"}
-{"prefLabel":"Wallfahrt","uri":"http://purl.org/lobid/rpb#n611085"}
-{"prefLabel":"Heiligenverehrung","uri":"http://purl.org/lobid/rpb#n611090"}
-{"prefLabel":"Reformation","uri":"http://purl.org/lobid/rpb#n612000"}
-{"prefLabel":"Calvinismus","uri":"http://purl.org/lobid/rpb#n612020"}
-{"prefLabel":"Zwinglianer","uri":"http://purl.org/lobid/rpb#n612022"}
-{"prefLabel":"Täufer","uri":"http://purl.org/lobid/rpb#n612030"}
-{"prefLabel":"Mennoniten","uri":"http://purl.org/lobid/rpb#n612032"}
-{"prefLabel":"Schwärmer / Theologie","uri":"http://purl.org/lobid/rpb#n612040"}
-{"prefLabel":"Reformator","uri":"http://purl.org/lobid/rpb#n612050"}
-{"prefLabel":"Glaubensflüchtling","uri":"http://purl.org/lobid/rpb#n612070"}
-{"prefLabel":"Hugenotten","uri":"http://purl.org/lobid/rpb#n612080"}
-{"prefLabel":"Gegenreformation","uri":"http://purl.org/lobid/rpb#n612500"}
-{"prefLabel":"Evangelische Kirche","uri":"http://purl.org/lobid/rpb#n613000"}
-{"prefLabel":"Kirchengeschichte","uri":"http://purl.org/lobid/rpb#n613010"}
-{"prefLabel":"Kirchenrecht","uri":"http://purl.org/lobid/rpb#n613020"}
-{"prefLabel":"Kirchenverwaltung","uri":"http://purl.org/lobid/rpb#n613025"}
-{"prefLabel":"Kirchengemeinde","uri":"http://purl.org/lobid/rpb#n613030"}
-{"prefLabel":"Kirchliches Leben","uri":"http://purl.org/lobid/rpb#n613040"}
-{"prefLabel":"Seelsorge","uri":"http://purl.org/lobid/rpb#n613042"}
-{"prefLabel":"Diakonie","uri":"http://purl.org/lobid/rpb#n613043"}
-{"prefLabel":"Kirchlicher Verein","uri":"http://purl.org/lobid/rpb#n613044"}
-{"prefLabel":"Kirchliche Stiftung","uri":"http://purl.org/lobid/rpb#n613045"}
-{"prefLabel":"Pfarrerin. Pfarrer. Geistliche","uri":"http://purl.org/lobid/rpb#n613050"}
-{"prefLabel":"Gottesdienst","uri":"http://purl.org/lobid/rpb#n613070"}
-{"prefLabel":"Sakrament","uri":"http://purl.org/lobid/rpb#n613072"}
-{"prefLabel":"Kirchenfest","uri":"http://purl.org/lobid/rpb#n613073"}
-{"prefLabel":"Sonstige christliche Religionsgemeinschaften","uri":"http://purl.org/lobid/rpb#n615000"}
-{"prefLabel":"Ökumene","uri":"http://purl.org/lobid/rpb#n616000"}
-{"prefLabel":"Bestattung","uri":"http://purl.org/lobid/rpb#n617000"}
-{"prefLabel":"Friedhof","uri":"http://purl.org/lobid/rpb#n617030"}
-{"prefLabel":"Grabmal","uri":"http://purl.org/lobid/rpb#n617050"}
+{"prefLabel":"Kirche allgemein","uri":"http://purl.org/lobid/rpb#n610100","definition":"Kirche (n610000) > Kirche allgemein (n610100)"}
+{"prefLabel":"Katholische Kirche","uri":"http://purl.org/lobid/rpb#n611000","definition":"Kirche (n610000) > Katholische Kirche (n611000)"}
+{"prefLabel":"Kirchengeschichte","uri":"http://purl.org/lobid/rpb#n611010","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kirchengeschichte (n611010)"}
+{"prefLabel":"Kirchenrecht","uri":"http://purl.org/lobid/rpb#n611020","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kirchenrecht (n611020)"}
+{"prefLabel":"Kirchenverwaltung","uri":"http://purl.org/lobid/rpb#n611025","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kirchenverwaltung (n611025)"}
+{"prefLabel":"Kirchengemeinde","uri":"http://purl.org/lobid/rpb#n611030","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kirchengemeinde (n611030)"}
+{"prefLabel":"Kirchliches Leben","uri":"http://purl.org/lobid/rpb#n611040","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040)"}
+{"prefLabel":"Seelsorge","uri":"http://purl.org/lobid/rpb#n611042","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040) > Seelsorge (n611042)"}
+{"prefLabel":"Laienamt","uri":"http://purl.org/lobid/rpb#n611043","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040) > Laienamt (n611043)"}
+{"prefLabel":"Kirchlicher Verein","uri":"http://purl.org/lobid/rpb#n611044","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040) > Kirchlicher Verein (n611044)"}
+{"prefLabel":"Kirchliche Stiftung","uri":"http://purl.org/lobid/rpb#n611045","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040) > Kirchliche Stiftung (n611045)"}
+{"prefLabel":"Geistlicher. Ordensleute","uri":"http://purl.org/lobid/rpb#n611050","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Geistlicher. Ordensleute (n611050)"}
+{"prefLabel":"Kloster. Stift","uri":"http://purl.org/lobid/rpb#n611060","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Kloster. Stift (n611060)"}
+{"prefLabel":"Orden","uri":"http://purl.org/lobid/rpb#n611070","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Orden (n611070)"}
+{"prefLabel":"Gottesdienst","uri":"http://purl.org/lobid/rpb#n611080","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080)"}
+{"prefLabel":"Sakrament","uri":"http://purl.org/lobid/rpb#n611082","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080) > Sakrament (n611082)"}
+{"prefLabel":"Kirchenfest","uri":"http://purl.org/lobid/rpb#n611083","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080) > Kirchenfest (n611083)"}
+{"prefLabel":"Prozession","uri":"http://purl.org/lobid/rpb#n611084","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080) > Prozession (n611084)"}
+{"prefLabel":"Wallfahrt","uri":"http://purl.org/lobid/rpb#n611085","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080) > Wallfahrt (n611085)"}
+{"prefLabel":"Heiligenverehrung","uri":"http://purl.org/lobid/rpb#n611090","definition":"Kirche (n610000) > Katholische Kirche (n611000) > Heiligenverehrung (n611090)"}
+{"prefLabel":"Reformation","uri":"http://purl.org/lobid/rpb#n612000","definition":"Kirche (n610000) > Reformation (n612000)"}
+{"prefLabel":"Calvinismus","uri":"http://purl.org/lobid/rpb#n612020","definition":"Kirche (n610000) > Reformation (n612000) > Calvinismus (n612020)"}
+{"prefLabel":"Zwinglianer","uri":"http://purl.org/lobid/rpb#n612022","definition":"Kirche (n610000) > Reformation (n612000) > Calvinismus (n612020) > Zwinglianer (n612022)"}
+{"prefLabel":"Täufer","uri":"http://purl.org/lobid/rpb#n612030","definition":"Kirche (n610000) > Reformation (n612000) > Täufer (n612030)"}
+{"prefLabel":"Mennoniten","uri":"http://purl.org/lobid/rpb#n612032","definition":"Kirche (n610000) > Reformation (n612000) > Täufer (n612030) > Mennoniten (n612032)"}
+{"prefLabel":"Schwärmer / Theologie","uri":"http://purl.org/lobid/rpb#n612040","definition":"Kirche (n610000) > Reformation (n612000) > Schwärmer / Theologie (n612040)"}
+{"prefLabel":"Reformator","uri":"http://purl.org/lobid/rpb#n612050","definition":"Kirche (n610000) > Reformation (n612000) > Reformator (n612050)"}
+{"prefLabel":"Glaubensflüchtling","uri":"http://purl.org/lobid/rpb#n612070","definition":"Kirche (n610000) > Reformation (n612000) > Glaubensflüchtling (n612070)"}
+{"prefLabel":"Hugenotten","uri":"http://purl.org/lobid/rpb#n612080","definition":"Kirche (n610000) > Reformation (n612000) > Hugenotten (n612080)"}
+{"prefLabel":"Gegenreformation","uri":"http://purl.org/lobid/rpb#n612500","definition":"Kirche (n610000) > Gegenreformation (n612500)"}
+{"prefLabel":"Evangelische Kirche","uri":"http://purl.org/lobid/rpb#n613000","definition":"Kirche (n610000) > Evangelische Kirche (n613000)"}
+{"prefLabel":"Kirchengeschichte","uri":"http://purl.org/lobid/rpb#n613010","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Kirchengeschichte (n613010)"}
+{"prefLabel":"Kirchenrecht","uri":"http://purl.org/lobid/rpb#n613020","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Kirchenrecht (n613020)"}
+{"prefLabel":"Kirchenverwaltung","uri":"http://purl.org/lobid/rpb#n613025","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Kirchenverwaltung (n613025)"}
+{"prefLabel":"Kirchengemeinde","uri":"http://purl.org/lobid/rpb#n613030","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Kirchengemeinde (n613030)"}
+{"prefLabel":"Kirchliches Leben","uri":"http://purl.org/lobid/rpb#n613040","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040)"}
+{"prefLabel":"Seelsorge","uri":"http://purl.org/lobid/rpb#n613042","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040) > Seelsorge (n613042)"}
+{"prefLabel":"Diakonie","uri":"http://purl.org/lobid/rpb#n613043","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040) > Diakonie (n613043)"}
+{"prefLabel":"Kirchlicher Verein","uri":"http://purl.org/lobid/rpb#n613044","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040) > Kirchlicher Verein (n613044)"}
+{"prefLabel":"Kirchliche Stiftung","uri":"http://purl.org/lobid/rpb#n613045","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040) > Kirchliche Stiftung (n613045)"}
+{"prefLabel":"Pfarrerin. Pfarrer. Geistliche","uri":"http://purl.org/lobid/rpb#n613050","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Pfarrerin. Pfarrer. Geistliche (n613050)"}
+{"prefLabel":"Gottesdienst","uri":"http://purl.org/lobid/rpb#n613070","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Gottesdienst (n613070)"}
+{"prefLabel":"Sakrament","uri":"http://purl.org/lobid/rpb#n613072","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Gottesdienst (n613070) > Sakrament (n613072)"}
+{"prefLabel":"Kirchenfest","uri":"http://purl.org/lobid/rpb#n613073","definition":"Kirche (n610000) > Evangelische Kirche (n613000) > Gottesdienst (n613070) > Kirchenfest (n613073)"}
+{"prefLabel":"Sonstige christliche Religionsgemeinschaften","uri":"http://purl.org/lobid/rpb#n615000","definition":"Kirche (n610000) > Sonstige christliche Religionsgemeinschaften (n615000)"}
+{"prefLabel":"Ökumene","uri":"http://purl.org/lobid/rpb#n616000","definition":"Kirche (n610000) > Ökumene (n616000)"}
+{"prefLabel":"Bestattung","uri":"http://purl.org/lobid/rpb#n617000","definition":"Kirche (n610000) > Bestattung (n617000)"}
+{"prefLabel":"Friedhof","uri":"http://purl.org/lobid/rpb#n617030","definition":"Kirche (n610000) > Bestattung (n617000) > Friedhof (n617030)"}
+{"prefLabel":"Grabmal","uri":"http://purl.org/lobid/rpb#n617050","definition":"Kirche (n610000) > Bestattung (n617000) > Grabmal (n617050)"}
 {"prefLabel":"Juden","uri":"http://purl.org/lobid/rpb#n630000"}
-{"prefLabel":"Juden allgemein","uri":"http://purl.org/lobid/rpb#n630100"}
-{"prefLabel":"Judentum","uri":"http://purl.org/lobid/rpb#n631000"}
-{"prefLabel":"Juden / Geschichte","uri":"http://purl.org/lobid/rpb#n632000"}
-{"prefLabel":"Judenverfolgung","uri":"http://purl.org/lobid/rpb#n632050"}
+{"prefLabel":"Juden allgemein","uri":"http://purl.org/lobid/rpb#n630100","definition":"Juden (n630000) > Juden allgemein (n630100)"}
+{"prefLabel":"Judentum","uri":"http://purl.org/lobid/rpb#n631000","definition":"Juden (n630000) > Judentum (n631000)"}
+{"prefLabel":"Juden / Geschichte","uri":"http://purl.org/lobid/rpb#n632000","definition":"Juden (n630000) > Juden / Geschichte (n632000)"}
+{"prefLabel":"Judenverfolgung","uri":"http://purl.org/lobid/rpb#n632050","definition":"Juden (n630000) > Juden / Geschichte (n632000) > Judenverfolgung (n632050)"}
 {"prefLabel":"Nichtchristliche Religion","uri":"http://purl.org/lobid/rpb#n650000"}
-{"prefLabel":"Nichtchristliche Religion allgemein","uri":"http://purl.org/lobid/rpb#n651000"}
-{"prefLabel":"Islam","uri":"http://purl.org/lobid/rpb#n651020"}
-{"prefLabel":"Buddhismus","uri":"http://purl.org/lobid/rpb#n651030"}
-{"prefLabel":"Weltanschauungsgemeinschaft","uri":"http://purl.org/lobid/rpb#n655000"}
-{"prefLabel":"Freimaurer","uri":"http://purl.org/lobid/rpb#n655030"}
+{"prefLabel":"Nichtchristliche Religion allgemein","uri":"http://purl.org/lobid/rpb#n651000","definition":"Nichtchristliche Religion (n650000) > Nichtchristliche Religion allgemein (n651000)"}
+{"prefLabel":"Islam","uri":"http://purl.org/lobid/rpb#n651020","definition":"Nichtchristliche Religion (n650000) > Nichtchristliche Religion allgemein (n651000) > Islam (n651020)"}
+{"prefLabel":"Buddhismus","uri":"http://purl.org/lobid/rpb#n651030","definition":"Nichtchristliche Religion (n650000) > Nichtchristliche Religion allgemein (n651000) > Buddhismus (n651030)"}
+{"prefLabel":"Weltanschauungsgemeinschaft","uri":"http://purl.org/lobid/rpb#n655000","definition":"Nichtchristliche Religion (n650000) > Weltanschauungsgemeinschaft (n655000)"}
+{"prefLabel":"Freimaurer","uri":"http://purl.org/lobid/rpb#n655030","definition":"Nichtchristliche Religion (n650000) > Weltanschauungsgemeinschaft (n655000) > Freimaurer (n655030)"}
 {"prefLabel":"Volkskunde","uri":"http://purl.org/lobid/rpb#n700000"}
-{"prefLabel":"Volkskunde allgemein","uri":"http://purl.org/lobid/rpb#n700100"}
-{"prefLabel":"Alltag","uri":"http://purl.org/lobid/rpb#n702000"}
-{"prefLabel":"Brauch","uri":"http://purl.org/lobid/rpb#n704000"}
-{"prefLabel":"Brauch / Alltag","uri":"http://purl.org/lobid/rpb#n704020"}
-{"prefLabel":"Brauch / Jahreslauf","uri":"http://purl.org/lobid/rpb#n704040"}
-{"prefLabel":"Winter / Brauch. Weihnachten. Neujahr","uri":"http://purl.org/lobid/rpb#n704042"}
-{"prefLabel":"Karneval","uri":"http://purl.org/lobid/rpb#n704043"}
-{"prefLabel":"Frühling / Brauch. Ostern","uri":"http://purl.org/lobid/rpb#n704044"}
-{"prefLabel":"Mai / Brauch. Pfingsten. Sommer / Brauch","uri":"http://purl.org/lobid/rpb#n704045"}
-{"prefLabel":"Erntedankfest","uri":"http://purl.org/lobid/rpb#n704046"}
-{"prefLabel":"Kirchweih","uri":"http://purl.org/lobid/rpb#n704047"}
-{"prefLabel":"Lebenslauf / Brauch","uri":"http://purl.org/lobid/rpb#n704060"}
-{"prefLabel":"Geburt","uri":"http://purl.org/lobid/rpb#n704061"}
-{"prefLabel":"Liebe / Brauch. Verlobung. Hochzeit","uri":"http://purl.org/lobid/rpb#n704063"}
-{"prefLabel":"Tod / Brauch. Bestattung","uri":"http://purl.org/lobid/rpb#n704064"}
-{"prefLabel":"Beruf / Brauch","uri":"http://purl.org/lobid/rpb#n704080"}
-{"prefLabel":"Handwerk / Brauch","uri":"http://purl.org/lobid/rpb#n704082"}
-{"prefLabel":"Brauchtumspflege / Verein","uri":"http://purl.org/lobid/rpb#n704090"}
-{"prefLabel":"Volkswissen","uri":"http://purl.org/lobid/rpb#n704200"}
-{"prefLabel":"Volksmedizin","uri":"http://purl.org/lobid/rpb#n704220"}
-{"prefLabel":"Ethnobotanik","uri":"http://purl.org/lobid/rpb#n704230"}
-{"prefLabel":"Volkszoologie","uri":"http://purl.org/lobid/rpb#n704240"}
-{"prefLabel":"Wetter / Bauernregel","uri":"http://purl.org/lobid/rpb#n704250"}
-{"prefLabel":"Astrologie","uri":"http://purl.org/lobid/rpb#n704260"}
-{"prefLabel":"Wahrsagen","uri":"http://purl.org/lobid/rpb#n704270"}
-{"prefLabel":"Alchemie","uri":"http://purl.org/lobid/rpb#n704280"}
-{"prefLabel":"Rechtliche Volkskunde","uri":"http://purl.org/lobid/rpb#n704400"}
-{"prefLabel":"Religiöse Volkskunde","uri":"http://purl.org/lobid/rpb#n704600"}
-{"prefLabel":"Volksfrömmigkeit","uri":"http://purl.org/lobid/rpb#n704630"}
-{"prefLabel":"Gegenstände der Volksfrömmigkeit","uri":"http://purl.org/lobid/rpb#n704634"}
-{"prefLabel":"Volksglaube","uri":"http://purl.org/lobid/rpb#n704700"}
-{"prefLabel":"Volksliteratur","uri":"http://purl.org/lobid/rpb#n706000"}
-{"prefLabel":"Volksbuch","uri":"http://purl.org/lobid/rpb#n706020"}
-{"prefLabel":"Märchen. Sage. Legende","uri":"http://purl.org/lobid/rpb#n706040"}
-{"prefLabel":"Schwank","uri":"http://purl.org/lobid/rpb#n706050"}
-{"prefLabel":"Witz","uri":"http://purl.org/lobid/rpb#n706052"}
-{"prefLabel":"Sprichwort","uri":"http://purl.org/lobid/rpb#n706060"}
-{"prefLabel":"Inschrift","uri":"http://purl.org/lobid/rpb#n706070"}
-{"prefLabel":"Rätsel","uri":"http://purl.org/lobid/rpb#n706080"}
-{"prefLabel":"Mundartliteratur","uri":"http://purl.org/lobid/rpb#n706090"}
-{"prefLabel":"Volksmusik. Volkstanz","uri":"http://purl.org/lobid/rpb#n706200"}
-{"prefLabel":"Volksmusik","uri":"http://purl.org/lobid/rpb#n706210"}
-{"prefLabel":"Volkslied","uri":"http://purl.org/lobid/rpb#n706230"}
-{"prefLabel":"Volkstanz","uri":"http://purl.org/lobid/rpb#n706240"}
-{"prefLabel":"Sachkulturforschung","uri":"http://purl.org/lobid/rpb#n708000"}
-{"prefLabel":"Hausform","uri":"http://purl.org/lobid/rpb#n708020"}
-{"prefLabel":"Bürgerhaus","uri":"http://purl.org/lobid/rpb#n708024"}
-{"prefLabel":"Bauernhaus","uri":"http://purl.org/lobid/rpb#n708026"}
-{"prefLabel":"Landwirtschaftliches Gebäude","uri":"http://purl.org/lobid/rpb#n708028"}
-{"prefLabel":"Mühle","uri":"http://purl.org/lobid/rpb#n708029"}
-{"prefLabel":"Hausrat","uri":"http://purl.org/lobid/rpb#n708030"}
-{"prefLabel":"Gerät","uri":"http://purl.org/lobid/rpb#n708040"}
-{"prefLabel":"Spielzeug","uri":"http://purl.org/lobid/rpb#n708050"}
-{"prefLabel":"Nahrung","uri":"http://purl.org/lobid/rpb#n708060"}
-{"prefLabel":"Volkskunst","uri":"http://purl.org/lobid/rpb#n708200"}
-{"prefLabel":"Holzbearbeitung","uri":"http://purl.org/lobid/rpb#n708220"}
-{"prefLabel":"Malerei","uri":"http://purl.org/lobid/rpb#n708230"}
-{"prefLabel":"Keramik","uri":"http://purl.org/lobid/rpb#n708250"}
-{"prefLabel":"Steinbearbeitung","uri":"http://purl.org/lobid/rpb#n708260"}
-{"prefLabel":"Metallbearbeitung","uri":"http://purl.org/lobid/rpb#n708270"}
-{"prefLabel":"Glas","uri":"http://purl.org/lobid/rpb#n708280"}
-{"prefLabel":"Textilien","uri":"http://purl.org/lobid/rpb#n708290"}
-{"prefLabel":"Kleidung","uri":"http://purl.org/lobid/rpb#n708400"}
-{"prefLabel":"Kostümkunde","uri":"http://purl.org/lobid/rpb#n708420"}
-{"prefLabel":"Tracht","uri":"http://purl.org/lobid/rpb#n708430"}
-{"prefLabel":"Schmuck","uri":"http://purl.org/lobid/rpb#n708450"}
+{"prefLabel":"Volkskunde allgemein","uri":"http://purl.org/lobid/rpb#n700100","definition":"Volkskunde (n700000) > Volkskunde allgemein (n700100)"}
+{"prefLabel":"Alltag","uri":"http://purl.org/lobid/rpb#n702000","definition":"Volkskunde (n700000) > Alltag (n702000)"}
+{"prefLabel":"Brauch","uri":"http://purl.org/lobid/rpb#n704000","definition":"Volkskunde (n700000) > Brauch (n704000)"}
+{"prefLabel":"Brauch / Alltag","uri":"http://purl.org/lobid/rpb#n704020","definition":"Volkskunde (n700000) > Brauch (n704000) > Brauch / Alltag (n704020)"}
+{"prefLabel":"Brauch / Jahreslauf","uri":"http://purl.org/lobid/rpb#n704040","definition":"Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040)"}
+{"prefLabel":"Winter / Brauch. Weihnachten. Neujahr","uri":"http://purl.org/lobid/rpb#n704042","definition":"Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Winter / Brauch. Weihnachten. Neujahr (n704042)"}
+{"prefLabel":"Karneval","uri":"http://purl.org/lobid/rpb#n704043","definition":"Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Karneval (n704043)"}
+{"prefLabel":"Frühling / Brauch. Ostern","uri":"http://purl.org/lobid/rpb#n704044","definition":"Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Frühling / Brauch. Ostern (n704044)"}
+{"prefLabel":"Mai / Brauch. Pfingsten. Sommer / Brauch","uri":"http://purl.org/lobid/rpb#n704045","definition":"Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Mai / Brauch. Pfingsten. Sommer / Brauch (n704045)"}
+{"prefLabel":"Erntedankfest","uri":"http://purl.org/lobid/rpb#n704046","definition":"Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Erntedankfest (n704046)"}
+{"prefLabel":"Kirchweih","uri":"http://purl.org/lobid/rpb#n704047","definition":"Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Kirchweih (n704047)"}
+{"prefLabel":"Lebenslauf / Brauch","uri":"http://purl.org/lobid/rpb#n704060","definition":"Volkskunde (n700000) > Brauch (n704000) > Lebenslauf / Brauch (n704060)"}
+{"prefLabel":"Geburt","uri":"http://purl.org/lobid/rpb#n704061","definition":"Volkskunde (n700000) > Brauch (n704000) > Lebenslauf / Brauch (n704060) > Geburt (n704061)"}
+{"prefLabel":"Liebe / Brauch. Verlobung. Hochzeit","uri":"http://purl.org/lobid/rpb#n704063","definition":"Volkskunde (n700000) > Brauch (n704000) > Lebenslauf / Brauch (n704060) > Liebe / Brauch. Verlobung. Hochzeit (n704063)"}
+{"prefLabel":"Tod / Brauch. Bestattung","uri":"http://purl.org/lobid/rpb#n704064","definition":"Volkskunde (n700000) > Brauch (n704000) > Lebenslauf / Brauch (n704060) > Tod / Brauch. Bestattung (n704064)"}
+{"prefLabel":"Beruf / Brauch","uri":"http://purl.org/lobid/rpb#n704080","definition":"Volkskunde (n700000) > Brauch (n704000) > Beruf / Brauch (n704080)"}
+{"prefLabel":"Handwerk / Brauch","uri":"http://purl.org/lobid/rpb#n704082","definition":"Volkskunde (n700000) > Brauch (n704000) > Beruf / Brauch (n704080) > Handwerk / Brauch (n704082)"}
+{"prefLabel":"Brauchtumspflege / Verein","uri":"http://purl.org/lobid/rpb#n704090","definition":"Volkskunde (n700000) > Brauch (n704000) > Brauchtumspflege / Verein (n704090)"}
+{"prefLabel":"Volkswissen","uri":"http://purl.org/lobid/rpb#n704200","definition":"Volkskunde (n700000) > Volkswissen (n704200)"}
+{"prefLabel":"Volksmedizin","uri":"http://purl.org/lobid/rpb#n704220","definition":"Volkskunde (n700000) > Volkswissen (n704200) > Volksmedizin (n704220)"}
+{"prefLabel":"Ethnobotanik","uri":"http://purl.org/lobid/rpb#n704230","definition":"Volkskunde (n700000) > Volkswissen (n704200) > Ethnobotanik (n704230)"}
+{"prefLabel":"Volkszoologie","uri":"http://purl.org/lobid/rpb#n704240","definition":"Volkskunde (n700000) > Volkswissen (n704200) > Volkszoologie (n704240)"}
+{"prefLabel":"Wetter / Bauernregel","uri":"http://purl.org/lobid/rpb#n704250","definition":"Volkskunde (n700000) > Volkswissen (n704200) > Wetter / Bauernregel (n704250)"}
+{"prefLabel":"Astrologie","uri":"http://purl.org/lobid/rpb#n704260","definition":"Volkskunde (n700000) > Volkswissen (n704200) > Astrologie (n704260)"}
+{"prefLabel":"Wahrsagen","uri":"http://purl.org/lobid/rpb#n704270","definition":"Volkskunde (n700000) > Volkswissen (n704200) > Wahrsagen (n704270)"}
+{"prefLabel":"Alchemie","uri":"http://purl.org/lobid/rpb#n704280","definition":"Volkskunde (n700000) > Volkswissen (n704200) > Alchemie (n704280)"}
+{"prefLabel":"Rechtliche Volkskunde","uri":"http://purl.org/lobid/rpb#n704400","definition":"Volkskunde (n700000) > Rechtliche Volkskunde (n704400)"}
+{"prefLabel":"Religiöse Volkskunde","uri":"http://purl.org/lobid/rpb#n704600","definition":"Volkskunde (n700000) > Religiöse Volkskunde (n704600)"}
+{"prefLabel":"Volksfrömmigkeit","uri":"http://purl.org/lobid/rpb#n704630","definition":"Volkskunde (n700000) > Religiöse Volkskunde (n704600) > Volksfrömmigkeit (n704630)"}
+{"prefLabel":"Gegenstände der Volksfrömmigkeit","uri":"http://purl.org/lobid/rpb#n704634","definition":"Volkskunde (n700000) > Religiöse Volkskunde (n704600) > Volksfrömmigkeit (n704630) > Gegenstände der Volksfrömmigkeit (n704634)"}
+{"prefLabel":"Volksglaube","uri":"http://purl.org/lobid/rpb#n704700","definition":"Volkskunde (n700000) > Volksglaube (n704700)"}
+{"prefLabel":"Volksliteratur","uri":"http://purl.org/lobid/rpb#n706000","definition":"Volkskunde (n700000) > Volksliteratur (n706000)"}
+{"prefLabel":"Volksbuch","uri":"http://purl.org/lobid/rpb#n706020","definition":"Volkskunde (n700000) > Volksliteratur (n706000) > Volksbuch (n706020)"}
+{"prefLabel":"Märchen. Sage. Legende","uri":"http://purl.org/lobid/rpb#n706040","definition":"Volkskunde (n700000) > Volksliteratur (n706000) > Märchen. Sage. Legende (n706040)"}
+{"prefLabel":"Schwank","uri":"http://purl.org/lobid/rpb#n706050","definition":"Volkskunde (n700000) > Volksliteratur (n706000) > Schwank (n706050)"}
+{"prefLabel":"Witz","uri":"http://purl.org/lobid/rpb#n706052","definition":"Volkskunde (n700000) > Volksliteratur (n706000) > Schwank (n706050) > Witz (n706052)"}
+{"prefLabel":"Sprichwort","uri":"http://purl.org/lobid/rpb#n706060","definition":"Volkskunde (n700000) > Volksliteratur (n706000) > Sprichwort (n706060)"}
+{"prefLabel":"Inschrift","uri":"http://purl.org/lobid/rpb#n706070","definition":"Volkskunde (n700000) > Volksliteratur (n706000) > Inschrift (n706070)"}
+{"prefLabel":"Rätsel","uri":"http://purl.org/lobid/rpb#n706080","definition":"Volkskunde (n700000) > Volksliteratur (n706000) > Rätsel (n706080)"}
+{"prefLabel":"Mundartliteratur","uri":"http://purl.org/lobid/rpb#n706090","definition":"Volkskunde (n700000) > Volksliteratur (n706000) > Mundartliteratur (n706090)"}
+{"prefLabel":"Volksmusik. Volkstanz","uri":"http://purl.org/lobid/rpb#n706200","definition":"Volkskunde (n700000) > Volksmusik. Volkstanz (n706200)"}
+{"prefLabel":"Volksmusik","uri":"http://purl.org/lobid/rpb#n706210","definition":"Volkskunde (n700000) > Volksmusik. Volkstanz (n706200) > Volksmusik (n706210)"}
+{"prefLabel":"Volkslied","uri":"http://purl.org/lobid/rpb#n706230","definition":"Volkskunde (n700000) > Volksmusik. Volkstanz (n706200) > Volkslied (n706230)"}
+{"prefLabel":"Volkstanz","uri":"http://purl.org/lobid/rpb#n706240","definition":"Volkskunde (n700000) > Volksmusik. Volkstanz (n706200) > Volkstanz (n706240)"}
+{"prefLabel":"Sachkulturforschung","uri":"http://purl.org/lobid/rpb#n708000","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000)"}
+{"prefLabel":"Hausform","uri":"http://purl.org/lobid/rpb#n708020","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020)"}
+{"prefLabel":"Bürgerhaus","uri":"http://purl.org/lobid/rpb#n708024","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020) > Bürgerhaus (n708024)"}
+{"prefLabel":"Bauernhaus","uri":"http://purl.org/lobid/rpb#n708026","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020) > Bauernhaus (n708026)"}
+{"prefLabel":"Landwirtschaftliches Gebäude","uri":"http://purl.org/lobid/rpb#n708028","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020) > Landwirtschaftliches Gebäude (n708028)"}
+{"prefLabel":"Mühle","uri":"http://purl.org/lobid/rpb#n708029","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020) > Mühle (n708029)"}
+{"prefLabel":"Hausrat","uri":"http://purl.org/lobid/rpb#n708030","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausrat (n708030)"}
+{"prefLabel":"Gerät","uri":"http://purl.org/lobid/rpb#n708040","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Gerät (n708040)"}
+{"prefLabel":"Spielzeug","uri":"http://purl.org/lobid/rpb#n708050","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Spielzeug (n708050)"}
+{"prefLabel":"Nahrung","uri":"http://purl.org/lobid/rpb#n708060","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Nahrung (n708060)"}
+{"prefLabel":"Volkskunst","uri":"http://purl.org/lobid/rpb#n708200","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200)"}
+{"prefLabel":"Holzbearbeitung","uri":"http://purl.org/lobid/rpb#n708220","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Holzbearbeitung (n708220)"}
+{"prefLabel":"Malerei","uri":"http://purl.org/lobid/rpb#n708230","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Malerei (n708230)"}
+{"prefLabel":"Keramik","uri":"http://purl.org/lobid/rpb#n708250","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Keramik (n708250)"}
+{"prefLabel":"Steinbearbeitung","uri":"http://purl.org/lobid/rpb#n708260","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Steinbearbeitung (n708260)"}
+{"prefLabel":"Metallbearbeitung","uri":"http://purl.org/lobid/rpb#n708270","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Metallbearbeitung (n708270)"}
+{"prefLabel":"Glas","uri":"http://purl.org/lobid/rpb#n708280","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Glas (n708280)"}
+{"prefLabel":"Textilien","uri":"http://purl.org/lobid/rpb#n708290","definition":"Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Textilien (n708290)"}
+{"prefLabel":"Kleidung","uri":"http://purl.org/lobid/rpb#n708400","definition":"Volkskunde (n700000) > Kleidung (n708400)"}
+{"prefLabel":"Kostümkunde","uri":"http://purl.org/lobid/rpb#n708420","definition":"Volkskunde (n700000) > Kleidung (n708400) > Kostümkunde (n708420)"}
+{"prefLabel":"Tracht","uri":"http://purl.org/lobid/rpb#n708430","definition":"Volkskunde (n700000) > Kleidung (n708400) > Tracht (n708430)"}
+{"prefLabel":"Schmuck","uri":"http://purl.org/lobid/rpb#n708450","definition":"Volkskunde (n700000) > Kleidung (n708400) > Schmuck (n708450)"}
 {"prefLabel":"Gesellschaft","uri":"http://purl.org/lobid/rpb#n720000"}
-{"prefLabel":"Gesellschaft allgemein","uri":"http://purl.org/lobid/rpb#n720100"}
-{"prefLabel":"Sozialgeschichte","uri":"http://purl.org/lobid/rpb#n722000"}
-{"prefLabel":"Sozialstruktur","uri":"http://purl.org/lobid/rpb#n724000"}
-{"prefLabel":"Kind","uri":"http://purl.org/lobid/rpb#n724020"}
-{"prefLabel":"Jugend","uri":"http://purl.org/lobid/rpb#n724030"}
-{"prefLabel":"Frau","uri":"http://purl.org/lobid/rpb#n724040"}
-{"prefLabel":"Mann","uri":"http://purl.org/lobid/rpb#n724050"}
-{"prefLabel":"Alter","uri":"http://purl.org/lobid/rpb#n724060"}
-{"prefLabel":"Original / Person","uri":"http://purl.org/lobid/rpb#n724070"}
-{"prefLabel":"Gruppe","uri":"http://purl.org/lobid/rpb#n725000"}
-{"prefLabel":"Familie","uri":"http://purl.org/lobid/rpb#n725010"}
-{"prefLabel":"Nachbarschaft","uri":"http://purl.org/lobid/rpb#n725020"}
-{"prefLabel":"Dorfgemeinschaft","uri":"http://purl.org/lobid/rpb#n725030"}
-{"prefLabel":"Alternativbewegung","uri":"http://purl.org/lobid/rpb#n725040"}
-{"prefLabel":"Interessenverband","uri":"http://purl.org/lobid/rpb#n725050"}
-{"prefLabel":"Randgruppe","uri":"http://purl.org/lobid/rpb#n725060"}
-{"prefLabel":"Ausländerin. Ausländer","uri":"http://purl.org/lobid/rpb#n725070"}
-{"prefLabel":"Behinderter Mensch","uri":"http://purl.org/lobid/rpb#n725080"}
-{"prefLabel":"Sozialer Wandel","uri":"http://purl.org/lobid/rpb#n726000"}
+{"prefLabel":"Gesellschaft allgemein","uri":"http://purl.org/lobid/rpb#n720100","definition":"Gesellschaft (n720000) > Gesellschaft allgemein (n720100)"}
+{"prefLabel":"Sozialgeschichte","uri":"http://purl.org/lobid/rpb#n722000","definition":"Gesellschaft (n720000) > Sozialgeschichte (n722000)"}
+{"prefLabel":"Sozialstruktur","uri":"http://purl.org/lobid/rpb#n724000","definition":"Gesellschaft (n720000) > Sozialstruktur (n724000)"}
+{"prefLabel":"Kind","uri":"http://purl.org/lobid/rpb#n724020","definition":"Gesellschaft (n720000) > Sozialstruktur (n724000) > Kind (n724020)"}
+{"prefLabel":"Jugend","uri":"http://purl.org/lobid/rpb#n724030","definition":"Gesellschaft (n720000) > Sozialstruktur (n724000) > Jugend (n724030)"}
+{"prefLabel":"Frau","uri":"http://purl.org/lobid/rpb#n724040","definition":"Gesellschaft (n720000) > Sozialstruktur (n724000) > Frau (n724040)"}
+{"prefLabel":"Mann","uri":"http://purl.org/lobid/rpb#n724050","definition":"Gesellschaft (n720000) > Sozialstruktur (n724000) > Mann (n724050)"}
+{"prefLabel":"Alter","uri":"http://purl.org/lobid/rpb#n724060","definition":"Gesellschaft (n720000) > Sozialstruktur (n724000) > Alter (n724060)"}
+{"prefLabel":"Original / Person","uri":"http://purl.org/lobid/rpb#n724070","definition":"Gesellschaft (n720000) > Sozialstruktur (n724000) > Original / Person (n724070)"}
+{"prefLabel":"Gruppe","uri":"http://purl.org/lobid/rpb#n725000","definition":"Gesellschaft (n720000) > Gruppe (n725000)"}
+{"prefLabel":"Familie","uri":"http://purl.org/lobid/rpb#n725010","definition":"Gesellschaft (n720000) > Gruppe (n725000) > Familie (n725010)"}
+{"prefLabel":"Nachbarschaft","uri":"http://purl.org/lobid/rpb#n725020","definition":"Gesellschaft (n720000) > Gruppe (n725000) > Nachbarschaft (n725020)"}
+{"prefLabel":"Dorfgemeinschaft","uri":"http://purl.org/lobid/rpb#n725030","definition":"Gesellschaft (n720000) > Gruppe (n725000) > Dorfgemeinschaft (n725030)"}
+{"prefLabel":"Alternativbewegung","uri":"http://purl.org/lobid/rpb#n725040","definition":"Gesellschaft (n720000) > Gruppe (n725000) > Alternativbewegung (n725040)"}
+{"prefLabel":"Interessenverband","uri":"http://purl.org/lobid/rpb#n725050","definition":"Gesellschaft (n720000) > Gruppe (n725000) > Interessenverband (n725050)"}
+{"prefLabel":"Randgruppe","uri":"http://purl.org/lobid/rpb#n725060","definition":"Gesellschaft (n720000) > Gruppe (n725000) > Randgruppe (n725060)"}
+{"prefLabel":"Ausländerin. Ausländer","uri":"http://purl.org/lobid/rpb#n725070","definition":"Gesellschaft (n720000) > Gruppe (n725000) > Ausländerin. Ausländer (n725070)"}
+{"prefLabel":"Behinderter Mensch","uri":"http://purl.org/lobid/rpb#n725080","definition":"Gesellschaft (n720000) > Gruppe (n725000) > Behinderter Mensch (n725080)"}
+{"prefLabel":"Sozialer Wandel","uri":"http://purl.org/lobid/rpb#n726000","definition":"Gesellschaft (n720000) > Sozialer Wandel (n726000)"}
 {"prefLabel":"Kultur und Freizeit","uri":"http://purl.org/lobid/rpb#n730000"}
-{"prefLabel":"Kultur und Freizeit allgemein","uri":"http://purl.org/lobid/rpb#n730100"}
-{"prefLabel":"Kulturpolitik","uri":"http://purl.org/lobid/rpb#n731000"}
-{"prefLabel":"Kulturgeschichte","uri":"http://purl.org/lobid/rpb#n732000"}
-{"prefLabel":"Kulturleben","uri":"http://purl.org/lobid/rpb#n733000"}
-{"prefLabel":"Kulturveranstaltung","uri":"http://purl.org/lobid/rpb#n733030"}
-{"prefLabel":"Kulturpreis","uri":"http://purl.org/lobid/rpb#n733050"}
-{"prefLabel":"Kulturverein","uri":"http://purl.org/lobid/rpb#n733070"}
-{"prefLabel":"Feier. Fest","uri":"http://purl.org/lobid/rpb#n734000"}
-{"prefLabel":"Freizeit und Erholung","uri":"http://purl.org/lobid/rpb#n735000"}
-{"prefLabel":"Freizeiteinrichtung","uri":"http://purl.org/lobid/rpb#n735020"}
-{"prefLabel":"Freizeitgestaltung","uri":"http://purl.org/lobid/rpb#n735040"}
-{"prefLabel":"Verein","uri":"http://purl.org/lobid/rpb#n735090"}
-{"prefLabel":"Sport und Spiel","uri":"http://purl.org/lobid/rpb#n736000"}
-{"prefLabel":"Sportart","uri":"http://purl.org/lobid/rpb#n736030"}
-{"prefLabel":"Sportverein","uri":"http://purl.org/lobid/rpb#n736050"}
-{"prefLabel":"Sportlerin. Sportler","uri":"http://purl.org/lobid/rpb#n736080"}
+{"prefLabel":"Kultur und Freizeit allgemein","uri":"http://purl.org/lobid/rpb#n730100","definition":"Kultur und Freizeit (n730000) > Kultur und Freizeit allgemein (n730100)"}
+{"prefLabel":"Kulturpolitik","uri":"http://purl.org/lobid/rpb#n731000","definition":"Kultur und Freizeit (n730000) > Kulturpolitik (n731000)"}
+{"prefLabel":"Kulturgeschichte","uri":"http://purl.org/lobid/rpb#n732000","definition":"Kultur und Freizeit (n730000) > Kulturgeschichte (n732000)"}
+{"prefLabel":"Kulturleben","uri":"http://purl.org/lobid/rpb#n733000","definition":"Kultur und Freizeit (n730000) > Kulturleben (n733000)"}
+{"prefLabel":"Kulturveranstaltung","uri":"http://purl.org/lobid/rpb#n733030","definition":"Kultur und Freizeit (n730000) > Kulturleben (n733000) > Kulturveranstaltung (n733030)"}
+{"prefLabel":"Kulturpreis","uri":"http://purl.org/lobid/rpb#n733050","definition":"Kultur und Freizeit (n730000) > Kulturleben (n733000) > Kulturpreis (n733050)"}
+{"prefLabel":"Kulturverein","uri":"http://purl.org/lobid/rpb#n733070","definition":"Kultur und Freizeit (n730000) > Kulturleben (n733000) > Kulturverein (n733070)"}
+{"prefLabel":"Feier. Fest","uri":"http://purl.org/lobid/rpb#n734000","definition":"Kultur und Freizeit (n730000) > Feier. Fest (n734000)"}
+{"prefLabel":"Freizeit und Erholung","uri":"http://purl.org/lobid/rpb#n735000","definition":"Kultur und Freizeit (n730000) > Freizeit und Erholung (n735000)"}
+{"prefLabel":"Freizeiteinrichtung","uri":"http://purl.org/lobid/rpb#n735020","definition":"Kultur und Freizeit (n730000) > Freizeit und Erholung (n735000) > Freizeiteinrichtung (n735020)"}
+{"prefLabel":"Freizeitgestaltung","uri":"http://purl.org/lobid/rpb#n735040","definition":"Kultur und Freizeit (n730000) > Freizeit und Erholung (n735000) > Freizeitgestaltung (n735040)"}
+{"prefLabel":"Verein","uri":"http://purl.org/lobid/rpb#n735090","definition":"Kultur und Freizeit (n730000) > Freizeit und Erholung (n735000) > Verein (n735090)"}
+{"prefLabel":"Sport und Spiel","uri":"http://purl.org/lobid/rpb#n736000","definition":"Kultur und Freizeit (n730000) > Sport und Spiel (n736000)"}
+{"prefLabel":"Sportart","uri":"http://purl.org/lobid/rpb#n736030","definition":"Kultur und Freizeit (n730000) > Sport und Spiel (n736000) > Sportart (n736030)"}
+{"prefLabel":"Sportverein","uri":"http://purl.org/lobid/rpb#n736050","definition":"Kultur und Freizeit (n730000) > Sport und Spiel (n736000) > Sportverein (n736050)"}
+{"prefLabel":"Sportlerin. Sportler","uri":"http://purl.org/lobid/rpb#n736080","definition":"Kultur und Freizeit (n730000) > Sport und Spiel (n736000) > Sportlerin. Sportler (n736080)"}
 {"prefLabel":"Sprache","uri":"http://purl.org/lobid/rpb#n740000"}
-{"prefLabel":"Sprache allgemein","uri":"http://purl.org/lobid/rpb#n740100"}
-{"prefLabel":"Sprache / Geschichte","uri":"http://purl.org/lobid/rpb#n742000"}
-{"prefLabel":"Grammatik","uri":"http://purl.org/lobid/rpb#n743000"}
-{"prefLabel":"Mundart","uri":"http://purl.org/lobid/rpb#n744000"}
-{"prefLabel":"Sprachgeographie","uri":"http://purl.org/lobid/rpb#n745000"}
-{"prefLabel":"Namenkunde","uri":"http://purl.org/lobid/rpb#n746000"}
-{"prefLabel":"Personenname","uri":"http://purl.org/lobid/rpb#n746020"}
-{"prefLabel":"Hausname. Hofname","uri":"http://purl.org/lobid/rpb#n746030"}
-{"prefLabel":"Hausname","uri":"http://purl.org/lobid/rpb#n746032"}
-{"prefLabel":"Hofname","uri":"http://purl.org/lobid/rpb#n746034"}
-{"prefLabel":"Geographischer Name","uri":"http://purl.org/lobid/rpb#n746040"}
-{"prefLabel":"Ortsname","uri":"http://purl.org/lobid/rpb#n746042"}
-{"prefLabel":"Straßenname","uri":"http://purl.org/lobid/rpb#n746043"}
-{"prefLabel":"Flurname","uri":"http://purl.org/lobid/rpb#n746044"}
-{"prefLabel":"Bergname","uri":"http://purl.org/lobid/rpb#n746045"}
-{"prefLabel":"Gewässername","uri":"http://purl.org/lobid/rpb#n746046"}
-{"prefLabel":"Tiername","uri":"http://purl.org/lobid/rpb#n746050"}
-{"prefLabel":"Pflanzenname","uri":"http://purl.org/lobid/rpb#n746060"}
-{"prefLabel":"Soziolinguistik","uri":"http://purl.org/lobid/rpb#n747000"}
-{"prefLabel":"Umgangssprache","uri":"http://purl.org/lobid/rpb#n747010"}
-{"prefLabel":"Geheimsprache","uri":"http://purl.org/lobid/rpb#n747020"}
-{"prefLabel":"Fachsprache","uri":"http://purl.org/lobid/rpb#n747030"}
-{"prefLabel":"Spracherwerb","uri":"http://purl.org/lobid/rpb#n747040"}
-{"prefLabel":"Sprachunterricht","uri":"http://purl.org/lobid/rpb#n747050"}
-{"prefLabel":"Sprachpflege","uri":"http://purl.org/lobid/rpb#n747060"}
+{"prefLabel":"Sprache allgemein","uri":"http://purl.org/lobid/rpb#n740100","definition":"Sprache (n740000) > Sprache allgemein (n740100)"}
+{"prefLabel":"Sprache / Geschichte","uri":"http://purl.org/lobid/rpb#n742000","definition":"Sprache (n740000) > Sprache / Geschichte (n742000)"}
+{"prefLabel":"Grammatik","uri":"http://purl.org/lobid/rpb#n743000","definition":"Sprache (n740000) > Grammatik (n743000)"}
+{"prefLabel":"Mundart","uri":"http://purl.org/lobid/rpb#n744000","definition":"Sprache (n740000) > Mundart (n744000)"}
+{"prefLabel":"Sprachgeographie","uri":"http://purl.org/lobid/rpb#n745000","definition":"Sprache (n740000) > Sprachgeographie (n745000)"}
+{"prefLabel":"Namenkunde","uri":"http://purl.org/lobid/rpb#n746000","definition":"Sprache (n740000) > Namenkunde (n746000)"}
+{"prefLabel":"Personenname","uri":"http://purl.org/lobid/rpb#n746020","definition":"Sprache (n740000) > Namenkunde (n746000) > Personenname (n746020)"}
+{"prefLabel":"Hausname. Hofname","uri":"http://purl.org/lobid/rpb#n746030","definition":"Sprache (n740000) > Namenkunde (n746000) > Hausname. Hofname (n746030)"}
+{"prefLabel":"Hausname","uri":"http://purl.org/lobid/rpb#n746032","definition":"Sprache (n740000) > Namenkunde (n746000) > Hausname. Hofname (n746030) > Hausname (n746032)"}
+{"prefLabel":"Hofname","uri":"http://purl.org/lobid/rpb#n746034","definition":"Sprache (n740000) > Namenkunde (n746000) > Hausname. Hofname (n746030) > Hofname (n746034)"}
+{"prefLabel":"Geographischer Name","uri":"http://purl.org/lobid/rpb#n746040","definition":"Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040)"}
+{"prefLabel":"Ortsname","uri":"http://purl.org/lobid/rpb#n746042","definition":"Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Ortsname (n746042)"}
+{"prefLabel":"Straßenname","uri":"http://purl.org/lobid/rpb#n746043","definition":"Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Straßenname (n746043)"}
+{"prefLabel":"Flurname","uri":"http://purl.org/lobid/rpb#n746044","definition":"Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Flurname (n746044)"}
+{"prefLabel":"Bergname","uri":"http://purl.org/lobid/rpb#n746045","definition":"Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Bergname (n746045)"}
+{"prefLabel":"Gewässername","uri":"http://purl.org/lobid/rpb#n746046","definition":"Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Gewässername (n746046)"}
+{"prefLabel":"Tiername","uri":"http://purl.org/lobid/rpb#n746050","definition":"Sprache (n740000) > Namenkunde (n746000) > Tiername (n746050)"}
+{"prefLabel":"Pflanzenname","uri":"http://purl.org/lobid/rpb#n746060","definition":"Sprache (n740000) > Namenkunde (n746000) > Pflanzenname (n746060)"}
+{"prefLabel":"Soziolinguistik","uri":"http://purl.org/lobid/rpb#n747000","definition":"Sprache (n740000) > Soziolinguistik (n747000)"}
+{"prefLabel":"Umgangssprache","uri":"http://purl.org/lobid/rpb#n747010","definition":"Sprache (n740000) > Soziolinguistik (n747000) > Umgangssprache (n747010)"}
+{"prefLabel":"Geheimsprache","uri":"http://purl.org/lobid/rpb#n747020","definition":"Sprache (n740000) > Soziolinguistik (n747000) > Geheimsprache (n747020)"}
+{"prefLabel":"Fachsprache","uri":"http://purl.org/lobid/rpb#n747030","definition":"Sprache (n740000) > Soziolinguistik (n747000) > Fachsprache (n747030)"}
+{"prefLabel":"Spracherwerb","uri":"http://purl.org/lobid/rpb#n747040","definition":"Sprache (n740000) > Soziolinguistik (n747000) > Spracherwerb (n747040)"}
+{"prefLabel":"Sprachunterricht","uri":"http://purl.org/lobid/rpb#n747050","definition":"Sprache (n740000) > Soziolinguistik (n747000) > Sprachunterricht (n747050)"}
+{"prefLabel":"Sprachpflege","uri":"http://purl.org/lobid/rpb#n747060","definition":"Sprache (n740000) > Soziolinguistik (n747000) > Sprachpflege (n747060)"}
 {"prefLabel":"Literatur","uri":"http://purl.org/lobid/rpb#n760000"}
-{"prefLabel":"Literatur allgemein","uri":"http://purl.org/lobid/rpb#n760100"}
-{"prefLabel":"Literaturwissenschaft","uri":"http://purl.org/lobid/rpb#n761000"}
-{"prefLabel":"Literaturgeographie","uri":"http://purl.org/lobid/rpb#n761020"}
-{"prefLabel":"Stoff / Literatur. Motiv / Literatur","uri":"http://purl.org/lobid/rpb#n761050"}
-{"prefLabel":"Literatur / Geschichte","uri":"http://purl.org/lobid/rpb#n762000"}
-{"prefLabel":"Literatursoziologie","uri":"http://purl.org/lobid/rpb#n766000"}
-{"prefLabel":"Leserin. Leser","uri":"http://purl.org/lobid/rpb#n766030"}
-{"prefLabel":"Literaturförderung","uri":"http://purl.org/lobid/rpb#n766050"}
-{"prefLabel":"Literaturausstellung","uri":"http://purl.org/lobid/rpb#n766060"}
-{"prefLabel":"Literarischer Text","uri":"http://purl.org/lobid/rpb#n767000"}
-{"prefLabel":"Anthologie","uri":"http://purl.org/lobid/rpb#n767040"}
-{"prefLabel":"Schriftstellerin. Schriftsteller","uri":"http://purl.org/lobid/rpb#n768000"}
-{"prefLabel":"Schriftstellerin. Schriftsteller / Primärliteratur","uri":"http://purl.org/lobid/rpb#n768010"}
-{"prefLabel":"Schriftstellerin. Schriftsteller / Sekundärliteratur","uri":"http://purl.org/lobid/rpb#n768030"}
-{"prefLabel":"Literaturgattung","uri":"http://purl.org/lobid/rpb#n769000"}
-{"prefLabel":"Lyrik","uri":"http://purl.org/lobid/rpb#n769020"}
-{"prefLabel":"Drama","uri":"http://purl.org/lobid/rpb#n769030"}
-{"prefLabel":"Epik","uri":"http://purl.org/lobid/rpb#n769040"}
-{"prefLabel":"Kurzform","uri":"http://purl.org/lobid/rpb#n769050"}
+{"prefLabel":"Literatur allgemein","uri":"http://purl.org/lobid/rpb#n760100","definition":"Literatur (n760000) > Literatur allgemein (n760100)"}
+{"prefLabel":"Literaturwissenschaft","uri":"http://purl.org/lobid/rpb#n761000","definition":"Literatur (n760000) > Literaturwissenschaft (n761000)"}
+{"prefLabel":"Literaturgeographie","uri":"http://purl.org/lobid/rpb#n761020","definition":"Literatur (n760000) > Literaturwissenschaft (n761000) > Literaturgeographie (n761020)"}
+{"prefLabel":"Stoff / Literatur. Motiv / Literatur","uri":"http://purl.org/lobid/rpb#n761050","definition":"Literatur (n760000) > Literaturwissenschaft (n761000) > Stoff / Literatur. Motiv / Literatur (n761050)"}
+{"prefLabel":"Literatur / Geschichte","uri":"http://purl.org/lobid/rpb#n762000","definition":"Literatur (n760000) > Literatur / Geschichte (n762000)"}
+{"prefLabel":"Literatursoziologie","uri":"http://purl.org/lobid/rpb#n766000","definition":"Literatur (n760000) > Literatursoziologie (n766000)"}
+{"prefLabel":"Leserin. Leser","uri":"http://purl.org/lobid/rpb#n766030","definition":"Literatur (n760000) > Literatursoziologie (n766000) > Leserin. Leser (n766030)"}
+{"prefLabel":"Literaturförderung","uri":"http://purl.org/lobid/rpb#n766050","definition":"Literatur (n760000) > Literatursoziologie (n766000) > Literaturförderung (n766050)"}
+{"prefLabel":"Literaturausstellung","uri":"http://purl.org/lobid/rpb#n766060","definition":"Literatur (n760000) > Literatursoziologie (n766000) > Literaturausstellung (n766060)"}
+{"prefLabel":"Literarischer Text","uri":"http://purl.org/lobid/rpb#n767000","definition":"Literatur (n760000) > Literarischer Text (n767000)"}
+{"prefLabel":"Anthologie","uri":"http://purl.org/lobid/rpb#n767040","definition":"Literatur (n760000) > Literarischer Text (n767000) > Anthologie (n767040)"}
+{"prefLabel":"Schriftstellerin. Schriftsteller","uri":"http://purl.org/lobid/rpb#n768000","definition":"Literatur (n760000) > Schriftstellerin. Schriftsteller (n768000)"}
+{"prefLabel":"Schriftstellerin. Schriftsteller / Primärliteratur","uri":"http://purl.org/lobid/rpb#n768010","definition":"Literatur (n760000) > Schriftstellerin. Schriftsteller (n768000) > Schriftstellerin. Schriftsteller / Primärliteratur (n768010)"}
+{"prefLabel":"Schriftstellerin. Schriftsteller / Sekundärliteratur","uri":"http://purl.org/lobid/rpb#n768030","definition":"Literatur (n760000) > Schriftstellerin. Schriftsteller (n768000) > Schriftstellerin. Schriftsteller / Sekundärliteratur (n768030)"}
+{"prefLabel":"Literaturgattung","uri":"http://purl.org/lobid/rpb#n769000","definition":"Literatur (n760000) > Literaturgattung (n769000)"}
+{"prefLabel":"Lyrik","uri":"http://purl.org/lobid/rpb#n769020","definition":"Literatur (n760000) > Literaturgattung (n769000) > Lyrik (n769020)"}
+{"prefLabel":"Drama","uri":"http://purl.org/lobid/rpb#n769030","definition":"Literatur (n760000) > Literaturgattung (n769000) > Drama (n769030)"}
+{"prefLabel":"Epik","uri":"http://purl.org/lobid/rpb#n769040","definition":"Literatur (n760000) > Literaturgattung (n769000) > Epik (n769040)"}
+{"prefLabel":"Kurzform","uri":"http://purl.org/lobid/rpb#n769050","definition":"Literatur (n760000) > Literaturgattung (n769000) > Kurzform (n769050)"}
 {"prefLabel":"Bildung. Erziehung","uri":"http://purl.org/lobid/rpb#n780000"}
-{"prefLabel":"Bildung. Erziehung allgemein","uri":"http://purl.org/lobid/rpb#n780100"}
-{"prefLabel":"Bildungspolitik","uri":"http://purl.org/lobid/rpb#n781000"}
-{"prefLabel":"Ausbildungsförderung","uri":"http://purl.org/lobid/rpb#n781040"}
-{"prefLabel":"Erziehung","uri":"http://purl.org/lobid/rpb#n782000"}
-{"prefLabel":"Vorschulerziehung","uri":"http://purl.org/lobid/rpb#n782500"}
-{"prefLabel":"Schule / Geschichte","uri":"http://purl.org/lobid/rpb#n783000"}
-{"prefLabel":"Allgemein bildende Schule","uri":"http://purl.org/lobid/rpb#n784000"}
-{"prefLabel":"Schulpolitik","uri":"http://purl.org/lobid/rpb#n784010"}
-{"prefLabel":"Schulreform","uri":"http://purl.org/lobid/rpb#n784012"}
-{"prefLabel":"Schulversuch","uri":"http://purl.org/lobid/rpb#n784014"}
-{"prefLabel":"Privatschule","uri":"http://purl.org/lobid/rpb#n784016"}
-{"prefLabel":"Schulrecht","uri":"http://purl.org/lobid/rpb#n784020"}
-{"prefLabel":"Elternarbeit","uri":"http://purl.org/lobid/rpb#n784025"}
-{"prefLabel":"Schulverwaltung","uri":"http://purl.org/lobid/rpb#n784030"}
-{"prefLabel":"Schulbau","uri":"http://purl.org/lobid/rpb#n784035"}
-{"prefLabel":"Schulgliederung","uri":"http://purl.org/lobid/rpb#n784040"}
-{"prefLabel":"Grundschule","uri":"http://purl.org/lobid/rpb#n784041"}
-{"prefLabel":"Hauptschule","uri":"http://purl.org/lobid/rpb#n784042"}
-{"prefLabel":"Realschule","uri":"http://purl.org/lobid/rpb#n784043"}
-{"prefLabel":"Realschule Plus","uri":"http://purl.org/lobid/rpb#n784033"}
-{"prefLabel":"Gymnasium","uri":"http://purl.org/lobid/rpb#n784044"}
-{"prefLabel":"Gesamtschule","uri":"http://purl.org/lobid/rpb#n784045"}
-{"prefLabel":"Kollegschule","uri":"http://purl.org/lobid/rpb#n784046"}
-{"prefLabel":"Sonderschule","uri":"http://purl.org/lobid/rpb#n784047"}
-{"prefLabel":"Regionale Schule","uri":"http://purl.org/lobid/rpb#n784048"}
-{"prefLabel":"Duale Oberschule","uri":"http://purl.org/lobid/rpb#n784049"}
-{"prefLabel":"Schulstufe","uri":"http://purl.org/lobid/rpb#n784050"}
-{"prefLabel":"Primarstufe","uri":"http://purl.org/lobid/rpb#n784052"}
-{"prefLabel":"Sekundarstufe 1","uri":"http://purl.org/lobid/rpb#n784053"}
-{"prefLabel":"Sekundarstufe 2","uri":"http://purl.org/lobid/rpb#n784054"}
-{"prefLabel":"Lehrerin. Lehrer","uri":"http://purl.org/lobid/rpb#n784060"}
-{"prefLabel":"Lehrerbildung","uri":"http://purl.org/lobid/rpb#n784062"}
-{"prefLabel":"Lehrerfortbildung","uri":"http://purl.org/lobid/rpb#n784064"}
-{"prefLabel":"Lehrerin. Lehrer / Besoldung","uri":"http://purl.org/lobid/rpb#n784066"}
-{"prefLabel":"Schülerin. Schüler","uri":"http://purl.org/lobid/rpb#n784070"}
-{"prefLabel":"Schülermitverwaltung","uri":"http://purl.org/lobid/rpb#n784072"}
-{"prefLabel":"Schülertransport","uri":"http://purl.org/lobid/rpb#n784074"}
-{"prefLabel":"Schulverpflegung","uri":"http://purl.org/lobid/rpb#n784076"}
-{"prefLabel":"Schüleraustausch","uri":"http://purl.org/lobid/rpb#n784078"}
-{"prefLabel":"Unterricht","uri":"http://purl.org/lobid/rpb#n784080"}
-{"prefLabel":"Schulleben","uri":"http://purl.org/lobid/rpb#n784090"}
-{"prefLabel":"Berufsbildende Schule","uri":"http://purl.org/lobid/rpb#n785000"}
-{"prefLabel":"Berufsschule","uri":"http://purl.org/lobid/rpb#n785020"}
-{"prefLabel":"Berufsfachschule","uri":"http://purl.org/lobid/rpb#n785030"}
-{"prefLabel":"Berufsaufbauschule","uri":"http://purl.org/lobid/rpb#n785040"}
-{"prefLabel":"Fachoberschule","uri":"http://purl.org/lobid/rpb#n785050"}
-{"prefLabel":"Berufliches Gymnasium","uri":"http://purl.org/lobid/rpb#n785060"}
-{"prefLabel":"Fachschule","uri":"http://purl.org/lobid/rpb#n785070"}
-{"prefLabel":"Nichtstaatliche Berufsschule","uri":"http://purl.org/lobid/rpb#n785080"}
-{"prefLabel":"Berufsausbildung","uri":"http://purl.org/lobid/rpb#n785500"}
-{"prefLabel":"Außerschulische Bildung","uri":"http://purl.org/lobid/rpb#n786000"}
+{"prefLabel":"Bildung. Erziehung allgemein","uri":"http://purl.org/lobid/rpb#n780100","definition":"Bildung. Erziehung (n780000) > Bildung. Erziehung allgemein (n780100)"}
+{"prefLabel":"Bildungspolitik","uri":"http://purl.org/lobid/rpb#n781000","definition":"Bildung. Erziehung (n780000) > Bildungspolitik (n781000)"}
+{"prefLabel":"Ausbildungsförderung","uri":"http://purl.org/lobid/rpb#n781040","definition":"Bildung. Erziehung (n780000) > Bildungspolitik (n781000) > Ausbildungsförderung (n781040)"}
+{"prefLabel":"Erziehung","uri":"http://purl.org/lobid/rpb#n782000","definition":"Bildung. Erziehung (n780000) > Erziehung (n782000)"}
+{"prefLabel":"Vorschulerziehung","uri":"http://purl.org/lobid/rpb#n782500","definition":"Bildung. Erziehung (n780000) > Erziehung (n782000) > Vorschulerziehung (n782500)"}
+{"prefLabel":"Schule / Geschichte","uri":"http://purl.org/lobid/rpb#n783000","definition":"Bildung. Erziehung (n780000) > Schule / Geschichte (n783000)"}
+{"prefLabel":"Allgemein bildende Schule","uri":"http://purl.org/lobid/rpb#n784000","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000)"}
+{"prefLabel":"Schulpolitik","uri":"http://purl.org/lobid/rpb#n784010","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulpolitik (n784010)"}
+{"prefLabel":"Schulreform","uri":"http://purl.org/lobid/rpb#n784012","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulpolitik (n784010) > Schulreform (n784012)"}
+{"prefLabel":"Schulversuch","uri":"http://purl.org/lobid/rpb#n784014","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulpolitik (n784010) > Schulversuch (n784014)"}
+{"prefLabel":"Privatschule","uri":"http://purl.org/lobid/rpb#n784016","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Privatschule (n784016)"}
+{"prefLabel":"Schulrecht","uri":"http://purl.org/lobid/rpb#n784020","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulrecht (n784020)"}
+{"prefLabel":"Elternarbeit","uri":"http://purl.org/lobid/rpb#n784025","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Elternarbeit (n784025)"}
+{"prefLabel":"Schulverwaltung","uri":"http://purl.org/lobid/rpb#n784030","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulverwaltung (n784030)"}
+{"prefLabel":"Realschule Plus","uri":"http://purl.org/lobid/rpb#n784033","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Realschule (n784043) > Realschule Plus (n784033)"}
+{"prefLabel":"Schulbau","uri":"http://purl.org/lobid/rpb#n784035","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulbau (n784035)"}
+{"prefLabel":"Schulgliederung","uri":"http://purl.org/lobid/rpb#n784040","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulgliederung (n784040)"}
+{"prefLabel":"Grundschule","uri":"http://purl.org/lobid/rpb#n784041","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Grundschule (n784041)"}
+{"prefLabel":"Hauptschule","uri":"http://purl.org/lobid/rpb#n784042","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Hauptschule (n784042)"}
+{"prefLabel":"Realschule","uri":"http://purl.org/lobid/rpb#n784043","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Realschule (n784043)"}
+{"prefLabel":"Gymnasium","uri":"http://purl.org/lobid/rpb#n784044","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Gymnasium (n784044)"}
+{"prefLabel":"Gesamtschule","uri":"http://purl.org/lobid/rpb#n784045","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Gesamtschule (n784045)"}
+{"prefLabel":"Kollegschule","uri":"http://purl.org/lobid/rpb#n784046","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Kollegschule (n784046)"}
+{"prefLabel":"Sonderschule","uri":"http://purl.org/lobid/rpb#n784047","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Sonderschule (n784047)"}
+{"prefLabel":"Regionale Schule","uri":"http://purl.org/lobid/rpb#n784048","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Regionale Schule (n784048)"}
+{"prefLabel":"Duale Oberschule","uri":"http://purl.org/lobid/rpb#n784049","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Duale Oberschule (n784049)"}
+{"prefLabel":"Schulstufe","uri":"http://purl.org/lobid/rpb#n784050","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulstufe (n784050)"}
+{"prefLabel":"Primarstufe","uri":"http://purl.org/lobid/rpb#n784052","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulstufe (n784050) > Primarstufe (n784052)"}
+{"prefLabel":"Sekundarstufe 1","uri":"http://purl.org/lobid/rpb#n784053","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulstufe (n784050) > Sekundarstufe 1 (n784053)"}
+{"prefLabel":"Sekundarstufe 2","uri":"http://purl.org/lobid/rpb#n784054","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulstufe (n784050) > Sekundarstufe 2 (n784054)"}
+{"prefLabel":"Lehrerin. Lehrer","uri":"http://purl.org/lobid/rpb#n784060","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Lehrerin. Lehrer (n784060)"}
+{"prefLabel":"Lehrerbildung","uri":"http://purl.org/lobid/rpb#n784062","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Lehrerin. Lehrer (n784060) > Lehrerbildung (n784062)"}
+{"prefLabel":"Lehrerfortbildung","uri":"http://purl.org/lobid/rpb#n784064","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Lehrerin. Lehrer (n784060) > Lehrerfortbildung (n784064)"}
+{"prefLabel":"Lehrerin. Lehrer / Besoldung","uri":"http://purl.org/lobid/rpb#n784066","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Lehrerin. Lehrer (n784060) > Lehrerin. Lehrer / Besoldung (n784066)"}
+{"prefLabel":"Schülerin. Schüler","uri":"http://purl.org/lobid/rpb#n784070","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070)"}
+{"prefLabel":"Schülermitverwaltung","uri":"http://purl.org/lobid/rpb#n784072","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070) > Schülermitverwaltung (n784072)"}
+{"prefLabel":"Schülertransport","uri":"http://purl.org/lobid/rpb#n784074","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070) > Schülertransport (n784074)"}
+{"prefLabel":"Schulverpflegung","uri":"http://purl.org/lobid/rpb#n784076","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070) > Schulverpflegung (n784076)"}
+{"prefLabel":"Schüleraustausch","uri":"http://purl.org/lobid/rpb#n784078","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070) > Schüleraustausch (n784078)"}
+{"prefLabel":"Unterricht","uri":"http://purl.org/lobid/rpb#n784080","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Unterricht (n784080)"}
+{"prefLabel":"Schulleben","uri":"http://purl.org/lobid/rpb#n784090","definition":"Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulleben (n784090)"}
+{"prefLabel":"Berufsbildende Schule","uri":"http://purl.org/lobid/rpb#n785000","definition":"Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000)"}
+{"prefLabel":"Berufsschule","uri":"http://purl.org/lobid/rpb#n785020","definition":"Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Berufsschule (n785020)"}
+{"prefLabel":"Berufsfachschule","uri":"http://purl.org/lobid/rpb#n785030","definition":"Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Berufsfachschule (n785030)"}
+{"prefLabel":"Berufsaufbauschule","uri":"http://purl.org/lobid/rpb#n785040","definition":"Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Berufsaufbauschule (n785040)"}
+{"prefLabel":"Fachoberschule","uri":"http://purl.org/lobid/rpb#n785050","definition":"Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Fachoberschule (n785050)"}
+{"prefLabel":"Berufliches Gymnasium","uri":"http://purl.org/lobid/rpb#n785060","definition":"Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Berufliches Gymnasium (n785060)"}
+{"prefLabel":"Fachschule","uri":"http://purl.org/lobid/rpb#n785070","definition":"Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Fachschule (n785070)"}
+{"prefLabel":"Nichtstaatliche Berufsschule","uri":"http://purl.org/lobid/rpb#n785080","definition":"Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Nichtstaatliche Berufsschule (n785080)"}
+{"prefLabel":"Berufsausbildung","uri":"http://purl.org/lobid/rpb#n785500","definition":"Bildung. Erziehung (n780000) > Berufsausbildung (n785500)"}
+{"prefLabel":"Außerschulische Bildung","uri":"http://purl.org/lobid/rpb#n786000","definition":"Bildung. Erziehung (n780000) > Außerschulische Bildung (n786000)"}
 {"prefLabel":"Hochschule. Wissenschaft","uri":"http://purl.org/lobid/rpb#n790000"}
-{"prefLabel":"Hochschule. Wissenschaft allgemein","uri":"http://purl.org/lobid/rpb#n790100"}
-{"prefLabel":"Hochschulrecht","uri":"http://purl.org/lobid/rpb#n791000"}
-{"prefLabel":"Hochschulpolitik","uri":"http://purl.org/lobid/rpb#n792000"}
-{"prefLabel":"Hochschule","uri":"http://purl.org/lobid/rpb#n794000"}
-{"prefLabel":"Einzelne Hochschule","uri":"http://purl.org/lobid/rpb#n794010"}
-{"prefLabel":"Fachhochschule","uri":"http://purl.org/lobid/rpb#n796000"}
-{"prefLabel":"Hochschullehrerin. Hochschullehrer. Wissenschaft","uri":"http://purl.org/lobid/rpb#n797000"}
-{"prefLabel":"Studentin. Student","uri":"http://purl.org/lobid/rpb#n798000"}
-{"prefLabel":"Außeruniversitäre Forschung","uri":"http://purl.org/lobid/rpb#n798200"}
-{"prefLabel":"Wissenschaftsförderung","uri":"http://purl.org/lobid/rpb#n799000"}
-{"prefLabel":"Wissenschaftliche Gesellschaft","uri":"http://purl.org/lobid/rpb#n799200"}
+{"prefLabel":"Hochschule. Wissenschaft allgemein","uri":"http://purl.org/lobid/rpb#n790100","definition":"Hochschule. Wissenschaft (n790000) > Hochschule. Wissenschaft allgemein (n790100)"}
+{"prefLabel":"Hochschulrecht","uri":"http://purl.org/lobid/rpb#n791000","definition":"Hochschule. Wissenschaft (n790000) > Hochschulrecht (n791000)"}
+{"prefLabel":"Hochschulpolitik","uri":"http://purl.org/lobid/rpb#n792000","definition":"Hochschule. Wissenschaft (n790000) > Hochschulpolitik (n792000)"}
+{"prefLabel":"Hochschule","uri":"http://purl.org/lobid/rpb#n794000","definition":"Hochschule. Wissenschaft (n790000) > Hochschule (n794000)"}
+{"prefLabel":"Einzelne Hochschule","uri":"http://purl.org/lobid/rpb#n794010","definition":"Hochschule. Wissenschaft (n790000) > Hochschule (n794000) > Einzelne Hochschule (n794010)"}
+{"prefLabel":"Fachhochschule","uri":"http://purl.org/lobid/rpb#n796000","definition":"Hochschule. Wissenschaft (n790000) > Fachhochschule (n796000)"}
+{"prefLabel":"Hochschullehrerin. Hochschullehrer. Wissenschaft","uri":"http://purl.org/lobid/rpb#n797000","definition":"Hochschule. Wissenschaft (n790000) > Hochschullehrerin. Hochschullehrer. Wissenschaft (n797000)"}
+{"prefLabel":"Studentin. Student","uri":"http://purl.org/lobid/rpb#n798000","definition":"Hochschule. Wissenschaft (n790000) > Studentin. Student (n798000)"}
+{"prefLabel":"Außeruniversitäre Forschung","uri":"http://purl.org/lobid/rpb#n798200","definition":"Hochschule. Wissenschaft (n790000) > Außeruniversitäre Forschung (n798200)"}
+{"prefLabel":"Wissenschaftsförderung","uri":"http://purl.org/lobid/rpb#n799000","definition":"Hochschule. Wissenschaft (n790000) > Wissenschaftsförderung (n799000)"}
+{"prefLabel":"Wissenschaftliche Gesellschaft","uri":"http://purl.org/lobid/rpb#n799200","definition":"Hochschule. Wissenschaft (n790000) > Wissenschaftsförderung (n799000) > Wissenschaftliche Gesellschaft (n799200)"}
 {"prefLabel":"Darstellende Kunst","uri":"http://purl.org/lobid/rpb#n800000"}
-{"prefLabel":"Darstellende Kunst allgemein","uri":"http://purl.org/lobid/rpb#n800100"}
-{"prefLabel":"Theater","uri":"http://purl.org/lobid/rpb#n802000"}
-{"prefLabel":"Theater / Geschichte","uri":"http://purl.org/lobid/rpb#n802020"}
-{"prefLabel":"Volksschauspiel","uri":"http://purl.org/lobid/rpb#n802030"}
-{"prefLabel":"Laienspiel","uri":"http://purl.org/lobid/rpb#n802040"}
-{"prefLabel":"Kindertheater. Jugendtheater","uri":"http://purl.org/lobid/rpb#n802050"}
-{"prefLabel":"Einzelne Theater","uri":"http://purl.org/lobid/rpb#n802060"}
-{"prefLabel":"Inszenierung","uri":"http://purl.org/lobid/rpb#n802070"}
-{"prefLabel":"Schauspielerin. Schauspieler","uri":"http://purl.org/lobid/rpb#n802080"}
-{"prefLabel":"Ballett","uri":"http://purl.org/lobid/rpb#n803000"}
-{"prefLabel":"Film","uri":"http://purl.org/lobid/rpb#n804000"}
-{"prefLabel":"Filmtheater","uri":"http://purl.org/lobid/rpb#n804020"}
-{"prefLabel":"Kleinkunst","uri":"http://purl.org/lobid/rpb#n806000"}
-{"prefLabel":"Kabarett","uri":"http://purl.org/lobid/rpb#n806020"}
+{"prefLabel":"Darstellende Kunst allgemein","uri":"http://purl.org/lobid/rpb#n800100","definition":"Darstellende Kunst (n800000) > Darstellende Kunst allgemein (n800100)"}
+{"prefLabel":"Theater","uri":"http://purl.org/lobid/rpb#n802000","definition":"Darstellende Kunst (n800000) > Theater (n802000)"}
+{"prefLabel":"Theater / Geschichte","uri":"http://purl.org/lobid/rpb#n802020","definition":"Darstellende Kunst (n800000) > Theater (n802000) > Theater / Geschichte (n802020)"}
+{"prefLabel":"Volksschauspiel","uri":"http://purl.org/lobid/rpb#n802030","definition":"Darstellende Kunst (n800000) > Theater (n802000) > Volksschauspiel (n802030)"}
+{"prefLabel":"Laienspiel","uri":"http://purl.org/lobid/rpb#n802040","definition":"Darstellende Kunst (n800000) > Theater (n802000) > Laienspiel (n802040)"}
+{"prefLabel":"Kindertheater. Jugendtheater","uri":"http://purl.org/lobid/rpb#n802050","definition":"Darstellende Kunst (n800000) > Theater (n802000) > Kindertheater. Jugendtheater (n802050)"}
+{"prefLabel":"Einzelne Theater","uri":"http://purl.org/lobid/rpb#n802060","definition":"Darstellende Kunst (n800000) > Theater (n802000) > Einzelne Theater (n802060)"}
+{"prefLabel":"Inszenierung","uri":"http://purl.org/lobid/rpb#n802070","definition":"Darstellende Kunst (n800000) > Theater (n802000) > Inszenierung (n802070)"}
+{"prefLabel":"Schauspielerin. Schauspieler","uri":"http://purl.org/lobid/rpb#n802080","definition":"Darstellende Kunst (n800000) > Theater (n802000) > Schauspielerin. Schauspieler (n802080)"}
+{"prefLabel":"Ballett","uri":"http://purl.org/lobid/rpb#n803000","definition":"Darstellende Kunst (n800000) > Ballett (n803000)"}
+{"prefLabel":"Film","uri":"http://purl.org/lobid/rpb#n804000","definition":"Darstellende Kunst (n800000) > Film (n804000)"}
+{"prefLabel":"Filmtheater","uri":"http://purl.org/lobid/rpb#n804020","definition":"Darstellende Kunst (n800000) > Film (n804000) > Filmtheater (n804020)"}
+{"prefLabel":"Kleinkunst","uri":"http://purl.org/lobid/rpb#n806000","definition":"Darstellende Kunst (n800000) > Kleinkunst (n806000)"}
+{"prefLabel":"Kabarett","uri":"http://purl.org/lobid/rpb#n806020","definition":"Darstellende Kunst (n800000) > Kleinkunst (n806000) > Kabarett (n806020)"}
 {"prefLabel":"Musik","uri":"http://purl.org/lobid/rpb#n820000"}
-{"prefLabel":"Musik allgemein","uri":"http://purl.org/lobid/rpb#n820100"}
-{"prefLabel":"Musikwissenschaft","uri":"http://purl.org/lobid/rpb#n821000"}
-{"prefLabel":"Musikerin. Musiker / Ausbildung","uri":"http://purl.org/lobid/rpb#n822000"}
-{"prefLabel":"Musikförderung","uri":"http://purl.org/lobid/rpb#n822400"}
-{"prefLabel":"Musikpreis","uri":"http://purl.org/lobid/rpb#n822500"}
-{"prefLabel":"Musik / Geschichte","uri":"http://purl.org/lobid/rpb#n823000"}
-{"prefLabel":"Musikerin. Musiker","uri":"http://purl.org/lobid/rpb#n824000"}
-{"prefLabel":"Instrumentalmusikerin. Instrumentalmusiker","uri":"http://purl.org/lobid/rpb#n824020"}
-{"prefLabel":"Komponistin. Komponist","uri":"http://purl.org/lobid/rpb#n824040"}
-{"prefLabel":"Dirigentin. Dirigent","uri":"http://purl.org/lobid/rpb#n824060"}
-{"prefLabel":"Sängerin. Sänger","uri":"http://purl.org/lobid/rpb#n824080"}
-{"prefLabel":"Chor","uri":"http://purl.org/lobid/rpb#n824500"}
-{"prefLabel":"Orchester","uri":"http://purl.org/lobid/rpb#n825000"}
-{"prefLabel":"Konzert. Musikveranstaltung","uri":"http://purl.org/lobid/rpb#n826000"}
-{"prefLabel":"Einzelne Aufführungen","uri":"http://purl.org/lobid/rpb#n826020"}
-{"prefLabel":"Kirchenmusik","uri":"http://purl.org/lobid/rpb#n827000"}
-{"prefLabel":"Kirchenmusik / Aufführung","uri":"http://purl.org/lobid/rpb#n827010"}
-{"prefLabel":"Musikinstrument","uri":"http://purl.org/lobid/rpb#n828000"}
-{"prefLabel":"Laienmusik","uri":"http://purl.org/lobid/rpb#n829000"}
+{"prefLabel":"Musik allgemein","uri":"http://purl.org/lobid/rpb#n820100","definition":"Musik (n820000) > Musik allgemein (n820100)"}
+{"prefLabel":"Musikwissenschaft","uri":"http://purl.org/lobid/rpb#n821000","definition":"Musik (n820000) > Musikwissenschaft (n821000)"}
+{"prefLabel":"Musikerin. Musiker / Ausbildung","uri":"http://purl.org/lobid/rpb#n822000","definition":"Musik (n820000) > Musikerin. Musiker / Ausbildung (n822000)"}
+{"prefLabel":"Musikförderung","uri":"http://purl.org/lobid/rpb#n822400","definition":"Musik (n820000) > Musikförderung (n822400)"}
+{"prefLabel":"Musikpreis","uri":"http://purl.org/lobid/rpb#n822500","definition":"Musik (n820000) > Musikpreis (n822500)"}
+{"prefLabel":"Musik / Geschichte","uri":"http://purl.org/lobid/rpb#n823000","definition":"Musik (n820000) > Musik / Geschichte (n823000)"}
+{"prefLabel":"Musikerin. Musiker","uri":"http://purl.org/lobid/rpb#n824000","definition":"Musik (n820000) > Musikerin. Musiker (n824000)"}
+{"prefLabel":"Instrumentalmusikerin. Instrumentalmusiker","uri":"http://purl.org/lobid/rpb#n824020","definition":"Musik (n820000) > Musikerin. Musiker (n824000) > Instrumentalmusikerin. Instrumentalmusiker (n824020)"}
+{"prefLabel":"Komponistin. Komponist","uri":"http://purl.org/lobid/rpb#n824040","definition":"Musik (n820000) > Musikerin. Musiker (n824000) > Komponistin. Komponist (n824040)"}
+{"prefLabel":"Dirigentin. Dirigent","uri":"http://purl.org/lobid/rpb#n824060","definition":"Musik (n820000) > Musikerin. Musiker (n824000) > Dirigentin. Dirigent (n824060)"}
+{"prefLabel":"Sängerin. Sänger","uri":"http://purl.org/lobid/rpb#n824080","definition":"Musik (n820000) > Musikerin. Musiker (n824000) > Sängerin. Sänger (n824080)"}
+{"prefLabel":"Chor","uri":"http://purl.org/lobid/rpb#n824500","definition":"Musik (n820000) > Chor (n824500)"}
+{"prefLabel":"Orchester","uri":"http://purl.org/lobid/rpb#n825000","definition":"Musik (n820000) > Orchester (n825000)"}
+{"prefLabel":"Konzert. Musikveranstaltung","uri":"http://purl.org/lobid/rpb#n826000","definition":"Musik (n820000) > Konzert. Musikveranstaltung (n826000)"}
+{"prefLabel":"Einzelne Aufführungen","uri":"http://purl.org/lobid/rpb#n826020","definition":"Musik (n820000) > Konzert. Musikveranstaltung (n826000) > Einzelne Aufführungen (n826020)"}
+{"prefLabel":"Kirchenmusik","uri":"http://purl.org/lobid/rpb#n827000","definition":"Musik (n820000) > Kirchenmusik (n827000)"}
+{"prefLabel":"Kirchenmusik / Aufführung","uri":"http://purl.org/lobid/rpb#n827010","definition":"Musik (n820000) > Kirchenmusik (n827000) > Kirchenmusik / Aufführung (n827010)"}
+{"prefLabel":"Musikinstrument","uri":"http://purl.org/lobid/rpb#n828000","definition":"Musik (n820000) > Musikinstrument (n828000)"}
+{"prefLabel":"Laienmusik","uri":"http://purl.org/lobid/rpb#n829000","definition":"Musik (n820000) > Laienmusik (n829000)"}
 {"prefLabel":"Kunst. Architektur","uri":"http://purl.org/lobid/rpb#n840000"}
-{"prefLabel":"Kunst. Architektur allgemein","uri":"http://purl.org/lobid/rpb#n840100"}
-{"prefLabel":"Kunst","uri":"http://purl.org/lobid/rpb#n841000"}
-{"prefLabel":"Kunststudium","uri":"http://purl.org/lobid/rpb#n841020"}
-{"prefLabel":"Kunstmuseum. Kunstsammlung","uri":"http://purl.org/lobid/rpb#n841040"}
-{"prefLabel":"Kunstgalerie","uri":"http://purl.org/lobid/rpb#n841050"}
-{"prefLabel":"Kunstausstellung","uri":"http://purl.org/lobid/rpb#n841060"}
-{"prefLabel":"Künstlerin.Künstler","uri":"http://purl.org/lobid/rpb#n841070"}
-{"prefLabel":"Bildhauerin. Bildhauer","uri":"http://purl.org/lobid/rpb#n841072"}
-{"prefLabel":"Malerin. Maler","uri":"http://purl.org/lobid/rpb#n841074"}
-{"prefLabel":"Zeichnerin. Zeichner","uri":"http://purl.org/lobid/rpb#n841076"}
-{"prefLabel":"Grafikerin. Grafiker","uri":"http://purl.org/lobid/rpb#n841078"}
-{"prefLabel":"Fotografin. Fotograf","uri":"http://purl.org/lobid/rpb#n841079"}
-{"prefLabel":"Künstlervereinigung","uri":"http://purl.org/lobid/rpb#n841080"}
-{"prefLabel":"Kunstförderung","uri":"http://purl.org/lobid/rpb#n841090"}
-{"prefLabel":"Kunst / Geschichte","uri":"http://purl.org/lobid/rpb#n842000"}
-{"prefLabel":"Architektur","uri":"http://purl.org/lobid/rpb#n843000"}
-{"prefLabel":"Baukonstruktion. Bautechnik","uri":"http://purl.org/lobid/rpb#n843010"}
-{"prefLabel":"Öffentliches Gebäude","uri":"http://purl.org/lobid/rpb#n843020"}
-{"prefLabel":"Büro-, Geschäfts- und Industriebauten","uri":"http://purl.org/lobid/rpb#n843040"}
-{"prefLabel":"Bürohaus","uri":"http://purl.org/lobid/rpb#n843042"}
-{"prefLabel":"Geschäftshaus","uri":"http://purl.org/lobid/rpb#n843044"}
-{"prefLabel":"Industriebau","uri":"http://purl.org/lobid/rpb#n843046"}
-{"prefLabel":"Bauernhaus","uri":"http://purl.org/lobid/rpb#n843050"}
-{"prefLabel":"Wohnhaus","uri":"http://purl.org/lobid/rpb#n843060"}
-{"prefLabel":"Architektin. Architekt","uri":"http://purl.org/lobid/rpb#n843090"}
-{"prefLabel":"Baudenkmal. Kunstwerk","uri":"http://purl.org/lobid/rpb#n844000"}
-{"prefLabel":"Kunst / Inventar","uri":"http://purl.org/lobid/rpb#n844010"}
-{"prefLabel":"Baustil","uri":"http://purl.org/lobid/rpb#n844020"}
-{"prefLabel":"Sakralbau","uri":"http://purl.org/lobid/rpb#n844030"}
-{"prefLabel":"Burg. Schloss","uri":"http://purl.org/lobid/rpb#n844040"}
-{"prefLabel":"Profanarchitektur","uri":"http://purl.org/lobid/rpb#n844050"}
-{"prefLabel":"Park. Garten","uri":"http://purl.org/lobid/rpb#n844060"}
-{"prefLabel":"Brunnen","uri":"http://purl.org/lobid/rpb#n844070"}
-{"prefLabel":"Denkmal","uri":"http://purl.org/lobid/rpb#n844080"}
-{"prefLabel":"Denkmalpflege. Denkmalschutz","uri":"http://purl.org/lobid/rpb#n844200"}
-{"prefLabel":"Städtebau","uri":"http://purl.org/lobid/rpb#n844500"}
-{"prefLabel":"Plastik","uri":"http://purl.org/lobid/rpb#n845000"}
-{"prefLabel":"Plastik / Einzelne Objekte","uri":"http://purl.org/lobid/rpb#n845020"}
-{"prefLabel":"Malerei","uri":"http://purl.org/lobid/rpb#n846000"}
-{"prefLabel":"Malerei / Einzelne Objekte","uri":"http://purl.org/lobid/rpb#n846020"}
-{"prefLabel":"Zeichnung","uri":"http://purl.org/lobid/rpb#n847000"}
-{"prefLabel":"Druckgrafik","uri":"http://purl.org/lobid/rpb#n847500"}
-{"prefLabel":"Fotografie","uri":"http://purl.org/lobid/rpb#n848000"}
-{"prefLabel":"Kunsthandwerk","uri":"http://purl.org/lobid/rpb#n849000"}
-{"prefLabel":"Goldschmiedekunst. Silberschmiedekunst. Schmuck","uri":"http://purl.org/lobid/rpb#n849020"}
-{"prefLabel":"Eisenguss","uri":"http://purl.org/lobid/rpb#n849030"}
-{"prefLabel":"Bronzeguss","uri":"http://purl.org/lobid/rpb#n849032"}
-{"prefLabel":"Zinnguss","uri":"http://purl.org/lobid/rpb#n849034"}
-{"prefLabel":"Keramik","uri":"http://purl.org/lobid/rpb#n849040"}
-{"prefLabel":"Porzellan. Glas. Fayence","uri":"http://purl.org/lobid/rpb#n849050"}
-{"prefLabel":"Porzellan","uri":"http://purl.org/lobid/rpb#n849052"}
-{"prefLabel":"Fayence","uri":"http://purl.org/lobid/rpb#n849054"}
-{"prefLabel":"Glas","uri":"http://purl.org/lobid/rpb#n849056"}
-{"prefLabel":"Hausrat","uri":"http://purl.org/lobid/rpb#n849060"}
-{"prefLabel":"Möbel","uri":"http://purl.org/lobid/rpb#n849070"}
-{"prefLabel":"Textilien. Teppich. Tapete","uri":"http://purl.org/lobid/rpb#n849080"}
-{"prefLabel":"Textilien","uri":"http://purl.org/lobid/rpb#n849082"}
-{"prefLabel":"Teppich","uri":"http://purl.org/lobid/rpb#n849084"}
-{"prefLabel":"Tapete","uri":"http://purl.org/lobid/rpb#n849086"}
-{"prefLabel":"Uhr. Musikinstrument","uri":"http://purl.org/lobid/rpb#n849090"}
+{"prefLabel":"Kunst. Architektur allgemein","uri":"http://purl.org/lobid/rpb#n840100","definition":"Kunst. Architektur (n840000) > Kunst. Architektur allgemein (n840100)"}
+{"prefLabel":"Kunst","uri":"http://purl.org/lobid/rpb#n841000","definition":"Kunst. Architektur (n840000) > Kunst (n841000)"}
+{"prefLabel":"Kunststudium","uri":"http://purl.org/lobid/rpb#n841020","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Kunststudium (n841020)"}
+{"prefLabel":"Kunstmuseum. Kunstsammlung","uri":"http://purl.org/lobid/rpb#n841040","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Kunstmuseum. Kunstsammlung (n841040)"}
+{"prefLabel":"Kunstgalerie","uri":"http://purl.org/lobid/rpb#n841050","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Kunstgalerie (n841050)"}
+{"prefLabel":"Kunstausstellung","uri":"http://purl.org/lobid/rpb#n841060","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Kunstausstellung (n841060)"}
+{"prefLabel":"Künstlerin.Künstler","uri":"http://purl.org/lobid/rpb#n841070","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070)"}
+{"prefLabel":"Bildhauerin. Bildhauer","uri":"http://purl.org/lobid/rpb#n841072","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Bildhauerin. Bildhauer (n841072)"}
+{"prefLabel":"Malerin. Maler","uri":"http://purl.org/lobid/rpb#n841074","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Malerin. Maler (n841074)"}
+{"prefLabel":"Zeichnerin. Zeichner","uri":"http://purl.org/lobid/rpb#n841076","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Zeichnerin. Zeichner (n841076)"}
+{"prefLabel":"Grafikerin. Grafiker","uri":"http://purl.org/lobid/rpb#n841078","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Grafikerin. Grafiker (n841078)"}
+{"prefLabel":"Fotografin. Fotograf","uri":"http://purl.org/lobid/rpb#n841079","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Fotografin. Fotograf (n841079)"}
+{"prefLabel":"Künstlervereinigung","uri":"http://purl.org/lobid/rpb#n841080","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Künstlervereinigung (n841080)"}
+{"prefLabel":"Kunstförderung","uri":"http://purl.org/lobid/rpb#n841090","definition":"Kunst. Architektur (n840000) > Kunst (n841000) > Kunstförderung (n841090)"}
+{"prefLabel":"Kunst / Geschichte","uri":"http://purl.org/lobid/rpb#n842000","definition":"Kunst. Architektur (n840000) > Kunst / Geschichte (n842000)"}
+{"prefLabel":"Architektur","uri":"http://purl.org/lobid/rpb#n843000","definition":"Kunst. Architektur (n840000) > Architektur (n843000)"}
+{"prefLabel":"Baukonstruktion. Bautechnik","uri":"http://purl.org/lobid/rpb#n843010","definition":"Kunst. Architektur (n840000) > Architektur (n843000) > Baukonstruktion. Bautechnik (n843010)"}
+{"prefLabel":"Öffentliches Gebäude","uri":"http://purl.org/lobid/rpb#n843020","definition":"Kunst. Architektur (n840000) > Architektur (n843000) > Öffentliches Gebäude (n843020)"}
+{"prefLabel":"Büro-, Geschäfts- und Industriebauten","uri":"http://purl.org/lobid/rpb#n843040","definition":"Kunst. Architektur (n840000) > Architektur (n843000) > Büro-, Geschäfts- und Industriebauten (n843040)"}
+{"prefLabel":"Bürohaus","uri":"http://purl.org/lobid/rpb#n843042","definition":"Kunst. Architektur (n840000) > Architektur (n843000) > Büro-, Geschäfts- und Industriebauten (n843040) > Bürohaus (n843042)"}
+{"prefLabel":"Geschäftshaus","uri":"http://purl.org/lobid/rpb#n843044","definition":"Kunst. Architektur (n840000) > Architektur (n843000) > Büro-, Geschäfts- und Industriebauten (n843040) > Geschäftshaus (n843044)"}
+{"prefLabel":"Industriebau","uri":"http://purl.org/lobid/rpb#n843046","definition":"Kunst. Architektur (n840000) > Architektur (n843000) > Büro-, Geschäfts- und Industriebauten (n843040) > Industriebau (n843046)"}
+{"prefLabel":"Bauernhaus","uri":"http://purl.org/lobid/rpb#n843050","definition":"Kunst. Architektur (n840000) > Architektur (n843000) > Bauernhaus (n843050)"}
+{"prefLabel":"Wohnhaus","uri":"http://purl.org/lobid/rpb#n843060","definition":"Kunst. Architektur (n840000) > Architektur (n843000) > Wohnhaus (n843060)"}
+{"prefLabel":"Architektin. Architekt","uri":"http://purl.org/lobid/rpb#n843090","definition":"Kunst. Architektur (n840000) > Architektur (n843000) > Architektin. Architekt (n843090)"}
+{"prefLabel":"Baudenkmal. Kunstwerk","uri":"http://purl.org/lobid/rpb#n844000","definition":"Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000)"}
+{"prefLabel":"Kunst / Inventar","uri":"http://purl.org/lobid/rpb#n844010","definition":"Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Kunst / Inventar (n844010)"}
+{"prefLabel":"Baustil","uri":"http://purl.org/lobid/rpb#n844020","definition":"Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Baustil (n844020)"}
+{"prefLabel":"Sakralbau","uri":"http://purl.org/lobid/rpb#n844030","definition":"Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Sakralbau (n844030)"}
+{"prefLabel":"Burg. Schloss","uri":"http://purl.org/lobid/rpb#n844040","definition":"Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Burg. Schloss (n844040)"}
+{"prefLabel":"Profanarchitektur","uri":"http://purl.org/lobid/rpb#n844050","definition":"Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Profanarchitektur (n844050)"}
+{"prefLabel":"Park. Garten","uri":"http://purl.org/lobid/rpb#n844060","definition":"Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Park. Garten (n844060)"}
+{"prefLabel":"Brunnen","uri":"http://purl.org/lobid/rpb#n844070","definition":"Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Brunnen (n844070)"}
+{"prefLabel":"Denkmal","uri":"http://purl.org/lobid/rpb#n844080","definition":"Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Denkmal (n844080)"}
+{"prefLabel":"Denkmalpflege. Denkmalschutz","uri":"http://purl.org/lobid/rpb#n844200","definition":"Kunst. Architektur (n840000) > Denkmalpflege. Denkmalschutz (n844200)"}
+{"prefLabel":"Städtebau","uri":"http://purl.org/lobid/rpb#n844500","definition":"Kunst. Architektur (n840000) > Städtebau (n844500)"}
+{"prefLabel":"Plastik","uri":"http://purl.org/lobid/rpb#n845000","definition":"Kunst. Architektur (n840000) > Plastik (n845000)"}
+{"prefLabel":"Plastik / Einzelne Objekte","uri":"http://purl.org/lobid/rpb#n845020","definition":"Kunst. Architektur (n840000) > Plastik (n845000) > Plastik / Einzelne Objekte (n845020)"}
+{"prefLabel":"Malerei","uri":"http://purl.org/lobid/rpb#n846000","definition":"Kunst. Architektur (n840000) > Malerei (n846000)"}
+{"prefLabel":"Malerei / Einzelne Objekte","uri":"http://purl.org/lobid/rpb#n846020","definition":"Kunst. Architektur (n840000) > Malerei (n846000) > Malerei / Einzelne Objekte (n846020)"}
+{"prefLabel":"Zeichnung","uri":"http://purl.org/lobid/rpb#n847000","definition":"Kunst. Architektur (n840000) > Zeichnung (n847000)"}
+{"prefLabel":"Druckgrafik","uri":"http://purl.org/lobid/rpb#n847500","definition":"Kunst. Architektur (n840000) > Druckgrafik (n847500)"}
+{"prefLabel":"Fotografie","uri":"http://purl.org/lobid/rpb#n848000","definition":"Kunst. Architektur (n840000) > Fotografie (n848000)"}
+{"prefLabel":"Kunsthandwerk","uri":"http://purl.org/lobid/rpb#n849000","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000)"}
+{"prefLabel":"Goldschmiedekunst. Silberschmiedekunst. Schmuck","uri":"http://purl.org/lobid/rpb#n849020","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Goldschmiedekunst. Silberschmiedekunst. Schmuck (n849020)"}
+{"prefLabel":"Eisenguss","uri":"http://purl.org/lobid/rpb#n849030","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Eisenguss (n849030)"}
+{"prefLabel":"Bronzeguss","uri":"http://purl.org/lobid/rpb#n849032","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Bronzeguss (n849032)"}
+{"prefLabel":"Zinnguss","uri":"http://purl.org/lobid/rpb#n849034","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Zinnguss (n849034)"}
+{"prefLabel":"Keramik","uri":"http://purl.org/lobid/rpb#n849040","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Keramik (n849040)"}
+{"prefLabel":"Porzellan. Glas. Fayence","uri":"http://purl.org/lobid/rpb#n849050","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Porzellan. Glas. Fayence (n849050)"}
+{"prefLabel":"Porzellan","uri":"http://purl.org/lobid/rpb#n849052","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Porzellan. Glas. Fayence (n849050) > Porzellan (n849052)"}
+{"prefLabel":"Fayence","uri":"http://purl.org/lobid/rpb#n849054","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Porzellan. Glas. Fayence (n849050) > Fayence (n849054)"}
+{"prefLabel":"Glas","uri":"http://purl.org/lobid/rpb#n849056","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Porzellan. Glas. Fayence (n849050) > Glas (n849056)"}
+{"prefLabel":"Hausrat","uri":"http://purl.org/lobid/rpb#n849060","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Hausrat (n849060)"}
+{"prefLabel":"Möbel","uri":"http://purl.org/lobid/rpb#n849070","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Möbel (n849070)"}
+{"prefLabel":"Textilien. Teppich. Tapete","uri":"http://purl.org/lobid/rpb#n849080","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Textilien. Teppich. Tapete (n849080)"}
+{"prefLabel":"Textilien","uri":"http://purl.org/lobid/rpb#n849082","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Textilien. Teppich. Tapete (n849080) > Textilien (n849082)"}
+{"prefLabel":"Teppich","uri":"http://purl.org/lobid/rpb#n849084","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Textilien. Teppich. Tapete (n849080) > Teppich (n849084)"}
+{"prefLabel":"Tapete","uri":"http://purl.org/lobid/rpb#n849086","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Textilien. Teppich. Tapete (n849080) > Tapete (n849086)"}
+{"prefLabel":"Uhr. Musikinstrument","uri":"http://purl.org/lobid/rpb#n849090","definition":"Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Uhr. Musikinstrument (n849090)"}
 {"prefLabel":"Buch. Bibliothek","uri":"http://purl.org/lobid/rpb#n860000"}
-{"prefLabel":"Buch. Bibliothek allgemein","uri":"http://purl.org/lobid/rpb#n860100"}
-{"prefLabel":"Buch","uri":"http://purl.org/lobid/rpb#n861000"}
-{"prefLabel":"Schrift / Geschichte","uri":"http://purl.org/lobid/rpb#n861010"}
-{"prefLabel":"Handschrift","uri":"http://purl.org/lobid/rpb#n861020"}
-{"prefLabel":"Buch / Geschichte","uri":"http://purl.org/lobid/rpb#n861030"}
-{"prefLabel":"Buchdruck","uri":"http://purl.org/lobid/rpb#n861040"}
-{"prefLabel":"Verlag","uri":"http://purl.org/lobid/rpb#n861050"}
-{"prefLabel":"Urheberrecht","uri":"http://purl.org/lobid/rpb#n861052"}
-{"prefLabel":"Verlagsrecht","uri":"http://purl.org/lobid/rpb#n861054"}
-{"prefLabel":"Verlegerin. Verleger","uri":"http://purl.org/lobid/rpb#n861056"}
-{"prefLabel":"Buchhandel","uri":"http://purl.org/lobid/rpb#n861060"}
-{"prefLabel":"Bibliothek","uri":"http://purl.org/lobid/rpb#n865000"}
-{"prefLabel":"Bibliotheksrecht","uri":"http://purl.org/lobid/rpb#n865010"}
-{"prefLabel":"Bibliothek / Geschichte","uri":"http://purl.org/lobid/rpb#n865020"}
-{"prefLabel":"Bibliotheksplanung","uri":"http://purl.org/lobid/rpb#n865030"}
-{"prefLabel":"Wissenschaftliche Bibliothek","uri":"http://purl.org/lobid/rpb#n865040"}
-{"prefLabel":"Öffentliche Bibliothek","uri":"http://purl.org/lobid/rpb#n865050"}
-{"prefLabel":"Stadtbibliothek","uri":"http://purl.org/lobid/rpb#n865052"}
-{"prefLabel":"Kommunale Bibliothek","uri":"http://purl.org/lobid/rpb#n865054"}
-{"prefLabel":"Spezialbibliothek","uri":"http://purl.org/lobid/rpb#n865060"}
-{"prefLabel":"Schulbibliothek","uri":"http://purl.org/lobid/rpb#n865070"}
-{"prefLabel":"Privatbibliothek","uri":"http://purl.org/lobid/rpb#n865080"}
-{"prefLabel":"Bibliothekarin. Bibliothekar","uri":"http://purl.org/lobid/rpb#n865090"}
+{"prefLabel":"Buch. Bibliothek allgemein","uri":"http://purl.org/lobid/rpb#n860100","definition":"Buch. Bibliothek (n860000) > Buch. Bibliothek allgemein (n860100)"}
+{"prefLabel":"Buch","uri":"http://purl.org/lobid/rpb#n861000","definition":"Buch. Bibliothek (n860000) > Buch (n861000)"}
+{"prefLabel":"Schrift / Geschichte","uri":"http://purl.org/lobid/rpb#n861010","definition":"Buch. Bibliothek (n860000) > Buch (n861000) > Schrift / Geschichte (n861010)"}
+{"prefLabel":"Handschrift","uri":"http://purl.org/lobid/rpb#n861020","definition":"Buch. Bibliothek (n860000) > Buch (n861000) > Handschrift (n861020)"}
+{"prefLabel":"Buch / Geschichte","uri":"http://purl.org/lobid/rpb#n861030","definition":"Buch. Bibliothek (n860000) > Buch (n861000) > Buch / Geschichte (n861030)"}
+{"prefLabel":"Buchdruck","uri":"http://purl.org/lobid/rpb#n861040","definition":"Buch. Bibliothek (n860000) > Buch (n861000) > Buchdruck (n861040)"}
+{"prefLabel":"Verlag","uri":"http://purl.org/lobid/rpb#n861050","definition":"Buch. Bibliothek (n860000) > Buch (n861000) > Verlag (n861050)"}
+{"prefLabel":"Urheberrecht","uri":"http://purl.org/lobid/rpb#n861052","definition":"Buch. Bibliothek (n860000) > Buch (n861000) > Verlag (n861050) > Urheberrecht (n861052)"}
+{"prefLabel":"Verlagsrecht","uri":"http://purl.org/lobid/rpb#n861054","definition":"Buch. Bibliothek (n860000) > Buch (n861000) > Verlag (n861050) > Verlagsrecht (n861054)"}
+{"prefLabel":"Verlegerin. Verleger","uri":"http://purl.org/lobid/rpb#n861056","definition":"Buch. Bibliothek (n860000) > Buch (n861000) > Verlag (n861050) > Verlegerin. Verleger (n861056)"}
+{"prefLabel":"Buchhandel","uri":"http://purl.org/lobid/rpb#n861060","definition":"Buch. Bibliothek (n860000) > Buch (n861000) > Buchhandel (n861060)"}
+{"prefLabel":"Bibliothek","uri":"http://purl.org/lobid/rpb#n865000","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000)"}
+{"prefLabel":"Bibliotheksrecht","uri":"http://purl.org/lobid/rpb#n865010","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Bibliotheksrecht (n865010)"}
+{"prefLabel":"Bibliothek / Geschichte","uri":"http://purl.org/lobid/rpb#n865020","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Bibliothek / Geschichte (n865020)"}
+{"prefLabel":"Bibliotheksplanung","uri":"http://purl.org/lobid/rpb#n865030","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Bibliotheksplanung (n865030)"}
+{"prefLabel":"Wissenschaftliche Bibliothek","uri":"http://purl.org/lobid/rpb#n865040","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Wissenschaftliche Bibliothek (n865040)"}
+{"prefLabel":"Öffentliche Bibliothek","uri":"http://purl.org/lobid/rpb#n865050","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Öffentliche Bibliothek (n865050)"}
+{"prefLabel":"Stadtbibliothek","uri":"http://purl.org/lobid/rpb#n865052","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Öffentliche Bibliothek (n865050) > Stadtbibliothek (n865052)"}
+{"prefLabel":"Kommunale Bibliothek","uri":"http://purl.org/lobid/rpb#n865054","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Öffentliche Bibliothek (n865050) > Kommunale Bibliothek (n865054)"}
+{"prefLabel":"Spezialbibliothek","uri":"http://purl.org/lobid/rpb#n865060","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Spezialbibliothek (n865060)"}
+{"prefLabel":"Schulbibliothek","uri":"http://purl.org/lobid/rpb#n865070","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Schulbibliothek (n865070)"}
+{"prefLabel":"Privatbibliothek","uri":"http://purl.org/lobid/rpb#n865080","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Privatbibliothek (n865080)"}
+{"prefLabel":"Bibliothekarin. Bibliothekar","uri":"http://purl.org/lobid/rpb#n865090","definition":"Buch. Bibliothek (n860000) > Bibliothek (n865000) > Bibliothekarin. Bibliothekar (n865090)"}
 {"prefLabel":"Publizistik. Information. Dokumentation","uri":"http://purl.org/lobid/rpb#n880000"}
-{"prefLabel":"Publizistik. Information. Dokumentation allgemein","uri":"http://purl.org/lobid/rpb#n880100"}
-{"prefLabel":"Publizistik","uri":"http://purl.org/lobid/rpb#n882000"}
-{"prefLabel":"Presse","uri":"http://purl.org/lobid/rpb#n882020"}
-{"prefLabel":"Presserecht","uri":"http://purl.org/lobid/rpb#n882022"}
-{"prefLabel":"Zeitung. Zeitschrift","uri":"http://purl.org/lobid/rpb#n882026"}
-{"prefLabel":"Audiovisuelle Medien","uri":"http://purl.org/lobid/rpb#n882030"}
-{"prefLabel":"Hörfunk","uri":"http://purl.org/lobid/rpb#n882040"}
-{"prefLabel":"Fernsehen","uri":"http://purl.org/lobid/rpb#n882060"}
-{"prefLabel":"Journalistin. Journalist","uri":"http://purl.org/lobid/rpb#n882090"}
-{"prefLabel":"Information und Dokumentation","uri":"http://purl.org/lobid/rpb#n884000"}
-{"prefLabel":"Internet","uri":"http://purl.org/lobid/rpb#n884020"}
+{"prefLabel":"Publizistik. Information. Dokumentation allgemein","uri":"http://purl.org/lobid/rpb#n880100","definition":"Publizistik. Information. Dokumentation (n880000) > Publizistik. Information. Dokumentation allgemein (n880100)"}
+{"prefLabel":"Publizistik","uri":"http://purl.org/lobid/rpb#n882000","definition":"Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000)"}
+{"prefLabel":"Presse","uri":"http://purl.org/lobid/rpb#n882020","definition":"Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Presse (n882020)"}
+{"prefLabel":"Presserecht","uri":"http://purl.org/lobid/rpb#n882022","definition":"Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Presse (n882020) > Presserecht (n882022)"}
+{"prefLabel":"Zeitung. Zeitschrift","uri":"http://purl.org/lobid/rpb#n882026","definition":"Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Presse (n882020) > Zeitung. Zeitschrift (n882026)"}
+{"prefLabel":"Audiovisuelle Medien","uri":"http://purl.org/lobid/rpb#n882030","definition":"Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Audiovisuelle Medien (n882030)"}
+{"prefLabel":"Hörfunk","uri":"http://purl.org/lobid/rpb#n882040","definition":"Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Hörfunk (n882040)"}
+{"prefLabel":"Fernsehen","uri":"http://purl.org/lobid/rpb#n882060","definition":"Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Fernsehen (n882060)"}
+{"prefLabel":"Journalistin. Journalist","uri":"http://purl.org/lobid/rpb#n882090","definition":"Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Journalistin. Journalist (n882090)"}
+{"prefLabel":"Information und Dokumentation","uri":"http://purl.org/lobid/rpb#n884000","definition":"Publizistik. Information. Dokumentation (n880000) > Information und Dokumentation (n884000)"}
+{"prefLabel":"Internet","uri":"http://purl.org/lobid/rpb#n884020","definition":"Publizistik. Information. Dokumentation (n880000) > Information und Dokumentation (n884000) > Internet (n884020)"}

--- a/rpb.ttl
+++ b/rpb.ttl
@@ -6,7 +6,7 @@
 
 <http://purl.org/lobid/rpb>
         a                              skos:ConceptScheme ;
-        dct:description                "This classification was created for use in the bibliography of Rhineland-Palatinate (RPB). The transformation to SKOS was carried out by Felix Ostrowski for the hbz."@en ;
+        dct:description                "This classification was created for use in the bibliography of Rhineland-Palatinate (RPB) and transformed to SKOS by hbz in 2014."@en ;
         dct:issued                     "2014-01-28" ;
         dct:license                    <http://creativecommons.org/publicdomain/zero/1.0/> ;
         dct:modified                   "2026-01-15" ;
@@ -7617,4 +7617,3 @@
         skos:inScheme    <http://purl.org/lobid/rpb> ;
         skos:notation    "884020" ;
         skos:prefLabel   "Internet"@de .
-

--- a/rpb.ttl
+++ b/rpb.ttl
@@ -1,7921 +1,7620 @@
-@base   <http://purl.org/lobid/rpb> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix dct: <http://purl.org/dc/terms/> .
-@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix vann: <http://purl.org/vocab/vann/> .
-
-<>
-    a skos:ConceptScheme ;
-    dct:title "Systematik der Rheinland-Pfälzischen Bibliographie"@de , "Classification scheme for the bibliography of Rhineland-Palatinate"@en ;
-    dct:license <http://creativecommons.org/publicdomain/zero/1.0/> ;
-    dct:description "This classification was created for use in the bibliography of . The transformation to SKOS was carried out by Felix Ostrowski for the hbz."@en ;
-    dct:issued "2014-01-28" ;
-    dct:publisher <http://lobid.org/organisation/DE-605> ;
-    vann:preferredNamespaceUri "http://purl.org/lobid/rpb#" ;
-    vann:preferredNamespacePrefix "rpb" ;
-    skos:hasTopConcept <#n100000>, <#n120000>, <#n140000>, <#n160000>, <#n200000>, <#n210000>, <#n220000>, <#n240000>, <#n260000>, <#n400000>, <#n420000>, <#n440000>, <#n500000>, <#n520000>, <#n530000>, <#n540000>, <#n550000>, <#n560000>, <#n570000>, <#n580000>, <#n610000>, <#n630000>, <#n650000>, <#n700000>, <#n720000>, <#n730000>, <#n740000>, <#n760000>, <#n780000>, <#n790000>, <#n800000>, <#n820000>, <#n840000>, <#n860000>, <#n880000> .
-
-<#n100000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n100100>, <#n101000>, <#n102000>, <#n105000>, <#n106000>, <#n109000> ;
-    skos:notation "100000" ;
-    skos:prefLabel "Landeskunde"@de .
-
-<#n100100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n100000> ;
-    skos:notation "100100" ;
-    skos:prefLabel "Landeskunde allgemein"@de .
-
-<#n101000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n100000> ;
-    skos:notation "101000" ;
-    skos:prefLabel "Bibliografie"@de .
-
-<#n102000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n100000> ;
-    skos:narrower <#n102040>, <#n102042>, <#n102045>, <#n102050>, <#n102060>, <#n102070> ;
-    skos:notation "102000" ;
-    skos:prefLabel "Landesbeschreibung"@de .
-
-<#n102040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n102000> ;
-    skos:notation "102040" ;
-    skos:prefLabel "Kreisbeschreibung"@de .
-
-<#n102042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n102000> ;
-    skos:notation "102042" ;
-    skos:prefLabel "Verbandsgemeindebeschreibung"@de .
-
-<#n102045>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n102000> ;
-    skos:notation "102045" ;
-    skos:prefLabel "Regionenbeschreibung"@de .
-
-<#n102050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n102000> ;
-    skos:notation "102050" ;
-    skos:prefLabel "Ortsbeschreibung"@de .
-
-<#n102060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n102000> ;
-    skos:notation "102060" ;
-    skos:prefLabel "Reisebericht"@de .
-
-<#n102070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n102000> ;
-    skos:notation "102070" ;
-    skos:prefLabel "Wandern / Führer"@de .
-
-<#n105000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n100000> ;
-    skos:notation "105000" ;
-    skos:prefLabel "Heimatpflege"@de .
-
-<#n106000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n100000> ;
-    skos:notation "106000" ;
-    skos:prefLabel "Heimatverein"@de .
-
-<#n109000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n100000> ;
-    skos:notation "109000" ;
-    skos:prefLabel "Biografie"@de .
-
-<#n120000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n120100>, <#n122000>, <#n124000>, <#n126000> ;
-    skos:notation "120000" ;
-    skos:prefLabel "Kartografie. Geodäsie"@de .
-
-<#n120100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n120000> ;
-    skos:notation "120100" ;
-    skos:prefLabel "Kartografie. Geodäsie allgemein"@de .
-
-<#n122000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n120000> ;
-    skos:narrower <#n122030>, <#n122050>, <#n122070> ;
-    skos:notation "122000" ;
-    skos:prefLabel "Kartografie"@de .
-
-<#n122030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n122000> ;
-    skos:notation "122030" ;
-    skos:prefLabel "Kartenauswertung"@de .
-
-<#n122050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n122000> ;
-    skos:notation "122050" ;
-    skos:prefLabel "Computerkartografie"@de .
-
-<#n122070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n122000> ;
-    skos:notation "122070" ;
-    skos:prefLabel "Luftbildauswertung"@de .
-
-<#n124000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n120000> ;
-    skos:notation "124000" ;
-    skos:prefLabel "Geodäsie"@de .
-
-<#n126000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n120000> ;
-    skos:notation "126000" ;
-    skos:prefLabel "Karte"@de .
-
-<#n140000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n140100>, <#n141000>, <#n141200>, <#n141400>, <#n141600>, <#n142000>, <#n142100>, <#n142300>, <#n142500>, <#n146000> ;
-    skos:notation "140000" ;
-    skos:prefLabel "Geowissenschaften"@de .
-
-<#n140100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:notation "140100" ;
-    skos:prefLabel "Geowissenschaften allgemein"@de .
-
-<#n141000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:narrower <#n141020>, <#n141030>, <#n141040> ;
-    skos:notation "141000" ;
-    skos:prefLabel "Geophysik"@de .
-
-<#n141020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141000> ;
-    skos:notation "141020" ;
-    skos:prefLabel "Erdmagnetismus"@de .
-
-<#n141030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141000> ;
-    skos:notation "141030" ;
-    skos:prefLabel "Schwere"@de .
-
-<#n141040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141000> ;
-    skos:notation "141040" ;
-    skos:prefLabel "Erdbeben"@de .
-
-<#n141200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:narrower <#n141220>, <#n141230>, <#n141240> ;
-    skos:notation "141200" ;
-    skos:prefLabel "Geologie"@de .
-
-<#n141220>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141200> ;
-    skos:notation "141220" ;
-    skos:prefLabel "Tektonik"@de .
-
-<#n141230>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141200> ;
-    skos:notation "141230" ;
-    skos:prefLabel "Ingenieurgeologie"@de .
-
-<#n141240>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141200> ;
-    skos:notation "141240" ;
-    skos:prefLabel "Stratigraphie"@de .
-
-<#n141400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:narrower <#n141420>, <#n141430>, <#n141440>, <#n141450>, <#n141460> ;
-    skos:notation "141400" ;
-    skos:prefLabel "Mineralogie. Gesteinskunde"@de .
-
-<#n141420>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141400> ;
-    skos:notation "141420" ;
-    skos:prefLabel "Mineralogie"@de .
-
-<#n141430>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141400> ;
-    skos:notation "141430" ;
-    skos:prefLabel "Gesteinskunde"@de .
-
-<#n141440>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141400> ;
-    skos:notation "141440" ;
-    skos:prefLabel "Geochemie"@de .
-
-<#n141450>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141400> ;
-    skos:notation "141450" ;
-    skos:prefLabel "Lagerstättenkunde"@de .
-
-<#n141460>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141400> ;
-    skos:notation "141460" ;
-    skos:prefLabel "Mineralquelle. Thermalquelle"@de .
-
-<#n141600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:narrower <#n141620>, <#n141630>, <#n141640> ;
-    skos:notation "141600" ;
-    skos:prefLabel "Paläontologie"@de .
-
-<#n141620>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141600> ;
-    skos:narrower <#n141622>, <#n141624> ;
-    skos:notation "141620" ;
-    skos:prefLabel "Paläobotanik"@de .
-
-<#n141622>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141620> ;
-    skos:notation "141622" ;
-    skos:prefLabel "Fossile Sporenpflanzen"@de .
-
-<#n141624>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141620> ;
-    skos:notation "141624" ;
-    skos:prefLabel "Fossile Samenpflanzen"@de .
-
-<#n141630>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141600> ;
-    skos:narrower <#n141632>, <#n141634> ;
-    skos:notation "141630" ;
-    skos:prefLabel "Paläozoologie"@de .
-
-<#n141632>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141630> ;
-    skos:notation "141632" ;
-    skos:prefLabel "Fossile Wirbellose"@de .
-
-<#n141634>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141630> ;
-    skos:notation "141634" ;
-    skos:prefLabel "Fossile Wirbeltiere"@de .
-
-<#n141640>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n141600> ;
-    skos:notation "141640" ;
-    skos:prefLabel "Mikropaläontologie"@de .
-
-<#n142000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:narrower <#n142020>, <#n142030>, <#n142040>, <#n142050>, <#n142060> ;
-    skos:notation "142000" ;
-    skos:prefLabel "Bodenkunde"@de .
-
-<#n142020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142000> ;
-    skos:notation "142020" ;
-    skos:prefLabel "Bodenentwicklung"@de .
-
-<#n142030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142000> ;
-    skos:notation "142030" ;
-    skos:prefLabel "Bodenphysik"@de .
-
-<#n142040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142000> ;
-    skos:notation "142040" ;
-    skos:prefLabel "Bodenbiologie"@de .
-
-<#n142050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142000> ;
-    skos:notation "142050" ;
-    skos:prefLabel "Bodenmechanik"@de .
-
-<#n142060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142000> ;
-    skos:notation "142060" ;
-    skos:prefLabel "Bodenchemie"@de .
-
-<#n142100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:narrower <#n142110>, <#n142120>, <#n142130>, <#n142140>, <#n142150>, <#n142170>, <#n142180>, <#n142190> ;
-    skos:notation "142100" ;
-    skos:prefLabel "Geomorphologie"@de .
-
-<#n142110>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142100> ;
-    skos:notation "142110" ;
-    skos:prefLabel "Relief / Geografie"@de .
-
-<#n142120>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142100> ;
-    skos:notation "142120" ;
-    skos:prefLabel "Abtragung"@de .
-
-<#n142130>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142100> ;
-    skos:notation "142130" ;
-    skos:prefLabel "Klimamorphologie"@de .
-
-<#n142140>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142100> ;
-    skos:notation "142140" ;
-    skos:prefLabel "Glazialmorphologie. Periglazialgeomorphologie"@de .
-
-<#n142150>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142100> ;
-    skos:notation "142150" ;
-    skos:prefLabel "Vulkanismus"@de .
-
-<#n142170>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142100> ;
-    skos:notation "142170" ;
-    skos:prefLabel "Karst"@de .
-
-<#n142180>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142100> ;
-    skos:notation "142180" ;
-    skos:prefLabel "Höhle"@de .
-
-<#n142190>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142100> ;
-    skos:notation "142190" ;
-    skos:prefLabel "Angewandte Geomorphologie"@de .
-
-<#n142300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:narrower <#n142310>, <#n142320>, <#n142330>, <#n142340>, <#n142350>, <#n142360>, <#n142370>, <#n142380>, <#n142390> ;
-    skos:notation "142300" ;
-    skos:prefLabel "Wasser"@de .
-
-<#n142310>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142300> ;
-    skos:notation "142310" ;
-    skos:prefLabel "Wasserrecht"@de .
-
-<#n142320>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142300> ;
-    skos:narrower <#n142323>, <#n142325> ;
-    skos:notation "142320" ;
-    skos:prefLabel "Fließgewässer"@de .
-
-<#n142323>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142320> ;
-    skos:notation "142323" ;
-    skos:prefLabel "Hochwasser"@de .
-
-<#n142325>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142320> ;
-    skos:notation "142325" ;
-    skos:prefLabel "Niedrigwasser"@de .
-
-<#n142330>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142300> ;
-    skos:notation "142330" ;
-    skos:prefLabel "See"@de .
-
-<#n142340>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142300> ;
-    skos:notation "142340" ;
-    skos:prefLabel "Moor"@de .
-
-<#n142350>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142300> ;
-    skos:narrower <#n142352> ;
-    skos:notation "142350" ;
-    skos:prefLabel "Hydrogeologie"@de .
-
-<#n142352>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142350> ;
-    skos:notation "142352" ;
-    skos:prefLabel "Bodenwasser"@de .
-
-<#n142360>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142300> ;
-    skos:notation "142360" ;
-    skos:prefLabel "Wasserhaushalt"@de .
-
-<#n142370>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142300> ;
-    skos:narrower <#n142372>, <#n142375> ;
-    skos:notation "142370" ;
-    skos:prefLabel "Wasserwirtschaft"@de .
-
-<#n142372>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142370> ;
-    skos:notation "142372" ;
-    skos:prefLabel "Trinkwasserversorgung"@de .
-
-<#n142375>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142370> ;
-    skos:notation "142375" ;
-    skos:prefLabel "Brauchwasser"@de .
-
-<#n142380>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142300> ;
-    skos:narrower <#n142382> ;
-    skos:notation "142380" ;
-    skos:prefLabel "Hydroökologie"@de .
-
-<#n142382>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142380> ;
-    skos:notation "142382" ;
-    skos:prefLabel "Wasseranalyse"@de .
-
-<#n142390>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142300> ;
-    skos:notation "142390" ;
-    skos:prefLabel "Wasserstatistik"@de .
-
-<#n142500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:narrower <#n142520>, <#n142530>, <#n142540>, <#n142541>, <#n142550>, <#n142560>, <#n142570> ;
-    skos:notation "142500" ;
-    skos:prefLabel "Klima"@de .
-
-<#n142520>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142500> ;
-    skos:narrower <#n142522>, <#n142523>, <#n142524>, <#n142525>, <#n142526>, <#n142527> ;
-    skos:notation "142520" ;
-    skos:prefLabel "Klimaelement"@de .
-
-<#n142522>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142520> ;
-    skos:notation "142522" ;
-    skos:prefLabel "Sonnenstrahlung"@de .
-
-<#n142523>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142520> ;
-    skos:notation "142523" ;
-    skos:prefLabel "Lufttemperatur"@de .
-
-<#n142524>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142520> ;
-    skos:notation "142524" ;
-    skos:prefLabel "Luftfeuchtigkeit"@de .
-
-<#n142525>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142520> ;
-    skos:notation "142525" ;
-    skos:prefLabel "Luftdruck"@de .
-
-<#n142526>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142520> ;
-    skos:notation "142526" ;
-    skos:prefLabel "Luftbewegung"@de .
-
-<#n142527>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142520> ;
-    skos:notation "142527" ;
-    skos:prefLabel "Luftelektrizität"@de .
-
-<#n142530>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142500> ;
-    skos:notation "142530" ;
-    skos:prefLabel "Klimatologie"@de .
-
-<#n142540>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142500> ;
-    skos:notation "142540" ;
-    skos:prefLabel "Wetterdienst"@de .
-
-<#n142541>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142500> ;
-    skos:notation "142541" ;
-    skos:prefLabel "Wetterlage"@de .
-
-<#n142550>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142500> ;
-    skos:notation "142550" ;
-    skos:prefLabel "Klimafaktor"@de .
-
-<#n142560>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142500> ;
-    skos:notation "142560" ;
-    skos:prefLabel "Klimaschwankung"@de .
-
-<#n142570>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n142500> ;
-    skos:notation "142570" ;
-    skos:prefLabel "Paläoklimatologie"@de .
-
-<#n146000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n140000> ;
-    skos:notation "146000" ;
-    skos:prefLabel "Geoökologie"@de .
-
-<#n160000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n160100>, <#n161000>, <#n162000>, <#n163000>, <#n164000> ;
-    skos:notation "160000" ;
-    skos:prefLabel "Biowissenschaften"@de .
-
-<#n160100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n160000> ;
-    skos:notation "160100" ;
-    skos:prefLabel "Biowissenschaften allgemein"@de .
-
-<#n161000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n160000> ;
-    skos:narrower <#n161030>, <#n161040>, <#n161050> ;
-    skos:notation "161000" ;
-    skos:prefLabel "Biologie"@de .
-
-<#n161030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n161000> ;
-    skos:notation "161030" ;
-    skos:prefLabel "Ökologie"@de .
-
-<#n161040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n161000> ;
-    skos:notation "161040" ;
-    skos:prefLabel "Biozönose"@de .
-
-<#n161050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n161000> ;
-    skos:notation "161050" ;
-    skos:prefLabel "Mikrobiologie"@de .
-
-<#n162000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n160000> ;
-    skos:narrower <#n162030>, <#n162040> ;
-    skos:notation "162000" ;
-    skos:prefLabel "Pflanzen"@de .
-
-<#n162030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n162000> ;
-    skos:notation "162030" ;
-    skos:prefLabel "Kryptogamen"@de .
-
-<#n162040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n162000> ;
-    skos:notation "162040" ;
-    skos:prefLabel "Samenpflanzen"@de .
-
-<#n163000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n160000> ;
-    skos:narrower <#n163020>, <#n163030>, <#n163040>, <#n163050>, <#n163060>, <#n163070>, <#n163080>, <#n163090> ;
-    skos:notation "163000" ;
-    skos:prefLabel "Tiere"@de .
-
-<#n163020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n163000> ;
-    skos:notation "163020" ;
-    skos:prefLabel "Wirbellose"@de .
-
-<#n163030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n163000> ;
-    skos:notation "163030" ;
-    skos:prefLabel "Insekten"@de .
-
-<#n163040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n163000> ;
-    skos:notation "163040" ;
-    skos:prefLabel "Wirbeltiere"@de .
-
-<#n163050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n163000> ;
-    skos:notation "163050" ;
-    skos:prefLabel "Fische"@de .
-
-<#n163060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n163000> ;
-    skos:notation "163060" ;
-    skos:prefLabel "Lurche"@de .
-
-<#n163070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n163000> ;
-    skos:notation "163070" ;
-    skos:prefLabel "Reptilien"@de .
-
-<#n163080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n163000> ;
-    skos:notation "163080" ;
-    skos:prefLabel "Vögel"@de .
-
-<#n163090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n163000> ;
-    skos:notation "163090" ;
-    skos:prefLabel "Säugetiere"@de .
-
-<#n164000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n160000> ;
-    skos:narrower <#n164020>, <#n164030>, <#n164040> ;
-    skos:notation "164000" ;
-    skos:prefLabel "Humanbiologie"@de .
-
-<#n164020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n164000> ;
-    skos:notation "164020" ;
-    skos:prefLabel "Menschenrasse"@de .
-
-<#n164030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n164000> ;
-    skos:notation "164030" ;
-    skos:prefLabel "Skelettfund"@de .
-
-<#n164040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n164000> ;
-    skos:notation "164040" ;
-    skos:prefLabel "Paläoanthropologie"@de .
-
-<#n200000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n200100>, <#n202000>, <#n202500>, <#n203000>, <#n203500>, <#n204000>, <#n205000>, <#n206000>, <#n207000>, <#n208000>, <#n209000> ;
-    skos:notation "200000" ;
-    skos:prefLabel "Historische Hilfswissenschaften"@de .
-
-<#n200100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:notation "200100" ;
-    skos:prefLabel "Historische Hilfswissenschaften allgemein"@de .
-
-<#n202000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:notation "202000" ;
-    skos:prefLabel "Chronologie"@de .
-
-<#n202500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:notation "202500" ;
-    skos:prefLabel "Metrologie"@de .
-
-<#n203000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:notation "203000" ;
-    skos:prefLabel "Urkundenlehre"@de .
-
-<#n203500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:notation "203500" ;
-    skos:prefLabel "Paläografie"@de .
-
-<#n204000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:notation "204000" ;
-    skos:prefLabel "Siegelkunde"@de .
-
-<#n205000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:narrower <#n205020>, <#n205030> ;
-    skos:notation "205000" ;
-    skos:prefLabel "Numismatik"@de .
-
-<#n205020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n205000> ;
-    skos:notation "205020" ;
-    skos:prefLabel "Münze"@de .
-
-<#n205030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n205000> ;
-    skos:notation "205030" ;
-    skos:prefLabel "Papiergeld"@de .
-
-<#n206000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:notation "206000" ;
-    skos:prefLabel "Epigraphik"@de .
-
-<#n207000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:narrower <#n207020> ;
-    skos:notation "207000" ;
-    skos:prefLabel "Genealogie"@de .
-
-<#n207020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n207000> ;
-    skos:notation "207020" ;
-    skos:prefLabel "Familie"@de .
-
-<#n208000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:narrower <#n208500> ;
-    skos:notation "208000" ;
-    skos:prefLabel "Heraldik"@de .
-
-<#n208500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n208000> ;
-    skos:notation "208500" ;
-    skos:prefLabel "Flagge"@de .
-
-<#n209000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n200000> ;
-    skos:notation "209000" ;
-    skos:prefLabel "Orden / Ehrenzeichen"@de .
-
-<#n210000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n210100>, <#n213000>, <#n217000> ;
-    skos:notation "210000" ;
-    skos:prefLabel "Archiv. Museum"@de .
-
-<#n210100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n210000> ;
-    skos:notation "210100" ;
-    skos:prefLabel "Archiv. Museum allgemein"@de .
-
-<#n213000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n210000> ;
-    skos:narrower <#n213010>, <#n213020>, <#n213030>, <#n213040>, <#n213050>, <#n213060>, <#n213070>, <#n213080>, <#n213090>, <#n213092> ;
-    skos:notation "213000" ;
-    skos:prefLabel "Archiv"@de .
-
-<#n213010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:notation "213010" ;
-    skos:prefLabel "Bundesarchiv Koblenz"@de .
-
-<#n213020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:notation "213020" ;
-    skos:prefLabel "Staatsarchiv"@de .
-
-<#n213030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:narrower <#n213031>, <#n213033> ;
-    skos:notation "213030" ;
-    skos:prefLabel "Kreisarchiv. Gemeindearchiv"@de .
-
-<#n213031>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213030> ;
-    skos:notation "213031" ;
-    skos:prefLabel "Kreisarchiv"@de .
-
-<#n213033>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213030> ;
-    skos:notation "213033" ;
-    skos:prefLabel "Gemeindearchiv"@de .
-
-<#n213040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:notation "213040" ;
-    skos:prefLabel "Kirchenarchiv"@de .
-
-<#n213050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:narrower <#n213052>, <#n213053>, <#n213054> ;
-    skos:notation "213050" ;
-    skos:prefLabel "Archiv für Literatur, Kunst und Wissenschaft"@de .
-
-<#n213052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213050> ;
-    skos:notation "213052" ;
-    skos:prefLabel "Literaturarchiv"@de .
-
-<#n213053>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213050> ;
-    skos:notation "213053" ;
-    skos:prefLabel "Kunstarchiv"@de .
-
-<#n213054>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213050> ;
-    skos:notation "213054" ;
-    skos:prefLabel "Wissenschaftsarchiv"@de .
-
-<#n213060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:notation "213060" ;
-    skos:prefLabel "Parteiarchiv"@de .
-
-<#n213070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:narrower <#n213072>, <#n213073>, <#n213074> ;
-    skos:notation "213070" ;
-    skos:prefLabel "Medienarchiv"@de .
-
-<#n213072>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213070> ;
-    skos:notation "213072" ;
-    skos:prefLabel "Rundfunkarchiv"@de .
-
-<#n213073>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213070> ;
-    skos:notation "213073" ;
-    skos:prefLabel "Pressearchiv"@de .
-
-<#n213074>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213070> ;
-    skos:notation "213074" ;
-    skos:prefLabel "Filmarchiv"@de .
-
-<#n213080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:narrower <#n213082> ;
-    skos:notation "213080" ;
-    skos:prefLabel "Wirtschaftsarchiv"@de .
-
-<#n213082>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213080> ;
-    skos:notation "213082" ;
-    skos:prefLabel "Firmenarchiv"@de .
-
-<#n213090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:notation "213090" ;
-    skos:prefLabel "Familienarchiv"@de .
-
-<#n213092>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n213000> ;
-    skos:notation "213092" ;
-    skos:prefLabel "Sonstige Archive"@de .
-
-<#n217000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n210000> ;
-    skos:narrower <#n217010>, <#n217020>, <#n217030>, <#n217040>, <#n217050>, <#n217090> ;
-    skos:notation "217000" ;
-    skos:prefLabel "Museum"@de .
-
-<#n217010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n217000> ;
-    skos:notation "217010" ;
-    skos:prefLabel "Museumspädagogik"@de .
-
-<#n217020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n217000> ;
-    skos:notation "217020" ;
-    skos:prefLabel "Naturkundemuseum"@de .
-
-<#n217030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n217000> ;
-    skos:notation "217030" ;
-    skos:prefLabel "Technisches Museum"@de .
-
-<#n217040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n217000> ;
-    skos:notation "217040" ;
-    skos:prefLabel "Historisches Museum. Heimatmuseum"@de .
-
-<#n217050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n217000> ;
-    skos:notation "217050" ;
-    skos:prefLabel "Volkskundemuseum"@de .
-
-<#n217090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n217000> ;
-    skos:notation "217090" ;
-    skos:prefLabel "Sonstige Museen"@de .
-
-<#n220000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n220100>, <#n220500>, <#n221000>, <#n222000>, <#n223000>, <#n224000>, <#n225000>, <#n226000>, <#n227000>, <#n228000> ;
-    skos:notation "220000" ;
-    skos:prefLabel "Vor- und Frühgeschichte. Archäologie"@de .
-
-<#n220100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:notation "220100" ;
-    skos:prefLabel "Vor- und Frühgeschichte. Archäologie allgemein"@de .
-
-<#n220500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:notation "220500" ;
-    skos:prefLabel "Archäologie"@de .
-
-<#n221000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:notation "221000" ;
-    skos:prefLabel "Vor- und Frühgeschichte"@de .
-
-<#n222000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:notation "222000" ;
-    skos:prefLabel "Paläolithikum. Mesolithikum"@de .
-
-<#n223000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:narrower <#n223020>, <#n223030>, <#n223040>, <#n223050>, <#n223060>, <#n223070> ;
-    skos:notation "223000" ;
-    skos:prefLabel "Neolithikum"@de .
-
-<#n223020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n223000> ;
-    skos:notation "223020" ;
-    skos:prefLabel "Bandkeramik"@de .
-
-<#n223030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n223000> ;
-    skos:notation "223030" ;
-    skos:prefLabel "Rössener Kultur"@de .
-
-<#n223040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n223000> ;
-    skos:notation "223040" ;
-    skos:prefLabel "Michelsberger Kultur"@de .
-
-<#n223050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n223000> ;
-    skos:notation "223050" ;
-    skos:prefLabel "Megalithkultur"@de .
-
-<#n223060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n223000> ;
-    skos:notation "223060" ;
-    skos:prefLabel "Schnurkeramik"@de .
-
-<#n223070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n223000> ;
-    skos:notation "223070" ;
-    skos:prefLabel "Glockenbecherkultur"@de .
-
-<#n224000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:narrower <#n224050>, <#n224060> ;
-    skos:notation "224000" ;
-    skos:prefLabel "Bronzezeit"@de .
-
-<#n224050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n224000> ;
-    skos:notation "224050" ;
-    skos:prefLabel "Hügelgräberkultur"@de .
-
-<#n224060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n224000> ;
-    skos:notation "224060" ;
-    skos:prefLabel "Urnenfelderkultur"@de .
-
-<#n225000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:narrower <#n225020>, <#n225025>, <#n225030>, <#n225040>, <#n225050> ;
-    skos:notation "225000" ;
-    skos:prefLabel "Vorrömische Eisenzeit"@de .
-
-<#n225020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n225000> ;
-    skos:notation "225020" ;
-    skos:prefLabel "Hallstattkultur"@de .
-
-<#n225025>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n225000> ;
-    skos:notation "225025" ;
-    skos:prefLabel "Hunsrück-Eifel-Kultur"@de .
-
-<#n225030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n225000> ;
-    skos:notation "225030" ;
-    skos:prefLabel "Latène-Zeit"@de .
-
-<#n225040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n225000> ;
-    skos:notation "225040" ;
-    skos:prefLabel "Kelten"@de .
-
-<#n225050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n225000> ;
-    skos:notation "225050" ;
-    skos:prefLabel "Germanen"@de .
-
-<#n226000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:narrower <#n226020>, <#n226030>, <#n226040>, <#n226050> ;
-    skos:notation "226000" ;
-    skos:prefLabel "Römerzeit"@de .
-
-<#n226020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n226000> ;
-    skos:notation "226020" ;
-    skos:prefLabel "Kelten"@de .
-
-<#n226030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n226000> ;
-    skos:notation "226030" ;
-    skos:prefLabel "Römer"@de .
-
-<#n226040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n226000> ;
-    skos:notation "226040" ;
-    skos:prefLabel "Germanen"@de .
-
-<#n226050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n226000> ;
-    skos:notation "226050" ;
-    skos:prefLabel "Franken <Volk>"@de .
-
-<#n227000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:narrower <#n227020>, <#n227030>, <#n227040> ;
-    skos:notation "227000" ;
-    skos:prefLabel "Völkerwanderung"@de .
-
-<#n227020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n227000> ;
-    skos:notation "227020" ;
-    skos:prefLabel "Römer"@de .
-
-<#n227030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n227000> ;
-    skos:notation "227030" ;
-    skos:prefLabel "Germanen"@de .
-
-<#n227040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n227000> ;
-    skos:notation "227040" ;
-    skos:prefLabel "Franken <Volk>"@de .
-
-<#n228000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n220000> ;
-    skos:narrower <#n228020>, <#n228030>, <#n228080> ;
-    skos:notation "228000" ;
-    skos:prefLabel "Mittelalterliche Archäologie. Neuzeitliche Archäologie"@de .
-
-<#n228020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n228000> ;
-    skos:notation "228020" ;
-    skos:prefLabel "Bestattung"@de .
-
-<#n228030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n228000> ;
-    skos:notation "228030" ;
-    skos:prefLabel "Funde"@de .
-
-<#n228080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n228000> ;
-    skos:notation "228080" ;
-    skos:prefLabel "Industriearchäologie"@de .
-
-<#n240000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n240100>, <#n240200>, <#n240300>, <#n240350>, <#n240400>, <#n240500>, <#n240600>, <#n241050>, <#n241100>, <#n241200>, <#n241400>, <#n242100>, <#n242200>, <#n242300>, <#n242500>, <#n242600>, <#n242700>, <#n242800>, <#n243100>, <#n243400>, <#n245100>, <#n245300>, <#n246100>, <#n246200>, <#n246300>, <#n246500>, <#n246700>, <#n248000>, <#n248100>, <#n248300>, <#n248500>, <#n249100> ;
-    skos:notation "240000" ;
-    skos:prefLabel "Geschichte"@de .
-
-<#n240100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "240100" ;
-    skos:prefLabel "Quelle"@de .
-
-<#n240200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "240200" ;
-    skos:prefLabel "Geschichtsschreibung"@de .
-
-<#n240300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "240300" ;
-    skos:prefLabel "Regionalgeschichte"@de .
-
-<#n240350>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "240350" ;
-    skos:prefLabel "Verbandsgemeindegeschichte"@de .
-
-<#n240400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "240400" ;
-    skos:prefLabel "Ortsgeschichte"@de .
-
-<#n240500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "240500" ;
-    skos:prefLabel "Historische Ausstellung"@de .
-
-<#n240600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "240600" ;
-    skos:prefLabel "Gedenkstätte"@de .
-
-<#n241050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "241050" ;
-    skos:prefLabel "Rheinland-Pfalz (gesamt) / Geschichte Anfänge-1945"@de .
-
-<#n241100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "241100" ;
-    skos:prefLabel "Rheinland / Geschichte Anfänge-1945"@de .
-
-<#n241200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "241200" ;
-    skos:prefLabel "Pfalz / Geschichte Anfänge-1945"@de .
-
-<#n241400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "241400" ;
-    skos:prefLabel "Rheinhessen / Geschichte Anfänge-1945"@de .
-
-<#n242100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "242100" ;
-    skos:prefLabel "Kurpfalz"@de .
-
-<#n242200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "242200" ;
-    skos:prefLabel "Hochstift Trier"@de .
-
-<#n242300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "242300" ;
-    skos:prefLabel "Hochstift Mainz"@de .
-
-<#n242500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "242500" ;
-    skos:prefLabel "Hochstift Speyer"@de .
-
-<#n242600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "242600" ;
-    skos:prefLabel "Hochstift Worms"@de .
-
-<#n242700>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:narrower <#n242720>, <#n242730>, <#n242740>, <#n242760> ;
-    skos:notation "242700" ;
-    skos:prefLabel "Reichsterritorium. Reichsbeziehung"@de .
-
-<#n242720>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242700> ;
-    skos:notation "242720" ;
-    skos:prefLabel "Reichstag"@de .
-
-<#n242730>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242700> ;
-    skos:notation "242730" ;
-    skos:prefLabel "Reichsrecht"@de .
-
-<#n242740>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242700> ;
-    skos:narrower <#n242743>, <#n242744>, <#n242746>, <#n242747> ;
-    skos:notation "242740" ;
-    skos:prefLabel "Reichsgut"@de .
-
-<#n242743>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242740> ;
-    skos:notation "242743" ;
-    skos:prefLabel "Königshof"@de .
-
-<#n242744>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242740> ;
-    skos:notation "242744" ;
-    skos:prefLabel "Königspfalz"@de .
-
-<#n242746>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242740> ;
-    skos:notation "242746" ;
-    skos:prefLabel "Reichsabtei"@de .
-
-<#n242747>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242740> ;
-    skos:notation "242747" ;
-    skos:prefLabel "Reichsstadt"@de .
-
-<#n242760>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242700> ;
-    skos:notation "242760" ;
-    skos:prefLabel "Reichsritterschaft"@de .
-
-<#n242800>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:narrower <#n242810>, <#n242812>, <#n242814>, <#n242816>, <#n242818>, <#n242830>, <#n242832>, <#n242834>, <#n242836>, <#n242850>, <#n242852>, <#n242854>, <#n242856>, <#n242870>, <#n242872>, <#n242874>, <#n242876>, <#n242878> ;
-    skos:notation "242800" ;
-    skos:prefLabel "Kleinere Territorien und Teile auswärtiger Territorien"@de .
-
-<#n242810>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242810" ;
-    skos:prefLabel "Luxemburg"@de .
-
-<#n242812>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242812" ;
-    skos:prefLabel "Hochstift Köln"@de .
-
-<#n242814>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242814" ;
-    skos:prefLabel "Grafschaft Homburg, Saar"@de .
-
-<#n242816>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242816" ;
-    skos:prefLabel "Grafschaft Saarbrücken"@de .
-
-<#n242818>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242818" ;
-    skos:prefLabel "Staat Leiningen"@de .
-
-<#n242830>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242830" ;
-    skos:prefLabel "Grafschaft Virneburg"@de .
-
-<#n242832>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242832" ;
-    skos:prefLabel "Grafschaft Manderscheid"@de .
-
-<#n242834>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242834" ;
-    skos:prefLabel "Herzogtum Arenberg"@de .
-
-<#n242836>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242836" ;
-    skos:prefLabel "Fürstentum Löwenstein-Wertheim"@de .
-
-<#n242850>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242850" ;
-    skos:prefLabel "Grafschaft Wied"@de .
-
-<#n242852>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242852" ;
-    skos:prefLabel "Fürstentum Isenburg. Grafschaft Isenburg"@de .
-
-<#n242854>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242854" ;
-    skos:prefLabel "Grafschaft Sayn"@de .
-
-<#n242856>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242856" ;
-    skos:prefLabel "Grafschaft Katzenelnbogen"@de .
-
-<#n242870>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242870" ;
-    skos:prefLabel "Grafschaft Veldenz"@de .
-
-<#n242872>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242872" ;
-    skos:prefLabel "Grafschaft Sponheim"@de .
-
-<#n242874>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242874" ;
-    skos:prefLabel "Wild- und Rheingrafen"@de .
-
-<#n242876>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242876" ;
-    skos:prefLabel "Pfalz-Simmern"@de .
-
-<#n242878>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n242800> ;
-    skos:notation "242878" ;
-    skos:prefLabel "Hanau-Lichtenberg"@de .
-
-<#n243100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "243100" ;
-    skos:prefLabel "Pfalz-Zweibrücken"@de .
-
-<#n243400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "243400" ;
-    skos:prefLabel "Staat Nassau"@de .
-
-<#n245100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:narrower <#n245120>, <#n245130>, <#n245140>, <#n245160>, <#n245180> ;
-    skos:notation "245100" ;
-    skos:prefLabel "Französische Besetzung / 1792-1815"@de .
-
-<#n245120>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n245100> ;
-    skos:notation "245120" ;
-    skos:prefLabel "Mainzer Republik"@de .
-
-<#n245130>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n245100> ;
-    skos:notation "245130" ;
-    skos:prefLabel "Wälderdepartement"@de .
-
-<#n245140>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n245100> ;
-    skos:notation "245140" ;
-    skos:prefLabel "Rhein-Mosel-Département"@de .
-
-<#n245160>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n245100> ;
-    skos:notation "245160" ;
-    skos:prefLabel "Département Donnersberg"@de .
-
-<#n245180>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n245100> ;
-    skos:notation "245180" ;
-    skos:prefLabel "Saardepartement"@de .
-
-<#n245300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "245300" ;
-    skos:prefLabel "Rheinbund / 1806-1813"@de .
-
-<#n246100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "246100" ;
-    skos:prefLabel "Rheinprovinz"@de .
-
-<#n246200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "246200" ;
-    skos:prefLabel "Hessen-Darmstadt"@de .
-
-<#n246300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "246300" ;
-    skos:prefLabel "Hessen-Nassau"@de .
-
-<#n246500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "246500" ;
-    skos:prefLabel "Bayerische Pfalz"@de .
-
-<#n246700>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:narrower <#n246720>, <#n246740>, <#n246760> ;
-    skos:notation "246700" ;
-    skos:prefLabel "Kleinere Territorien des 19. Jahrhunderts"@de .
-
-<#n246720>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n246700> ;
-    skos:notation "246720" ;
-    skos:prefLabel "Fürstentum Birkenfeld"@de .
-
-<#n246740>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n246700> ;
-    skos:notation "246740" ;
-    skos:prefLabel "Fürstentum Lichtenberg"@de .
-
-<#n246760>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n246700> ;
-    skos:notation "246760" ;
-    skos:prefLabel "Oberamt Meisenheim"@de .
-
-<#n248000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "248000" ;
-    skos:prefLabel "Rheinland-Pfalz / Geschichte 1945-1947"@de .
-
-<#n248100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "248100" ;
-    skos:prefLabel "Rheinland / Geschichte 1945-"@de .
-
-<#n248300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "248300" ;
-    skos:prefLabel "Rheinhessen / Geschichte 1945-"@de .
-
-<#n248500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "248500" ;
-    skos:prefLabel "Pfalz / Geschichte 1945-"@de .
-
-<#n249100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n240000> ;
-    skos:notation "249100" ;
-    skos:prefLabel "Rheinland-Pfalz / Geschichte 1947-"@de .
-
-<#n260000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n260100>, <#n262000>, <#n263000> ;
-    skos:notation "260000" ;
-    skos:prefLabel "Militär- und Wehrwesen"@de .
-
-<#n260100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n260000> ;
-    skos:notation "260100" ;
-    skos:prefLabel "Militär- und Wehrwesen allgemein"@de .
-
-<#n262000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n260000> ;
-    skos:narrower <#n262010>, <#n262020> ;
-    skos:notation "262000" ;
-    skos:prefLabel "Militär"@de .
-
-<#n262010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262000> ;
-    skos:narrower <#n262011>, <#n262012>, <#n262014>, <#n262016> ;
-    skos:notation "262010" ;
-    skos:prefLabel "Militärbau"@de .
-
-<#n262011>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262010> ;
-    skos:notation "262011" ;
-    skos:prefLabel "Burg"@de .
-
-<#n262012>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262010> ;
-    skos:notation "262012" ;
-    skos:prefLabel "Festung"@de .
-
-<#n262014>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262010> ;
-    skos:notation "262014" ;
-    skos:prefLabel "Schanze"@de .
-
-<#n262016>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262010> ;
-    skos:notation "262016" ;
-    skos:prefLabel "Standort"@de .
-
-<#n262020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262000> ;
-    skos:narrower <#n262022>, <#n262023>, <#n262024>, <#n262025>, <#n262026> ;
-    skos:notation "262020" ;
-    skos:prefLabel "Militär / Ausrüstung"@de .
-
-<#n262022>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262020> ;
-    skos:notation "262022" ;
-    skos:prefLabel "Kriegswaffe"@de .
-
-<#n262023>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262020> ;
-    skos:notation "262023" ;
-    skos:prefLabel "Rüstung"@de .
-
-<#n262024>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262020> ;
-    skos:notation "262024" ;
-    skos:prefLabel "Uniform"@de .
-
-<#n262025>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262020> ;
-    skos:notation "262025" ;
-    skos:prefLabel "Feldzeichen"@de .
-
-<#n262026>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n262020> ;
-    skos:notation "262026" ;
-    skos:prefLabel "Orden / Ehrenzeichen"@de .
-
-<#n263000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n260000> ;
-    skos:narrower <#n263010>, <#n263020>, <#n263030>, <#n263040>, <#n263050>, <#n263060>, <#n263090> ;
-    skos:notation "263000" ;
-    skos:prefLabel "Wehrwesen"@de .
-
-<#n263010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n263000> ;
-    skos:notation "263010" ;
-    skos:prefLabel "Bürgerwehr"@de .
-
-<#n263020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n263000> ;
-    skos:notation "263020" ;
-    skos:prefLabel "Militär / Geschichte Anfänge-1918"@de .
-
-<#n263030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n263000> ;
-    skos:notation "263030" ;
-    skos:prefLabel "Deutschland / Reichswehr"@de .
-
-<#n263040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n263000> ;
-    skos:notation "263040" ;
-    skos:prefLabel "Deutschland / Wehrmacht"@de .
-
-<#n263050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n263000> ;
-    skos:notation "263050" ;
-    skos:prefLabel "Ausländisches Militär"@de .
-
-<#n263060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n263000> ;
-    skos:notation "263060" ;
-    skos:prefLabel "Deutschland / Bundeswehr"@de .
-
-<#n263090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n263000> ;
-    skos:notation "263090" ;
-    skos:prefLabel "Soldat"@de .
-
-<#n400000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n400100>, <#n402000>, <#n402300>, <#n404000>, <#n404300>, <#n406000> ;
-    skos:notation "400000" ;
-    skos:prefLabel "Staat. Politik"@de .
-
-<#n400100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n400000> ;
-    skos:notation "400100" ;
-    skos:prefLabel "Staat. Politik allgemein"@de .
-
-<#n402000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n400000> ;
-    skos:narrower <#n402020>, <#n402030>, <#n402040>, <#n402050>, <#n402060>, <#n402070> ;
-    skos:notation "402000" ;
-    skos:prefLabel "Staatsgrundlage"@de .
-
-<#n402020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402000> ;
-    skos:notation "402020" ;
-    skos:prefLabel "Staatsrecht"@de .
-
-<#n402030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402000> ;
-    skos:notation "402030" ;
-    skos:prefLabel "Staatsangehörigkeit"@de .
-
-<#n402040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402000> ;
-    skos:notation "402040" ;
-    skos:prefLabel "Staatsgebiet"@de .
-
-<#n402050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402000> ;
-    skos:notation "402050" ;
-    skos:prefLabel "Hoheitsrecht"@de .
-
-<#n402060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402000> ;
-    skos:notation "402060" ;
-    skos:prefLabel "Staatsform"@de .
-
-<#n402070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402000> ;
-    skos:notation "402070" ;
-    skos:prefLabel "Föderalismus"@de .
-
-<#n402300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n400000> ;
-    skos:narrower <#n402330>, <#n402340>, <#n402350> ;
-    skos:notation "402300" ;
-    skos:prefLabel "Verfassung"@de .
-
-<#n402330>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402300> ;
-    skos:notation "402330" ;
-    skos:prefLabel "Verfassung / Geschichte"@de .
-
-<#n402340>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402300> ;
-    skos:narrower <#n402344> ;
-    skos:notation "402340" ;
-    skos:prefLabel "Grundrecht"@de .
-
-<#n402344>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402340> ;
-    skos:notation "402344" ;
-    skos:prefLabel "Datenschutz"@de .
-
-<#n402350>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n402300> ;
-    skos:notation "402350" ;
-    skos:prefLabel "Gewaltenteilung"@de .
-
-<#n404000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n400000> ;
-    skos:narrower <#n404030>, <#n404040>, <#n404050>, <#n404060>, <#n404070>, <#n404090> ;
-    skos:notation "404000" ;
-    skos:prefLabel "Politisches System"@de .
-
-<#n404030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404000> ;
-    skos:notation "404030" ;
-    skos:prefLabel "Regierungsbildung"@de .
-
-<#n404040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404000> ;
-    skos:notation "404040" ;
-    skos:prefLabel "Regierungschef"@de .
-
-<#n404050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404000> ;
-    skos:notation "404050" ;
-    skos:prefLabel "Regierung"@de .
-
-<#n404060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404000> ;
-    skos:notation "404060" ;
-    skos:prefLabel "Ministerium"@de .
-
-<#n404070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404000> ;
-    skos:notation "404070" ;
-    skos:prefLabel "Regierungspolitik"@de .
-
-<#n404090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404000> ;
-    skos:notation "404090" ;
-    skos:prefLabel "Landespartnerschaft"@de .
-
-<#n404300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n400000> ;
-    skos:narrower <#n404320>, <#n404340>, <#n404350>, <#n404360>, <#n404380> ;
-    skos:notation "404300" ;
-    skos:prefLabel "Parlament"@de .
-
-<#n404320>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404300> ;
-    skos:notation "404320" ;
-    skos:prefLabel "Parlament / Geschichte"@de .
-
-<#n404340>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404300> ;
-    skos:notation "404340" ;
-    skos:prefLabel "Regierungspartei"@de .
-
-<#n404350>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404300> ;
-    skos:notation "404350" ;
-    skos:prefLabel "Opposition"@de .
-
-<#n404360>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404300> ;
-    skos:narrower <#n404361>, <#n404365> ;
-    skos:notation "404360" ;
-    skos:prefLabel "Parlamentsorganisation"@de .
-
-<#n404361>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404360> ;
-    skos:notation "404361" ;
-    skos:prefLabel "Parlamentsausschuss"@de .
-
-<#n404365>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404360> ;
-    skos:notation "404365" ;
-    skos:prefLabel "Ombudsmann"@de .
-
-<#n404380>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n404300> ;
-    skos:notation "404380" ;
-    skos:prefLabel "Abgeordneter"@de .
-
-<#n406000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n400000> ;
-    skos:narrower <#n406020>, <#n406030>, <#n406040>, <#n406060>, <#n406080>, <#n406100>, <#n406200>, <#n406300> ;
-    skos:notation "406000" ;
-    skos:prefLabel "Politische Willensbildung"@de .
-
-<#n406020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406000> ;
-    skos:notation "406020" ;
-    skos:prefLabel "Öffentlichkeitsarbeit"@de .
-
-<#n406030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406000> ;
-    skos:notation "406030" ;
-    skos:prefLabel "Politische Bildung"@de .
-
-<#n406040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406000> ;
-    skos:notation "406040" ;
-    skos:prefLabel "Öffentliche Meinung"@de .
-
-<#n406060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406000> ;
-    skos:notation "406060" ;
-    skos:prefLabel "Politische Bewegung"@de .
-
-<#n406080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406000> ;
-    skos:notation "406080" ;
-    skos:prefLabel "Parteistiftung"@de .
-
-<#n406100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406000> ;
-    skos:narrower <#n406120>, <#n406130> ;
-    skos:notation "406100" ;
-    skos:prefLabel "Partei. Politikerin. Politiker"@de .
-
-<#n406120>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406100> ;
-    skos:notation "406120" ;
-    skos:prefLabel "Partei"@de .
-
-<#n406130>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406100> ;
-    skos:notation "406130" ;
-    skos:prefLabel "Politikerin. Politiker"@de .
-
-<#n406200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406000> ;
-    skos:narrower <#n406230>, <#n406250>, <#n406270> ;
-    skos:notation "406200" ;
-    skos:prefLabel "Politische Gruppe"@de .
-
-<#n406230>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406200> ;
-    skos:notation "406230" ;
-    skos:prefLabel "Politischer Verein"@de .
-
-<#n406250>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406200> ;
-    skos:notation "406250" ;
-    skos:prefLabel "Bürgerinitiative"@de .
-
-<#n406270>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406200> ;
-    skos:notation "406270" ;
-    skos:prefLabel "Projektgruppe"@de .
-
-<#n406300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406000> ;
-    skos:narrower <#n406310>, <#n406320>, <#n406330>, <#n406340>, <#n406350>, <#n406360>, <#n406370>, <#n406380>, <#n406390> ;
-    skos:notation "406300" ;
-    skos:prefLabel "Wahl"@de .
-
-<#n406310>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406300> ;
-    skos:notation "406310" ;
-    skos:prefLabel "Wahlrecht"@de .
-
-<#n406320>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406300> ;
-    skos:notation "406320" ;
-    skos:prefLabel "Wahlkreiseinteilung"@de .
-
-<#n406330>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406300> ;
-    skos:notation "406330" ;
-    skos:prefLabel "Volksabstimmung"@de .
-
-<#n406340>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406300> ;
-    skos:notation "406340" ;
-    skos:prefLabel "Europawahl"@de .
-
-<#n406350>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406300> ;
-    skos:notation "406350" ;
-    skos:prefLabel "Bundestagswahl"@de .
-
-<#n406360>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406300> ;
-    skos:notation "406360" ;
-    skos:prefLabel "Landtagswahl"@de .
-
-<#n406370>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406300> ;
-    skos:notation "406370" ;
-    skos:prefLabel "Kreistag / Wahl"@de .
-
-<#n406380>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406300> ;
-    skos:notation "406380" ;
-    skos:prefLabel "Bezirkstag / Wahl"@de .
-
-<#n406390>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n406300> ;
-    skos:notation "406390" ;
-    skos:prefLabel "Kommunalwahl"@de .
-
-<#n420000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n420100>, <#n421000>, <#n421400>, <#n422000>, <#n423000>, <#n424000>, <#n425000>, <#n426000>, <#n427000>, <#n428000> ;
-    skos:notation "420000" ;
-    skos:prefLabel "Verwaltung"@de .
-
-<#n420100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:notation "420100" ;
-    skos:prefLabel "Verwaltung allgemein"@de .
-
-<#n421000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:notation "421000" ;
-    skos:prefLabel "Verwaltungsrecht"@de .
-
-<#n421400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:notation "421400" ;
-    skos:prefLabel "Verwaltungskontrolle"@de .
-
-<#n422000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:notation "422000" ;
-    skos:prefLabel "Verwaltung / Geschichte"@de .
-
-<#n423000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:narrower <#n423020>, <#n423030>, <#n423050>, <#n423400>, <#n423600> ;
-    skos:notation "423000" ;
-    skos:prefLabel "Allgemeine Verwaltung"@de .
-
-<#n423020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423000> ;
-    skos:notation "423020" ;
-    skos:prefLabel "Verwaltung / Struktur"@de .
-
-<#n423030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423000> ;
-    skos:notation "423030" ;
-    skos:prefLabel "Behörde / Organisation"@de .
-
-<#n423050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423000> ;
-    skos:notation "423050" ;
-    skos:prefLabel "Behörde / Datenverarbeitung"@de .
-
-<#n423400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423000> ;
-    skos:narrower <#n423420>, <#n423430>, <#n423440> ;
-    skos:notation "423400" ;
-    skos:prefLabel "Verwaltungsreform"@de .
-
-<#n423420>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423400> ;
-    skos:notation "423420" ;
-    skos:prefLabel "Länderneugliederung"@de .
-
-<#n423430>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423400> ;
-    skos:notation "423430" ;
-    skos:prefLabel "Gebietsreform"@de .
-
-<#n423440>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423400> ;
-    skos:notation "423440" ;
-    skos:prefLabel "Funktionalreform"@de .
-
-<#n423600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423000> ;
-    skos:narrower <#n423610>, <#n423620>, <#n423640> ;
-    skos:notation "423600" ;
-    skos:prefLabel "Öffentlicher Dienst"@de .
-
-<#n423610>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423600> ;
-    skos:notation "423610" ;
-    skos:prefLabel "Dienstrecht"@de .
-
-<#n423620>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423600> ;
-    skos:notation "423620" ;
-    skos:prefLabel "Personalwesen"@de .
-
-<#n423640>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n423600> ;
-    skos:notation "423640" ;
-    skos:prefLabel "Beamter"@de .
-
-<#n424000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:narrower <#n424020>, <#n424030>, <#n424040>, <#n424050>, <#n424060> ;
-    skos:notation "424000" ;
-    skos:prefLabel "Öffentlicher Haushalt"@de .
-
-<#n424020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424000> ;
-    skos:narrower <#n424021>, <#n424022>, <#n424024>, <#n424026>, <#n424028> ;
-    skos:notation "424020" ;
-    skos:prefLabel "Finanzverwaltung"@de .
-
-<#n424021>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424020> ;
-    skos:notation "424021" ;
-    skos:prefLabel "Finanzamt"@de .
-
-<#n424022>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424020> ;
-    skos:notation "424022" ;
-    skos:prefLabel "Finanzausgleich"@de .
-
-<#n424024>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424020> ;
-    skos:notation "424024" ;
-    skos:prefLabel "Finanzreform"@de .
-
-<#n424026>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424020> ;
-    skos:notation "424026" ;
-    skos:prefLabel "Öffentliche Beschaffung"@de .
-
-<#n424028>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424020> ;
-    skos:notation "424028" ;
-    skos:prefLabel "Rechnungshof"@de .
-
-<#n424030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424000> ;
-    skos:notation "424030" ;
-    skos:prefLabel "Abgabe"@de .
-
-<#n424040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424000> ;
-    skos:narrower <#n424042> ;
-    skos:notation "424040" ;
-    skos:prefLabel "Steuer"@de .
-
-<#n424042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424040> ;
-    skos:notation "424042" ;
-    skos:prefLabel "Steuerberatung"@de .
-
-<#n424050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424000> ;
-    skos:notation "424050" ;
-    skos:prefLabel "Gebühr"@de .
-
-<#n424060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n424000> ;
-    skos:notation "424060" ;
-    skos:prefLabel "Zoll"@de .
-
-<#n425000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:narrower <#n425020>, <#n425030>, <#n425040>, <#n425050>, <#n425200> ;
-    skos:notation "425000" ;
-    skos:prefLabel "Bezirksverwaltung"@de .
-
-<#n425020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n425000> ;
-    skos:notation "425020" ;
-    skos:prefLabel "Regierungspräsident"@de .
-
-<#n425030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n425000> ;
-    skos:notation "425030" ;
-    skos:prefLabel "Regierungsbezirk Koblenz"@de .
-
-<#n425040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n425000> ;
-    skos:notation "425040" ;
-    skos:prefLabel "Regierungsbezirk Trier"@de .
-
-<#n425050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n425000> ;
-    skos:narrower <#n425052> ;
-    skos:notation "425050" ;
-    skos:prefLabel "Regierungsbezirk Rheinhessen-Pfalz"@de .
-
-<#n425052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n425050> ;
-    skos:notation "425052" ;
-    skos:prefLabel "Bezirksverband Pfalz"@de .
-
-<#n425200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n425000> ;
-    skos:narrower <#n425220>, <#n425230>, <#n425290> ;
-    skos:notation "425200" ;
-    skos:prefLabel "Kreisverwaltung"@de .
-
-<#n425220>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n425200> ;
-    skos:notation "425220" ;
-    skos:prefLabel "Kreisrecht"@de .
-
-<#n425230>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n425200> ;
-    skos:notation "425230" ;
-    skos:prefLabel "Kreisparlament"@de .
-
-<#n425290>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n425200> ;
-    skos:notation "425290" ;
-    skos:prefLabel "Kreispartnerschaft"@de .
-
-<#n426000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:narrower <#n426020>, <#n426030>, <#n426040>, <#n426050>, <#n426060>, <#n426070>, <#n426090> ;
-    skos:notation "426000" ;
-    skos:prefLabel "Gemeindeverwaltung"@de .
-
-<#n426020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n426000> ;
-    skos:notation "426020" ;
-    skos:prefLabel "Ortsrecht"@de .
-
-<#n426030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n426000> ;
-    skos:notation "426030" ;
-    skos:prefLabel "Gemeinderat"@de .
-
-<#n426040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n426000> ;
-    skos:notation "426040" ;
-    skos:prefLabel "Kommunale Selbstverwaltung"@de .
-
-<#n426050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n426000> ;
-    skos:notation "426050" ;
-    skos:prefLabel "Auftragsverwaltung"@de .
-
-<#n426060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n426000> ;
-    skos:notation "426060" ;
-    skos:prefLabel "Kommunaler Spitzenverband"@de .
-
-<#n426070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n426000> ;
-    skos:notation "426070" ;
-    skos:prefLabel "Verbandsgemeinde"@de .
-
-<#n426090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n426000> ;
-    skos:notation "426090" ;
-    skos:prefLabel "Kommunale Partnerschaft"@de .
-
-<#n427000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:narrower <#n427010>, <#n427020>, <#n427030>, <#n427040> ;
-    skos:notation "427000" ;
-    skos:prefLabel "Obere Landesbehörde"@de .
-
-<#n427010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n427000> ;
-    skos:notation "427010" ;
-    skos:prefLabel "Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Nord"@de .
-
-<#n427020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n427000> ;
-    skos:notation "427020" ;
-    skos:prefLabel "Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Süd"@de .
-
-<#n427030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n427000> ;
-    skos:notation "427030" ;
-    skos:prefLabel "Rheinland-Pfalz / Aufsichts- und Dienstleistungsdirektion"@de .
-
-<#n427040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n427000> ;
-    skos:notation "427040" ;
-    skos:prefLabel "Rheinland-Pfalz / Landesuntersuchungsamt"@de .
-
-<#n428000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n420000> ;
-    skos:narrower <#n428020>, <#n428030>, <#n428040>, <#n428050>, <#n428060>, <#n428070>, <#n428080> ;
-    skos:notation "428000" ;
-    skos:prefLabel "Sicherheit und Ordnung"@de .
-
-<#n428020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428000> ;
-    skos:notation "428020" ;
-    skos:prefLabel "Ordnungsrecht"@de .
-
-<#n428030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428000> ;
-    skos:narrower <#n428032>, <#n428033> ;
-    skos:notation "428030" ;
-    skos:prefLabel "Polizei"@de .
-
-<#n428032>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428030> ;
-    skos:notation "428032" ;
-    skos:prefLabel "Polizeiorganisation"@de .
-
-<#n428033>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428030> ;
-    skos:notation "428033" ;
-    skos:prefLabel "Polizei / Ausrüstung"@de .
-
-<#n428040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428000> ;
-    skos:notation "428040" ;
-    skos:prefLabel "Zivilschutz"@de .
-
-<#n428050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428000> ;
-    skos:narrower <#n428052>, <#n428054> ;
-    skos:notation "428050" ;
-    skos:prefLabel "Staatsschutz"@de .
-
-<#n428052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428050> ;
-    skos:notation "428052" ;
-    skos:prefLabel "Grenzschutz"@de .
-
-<#n428054>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428050> ;
-    skos:notation "428054" ;
-    skos:prefLabel "Verfassungsschutz"@de .
-
-<#n428060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428000> ;
-    skos:notation "428060" ;
-    skos:prefLabel "Personenstandswesen"@de .
-
-<#n428070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428000> ;
-    skos:narrower <#n428072>, <#n428074>, <#n428076>, <#n428078> ;
-    skos:notation "428070" ;
-    skos:prefLabel "Sicherheitsbehörde"@de .
-
-<#n428072>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428070> ;
-    skos:notation "428072" ;
-    skos:prefLabel "Technischer Überwachungsverein"@de .
-
-<#n428074>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428070> ;
-    skos:notation "428074" ;
-    skos:prefLabel "Feuerwehr"@de .
-
-<#n428076>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428070> ;
-    skos:notation "428076" ;
-    skos:prefLabel "Rettungswesen"@de .
-
-<#n428078>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428070> ;
-    skos:notation "428078" ;
-    skos:prefLabel "Katastrophe. Unfall"@de .
-
-<#n428080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n428000> ;
-    skos:notation "428080" ;
-    skos:prefLabel "Friedhofsordnung"@de .
-
-<#n440000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n440100>, <#n442000>, <#n443000>, <#n444000>, <#n446000>, <#n447000>, <#n448000> ;
-    skos:notation "440000" ;
-    skos:prefLabel "Recht"@de .
-
-<#n440100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n440000> ;
-    skos:notation "440100" ;
-    skos:prefLabel "Recht allgemein"@de .
-
-<#n442000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n440000> ;
-    skos:narrower <#n442050> ;
-    skos:notation "442000" ;
-    skos:prefLabel "Recht / Geschichte"@de .
-
-<#n442050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n442000> ;
-    skos:notation "442050" ;
-    skos:prefLabel "Recht / Geschichte / Quelle"@de .
-
-<#n443000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n440000> ;
-    skos:notation "443000" ;
-    skos:prefLabel "Privatrecht"@de .
-
-<#n444000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n440000> ;
-    skos:narrower <#n444030>, <#n444050>, <#n444070> ;
-    skos:notation "444000" ;
-    skos:prefLabel "Strafrecht"@de .
-
-<#n444030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n444000> ;
-    skos:notation "444030" ;
-    skos:prefLabel "Strafvollzug"@de .
-
-<#n444050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n444000> ;
-    skos:notation "444050" ;
-    skos:prefLabel "Kriminalität"@de .
-
-<#n444070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n444000> ;
-    skos:notation "444070" ;
-    skos:prefLabel "Kriminalfall"@de .
-
-<#n446000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n440000> ;
-    skos:narrower <#n446010>, <#n446030>, <#n446050>, <#n446060>, <#n446070>, <#n446080> ;
-    skos:notation "446000" ;
-    skos:prefLabel "Gerichtsbarkeit"@de .
-
-<#n446010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n446000> ;
-    skos:notation "446010" ;
-    skos:prefLabel "Verfassungsgerichtsbarkeit"@de .
-
-<#n446030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n446000> ;
-    skos:narrower <#n446032>, <#n446034> ;
-    skos:notation "446030" ;
-    skos:prefLabel "Ordentliche Gerichtsbarkeit"@de .
-
-<#n446032>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n446030> ;
-    skos:notation "446032" ;
-    skos:prefLabel "Strafgerichtsbarkeit"@de .
-
-<#n446034>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n446030> ;
-    skos:notation "446034" ;
-    skos:prefLabel "Zivilgerichtsbarkeit"@de .
-
-<#n446050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n446000> ;
-    skos:notation "446050" ;
-    skos:prefLabel "Verwaltungsgerichtsbarkeit"@de .
-
-<#n446060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n446000> ;
-    skos:notation "446060" ;
-    skos:prefLabel "Finanzgerichtsbarkeit"@de .
-
-<#n446070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n446000> ;
-    skos:notation "446070" ;
-    skos:prefLabel "Arbeitsgerichtsbarkeit"@de .
-
-<#n446080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n446000> ;
-    skos:notation "446080" ;
-    skos:prefLabel "Sozialgerichtsbarkeit"@de .
-
-<#n447000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n440000> ;
-    skos:notation "447000" ;
-    skos:prefLabel "Rechtsprechung"@de .
-
-<#n448000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n440000> ;
-    skos:notation "448000" ;
-    skos:prefLabel "Rechtspflege"@de .
-
-<#n500000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n500100>, <#n502000>, <#n503000>, <#n503200>, <#n503400>, <#n503600> ;
-    skos:notation "500000" ;
-    skos:prefLabel "Bevölkerung"@de .
-
-<#n500100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n500000> ;
-    skos:notation "500100" ;
-    skos:prefLabel "Bevölkerung allgemein"@de .
-
-<#n502000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n500000> ;
-    skos:notation "502000" ;
-    skos:prefLabel "Bevölkerung / Geschichte"@de .
-
-<#n503000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n500000> ;
-    skos:narrower <#n503020>, <#n503030>, <#n503040>, <#n503050>, <#n503060>, <#n503070>, <#n503080>, <#n503090> ;
-    skos:notation "503000" ;
-    skos:prefLabel "Bevölkerungsstruktur"@de .
-
-<#n503020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503000> ;
-    skos:notation "503020" ;
-    skos:prefLabel "Altersstruktur"@de .
-
-<#n503030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503000> ;
-    skos:notation "503030" ;
-    skos:prefLabel "Geschlechtsverhältnis"@de .
-
-<#n503040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503000> ;
-    skos:notation "503040" ;
-    skos:prefLabel "Volkszählung"@de .
-
-<#n503050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503000> ;
-    skos:notation "503050" ;
-    skos:prefLabel "Einwohnerverzeichnis"@de .
-
-<#n503060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503000> ;
-    skos:notation "503060" ;
-    skos:prefLabel "Haushaltsgrösse"@de .
-
-<#n503070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503000> ;
-    skos:notation "503070" ;
-    skos:prefLabel "Wohnstandard"@de .
-
-<#n503080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503000> ;
-    skos:notation "503080" ;
-    skos:prefLabel "Einkommensstatistik"@de .
-
-<#n503090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503000> ;
-    skos:notation "503090" ;
-    skos:prefLabel "Denomination / Religion"@de .
-
-<#n503200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n500000> ;
-    skos:narrower <#n503220>, <#n503230>, <#n503240>, <#n503250>, <#n503260> ;
-    skos:notation "503200" ;
-    skos:prefLabel "Bevölkerungsentwicklung"@de .
-
-<#n503220>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503200> ;
-    skos:notation "503220" ;
-    skos:prefLabel "Bevölkerungspolitik"@de .
-
-<#n503230>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503200> ;
-    skos:notation "503230" ;
-    skos:prefLabel "Geburt / Statistik"@de .
-
-<#n503240>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503200> ;
-    skos:notation "503240" ;
-    skos:prefLabel "Heirat / Statistik"@de .
-
-<#n503250>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503200> ;
-    skos:notation "503250" ;
-    skos:prefLabel "Tod / Statistik"@de .
-
-<#n503260>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503200> ;
-    skos:notation "503260" ;
-    skos:prefLabel "Bevölkerungsentwicklung / Prognose"@de .
-
-<#n503400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n500000> ;
-    skos:narrower <#n503420>, <#n503430>, <#n503440> ;
-    skos:notation "503400" ;
-    skos:prefLabel "Migration"@de .
-
-<#n503420>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503400> ;
-    skos:narrower <#n503424> ;
-    skos:notation "503420" ;
-    skos:prefLabel "Binnenwanderung"@de .
-
-<#n503424>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503420> ;
-    skos:notation "503424" ;
-    skos:prefLabel "Berufspendlerin. Berufspendler"@de .
-
-<#n503430>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503400> ;
-    skos:notation "503430" ;
-    skos:prefLabel "Auswanderung"@de .
-
-<#n503440>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n503400> ;
-    skos:notation "503440" ;
-    skos:prefLabel "Einwanderung"@de .
-
-<#n503600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n500000> ;
-    skos:notation "503600" ;
-    skos:prefLabel "Bevölkerungsdichte"@de .
-
-<#n520000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n520100>, <#n521000>, <#n521200>, <#n521400>, <#n522000>, <#n523000>, <#n524000> ;
-    skos:notation "520000" ;
-    skos:prefLabel "Sozialwesen"@de .
-
-<#n520100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n520000> ;
-    skos:notation "520100" ;
-    skos:prefLabel "Sozialwesen allgemein"@de .
-
-<#n521000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n520000> ;
-    skos:notation "521000" ;
-    skos:prefLabel "Sozialpolitik"@de .
-
-<#n521200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n520000> ;
-    skos:notation "521200" ;
-    skos:prefLabel "Sozialrecht"@de .
-
-<#n521400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n520000> ;
-    skos:narrower <#n521410>, <#n521420>, <#n521430>, <#n521450> ;
-    skos:notation "521400" ;
-    skos:prefLabel "Sozialversicherung"@de .
-
-<#n521410>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n521400> ;
-    skos:notation "521410" ;
-    skos:prefLabel "Krankenversicherung"@de .
-
-<#n521420>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n521400> ;
-    skos:notation "521420" ;
-    skos:prefLabel "Unfallversicherung"@de .
-
-<#n521430>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n521400> ;
-    skos:notation "521430" ;
-    skos:prefLabel "Rentenversicherung"@de .
-
-<#n521450>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n521400> ;
-    skos:notation "521450" ;
-    skos:prefLabel "Arbeitslosenversicherung"@de .
-
-<#n522000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n520000> ;
-    skos:narrower <#n522010>, <#n522020>, <#n522030>, <#n522050> ;
-    skos:notation "522000" ;
-    skos:prefLabel "Sozialhilfe / Kostenträger"@de .
-
-<#n522010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n522000> ;
-    skos:notation "522010" ;
-    skos:prefLabel "Öffentlicher Träger"@de .
-
-<#n522020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n522000> ;
-    skos:notation "522020" ;
-    skos:prefLabel "Kirchlicher Träger"@de .
-
-<#n522030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n522000> ;
-    skos:notation "522030" ;
-    skos:prefLabel "Privater Träger"@de .
-
-<#n522050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n522000> ;
-    skos:notation "522050" ;
-    skos:prefLabel "Karitative Stiftung"@de .
-
-<#n523000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n520000> ;
-    skos:narrower <#n523010>, <#n523030>, <#n523040>, <#n523050>, <#n523060>, <#n523070>, <#n523075>, <#n523080>, <#n523090> ;
-    skos:notation "523000" ;
-    skos:prefLabel "Sozialhilfe"@de .
-
-<#n523010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523000> ;
-    skos:notation "523010" ;
-    skos:prefLabel "Arbeitslosenunterstützung"@de .
-
-<#n523030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523000> ;
-    skos:narrower <#n523035> ;
-    skos:notation "523030" ;
-    skos:prefLabel "Fürsorge"@de .
-
-<#n523035>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523030> ;
-    skos:notation "523035" ;
-    skos:prefLabel "Obdachlosenhilfe"@de .
-
-<#n523040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523000> ;
-    skos:notation "523040" ;
-    skos:prefLabel "Unfallfürsorge"@de .
-
-<#n523050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523000> ;
-    skos:notation "523050" ;
-    skos:prefLabel "Krankenfürsorge"@de .
-
-<#n523060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523000> ;
-    skos:notation "523060" ;
-    skos:prefLabel "Behindertenhilfe"@de .
-
-<#n523070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523000> ;
-    skos:notation "523070" ;
-    skos:prefLabel "Kriegsopferfürsorge"@de .
-
-<#n523075>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523000> ;
-    skos:notation "523075" ;
-    skos:prefLabel "Gefangenenfürsorge"@de .
-
-<#n523080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523000> ;
-    skos:notation "523080" ;
-    skos:prefLabel "Waisenfürsorge"@de .
-
-<#n523090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n523000> ;
-    skos:notation "523090" ;
-    skos:prefLabel "Altenhilfe"@de .
-
-<#n524000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n520000> ;
-    skos:narrower <#n524010>, <#n524050>, <#n524060>, <#n524070>, <#n524080> ;
-    skos:notation "524000" ;
-    skos:prefLabel "Sozialpädagogik"@de .
-
-<#n524010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n524000> ;
-    skos:notation "524010" ;
-    skos:prefLabel "Jugendhilfe"@de .
-
-<#n524050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n524000> ;
-    skos:notation "524050" ;
-    skos:prefLabel "Bewährungshilfe"@de .
-
-<#n524060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n524000> ;
-    skos:notation "524060" ;
-    skos:prefLabel "Erziehungsberatung"@de .
-
-<#n524070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n524000> ;
-    skos:notation "524070" ;
-    skos:prefLabel "Familienfürsorge"@de .
-
-<#n524080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n524000> ;
-    skos:notation "524080" ;
-    skos:prefLabel "Berufsbetreuung"@de .
-
-<#n530000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n530100>, <#n532000>, <#n533000>, <#n534000>, <#n535000>, <#n537000> ;
-    skos:notation "530000" ;
-    skos:prefLabel "Gesundheitswesen"@de .
-
-<#n530100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n530000> ;
-    skos:notation "530100" ;
-    skos:prefLabel "Gesundheitswesen allgemein"@de .
-
-<#n532000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n530000> ;
-    skos:narrower <#n532010>, <#n532030>, <#n532050>, <#n532070> ;
-    skos:notation "532000" ;
-    skos:prefLabel "Medizin"@de .
-
-<#n532010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n532000> ;
-    skos:notation "532010" ;
-    skos:prefLabel "Medizin / Geschichte"@de .
-
-<#n532030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n532000> ;
-    skos:notation "532030" ;
-    skos:prefLabel "Medizinische Versorgung"@de .
-
-<#n532050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n532000> ;
-    skos:notation "532050" ;
-    skos:prefLabel "Ärztin. Arzt. Heilberuf"@de .
-
-<#n532070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n532000> ;
-    skos:notation "532070" ;
-    skos:prefLabel "Gesundheitsvorsorge"@de .
-
-<#n533000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n530000> ;
-    skos:notation "533000" ;
-    skos:prefLabel "Apotheke"@de .
-
-<#n534000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n530000> ;
-    skos:narrower <#n534010>, <#n534020>, <#n534030>, <#n534050>, <#n534060>, <#n534080> ;
-    skos:notation "534000" ;
-    skos:prefLabel "Krankenversorgung"@de .
-
-<#n534010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n534000> ;
-    skos:notation "534010" ;
-    skos:prefLabel "Krankenpflege"@de .
-
-<#n534020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n534000> ;
-    skos:notation "534020" ;
-    skos:prefLabel "Krankenpflege / Beruf"@de .
-
-<#n534030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n534000> ;
-    skos:notation "534030" ;
-    skos:prefLabel "Krankenhaus"@de .
-
-<#n534050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n534000> ;
-    skos:notation "534050" ;
-    skos:prefLabel "Sanatorium"@de .
-
-<#n534060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n534000> ;
-    skos:notation "534060" ;
-    skos:prefLabel "Suchtkrankenhilfe"@de .
-
-<#n534080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n534000> ;
-    skos:notation "534080" ;
-    skos:prefLabel "Psychiatrie"@de .
-
-<#n535000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n530000> ;
-    skos:notation "535000" ;
-    skos:prefLabel "Hygiene"@de .
-
-<#n537000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n530000> ;
-    skos:notation "537000" ;
-    skos:prefLabel "Veterinärwesen"@de .
-
-<#n540000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n540100>, <#n541000>, <#n541500>, <#n542000>, <#n543000>, <#n543200>, <#n543400>, <#n543600>, <#n543800>, <#n544000>, <#n544200>, <#n544300>, <#n544310>, <#n544400>, <#n544600>, <#n545000>, <#n546000>, <#n547000>, <#n548000>, <#n548200>, <#n548300>, <#n548400>, <#n548600>, <#n548800> ;
-    skos:notation "540000" ;
-    skos:prefLabel "Wirtschaft"@de .
-
-<#n540100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "540100" ;
-    skos:prefLabel "Wirtschaft allgemein"@de .
-
-<#n541000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "541000" ;
-    skos:prefLabel "Wirtschaftspolitik"@de .
-
-<#n541500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "541500" ;
-    skos:prefLabel "Wirtschaftsrecht"@de .
-
-<#n542000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "542000" ;
-    skos:prefLabel "Wirtschaft / Geschichte"@de .
-
-<#n543000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n543010>, <#n543040>, <#n543060>, <#n543080> ;
-    skos:notation "543000" ;
-    skos:prefLabel "Wirtschaftsstruktur"@de .
-
-<#n543010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543000> ;
-    skos:notation "543010" ;
-    skos:prefLabel "Wirtschaftsförderung"@de .
-
-<#n543040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543000> ;
-    skos:notation "543040" ;
-    skos:prefLabel "Bruttoinlandsprodukt"@de .
-
-<#n543060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543000> ;
-    skos:notation "543060" ;
-    skos:prefLabel "Außenwirtschaft"@de .
-
-<#n543080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543000> ;
-    skos:notation "543080" ;
-    skos:prefLabel "Wirtschaftsstatistik"@de .
-
-<#n543200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "543200" ;
-    skos:prefLabel "Wirtschaftsverfassung"@de .
-
-<#n543400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n543430>, <#n543440>, <#n543460>, <#n543480> ;
-    skos:notation "543400" ;
-    skos:prefLabel "Wirtschaftsverband"@de .
-
-<#n543430>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543400> ;
-    skos:notation "543430" ;
-    skos:prefLabel "Industrie- und Handelskammer"@de .
-
-<#n543440>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543400> ;
-    skos:notation "543440" ;
-    skos:prefLabel "Verbraucherverband"@de .
-
-<#n543460>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543400> ;
-    skos:notation "543460" ;
-    skos:prefLabel "Arbeitgeberverband"@de .
-
-<#n543480>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543400> ;
-    skos:notation "543480" ;
-    skos:prefLabel "Gewerkschaft"@de .
-
-<#n543600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n543620>, <#n543630>, <#n543640>, <#n543660>, <#n543680> ;
-    skos:notation "543600" ;
-    skos:prefLabel "Arbeitsmarkt"@de .
-
-<#n543620>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543600> ;
-    skos:notation "543620" ;
-    skos:prefLabel "Unternehmerin. Unternehmer"@de .
-
-<#n543630>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543600> ;
-    skos:notation "543630" ;
-    skos:prefLabel "Arbeitnehmerin. Arbeitnehmer"@de .
-
-<#n543640>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543600> ;
-    skos:notation "543640" ;
-    skos:prefLabel "Freier Beruf"@de .
-
-<#n543660>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543600> ;
-    skos:notation "543660" ;
-    skos:prefLabel "Lohn"@de .
-
-<#n543680>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n543600> ;
-    skos:notation "543680" ;
-    skos:prefLabel "Arbeitslosigkeit"@de .
-
-<#n543800>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "543800" ;
-    skos:prefLabel "Marketing"@de .
-
-<#n544000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n544010>, <#n544020>, <#n544030>, <#n544040>, <#n544050>, <#n544060>, <#n544090> ;
-    skos:notation "544000" ;
-    skos:prefLabel "Landwirtschaft"@de .
-
-<#n544010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544000> ;
-    skos:notation "544010" ;
-    skos:prefLabel "Agrarpolitik"@de .
-
-<#n544020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544000> ;
-    skos:notation "544020" ;
-    skos:prefLabel "Landwirtschaft / Geschichte"@de .
-
-<#n544030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544000> ;
-    skos:notation "544030" ;
-    skos:prefLabel "Bauernhof / Geschichte"@de .
-
-<#n544040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544000> ;
-    skos:notation "544040" ;
-    skos:prefLabel "Flurform"@de .
-
-<#n544050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544000> ;
-    skos:narrower <#n544052>, <#n544054>, <#n544056> ;
-    skos:notation "544050" ;
-    skos:prefLabel "Landwirtschaft / Beruf"@de .
-
-<#n544052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544050> ;
-    skos:notation "544052" ;
-    skos:prefLabel "Bäuerin. Bauer"@de .
-
-<#n544054>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544050> ;
-    skos:notation "544054" ;
-    skos:prefLabel "Landfrau"@de .
-
-<#n544056>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544050> ;
-    skos:notation "544056" ;
-    skos:prefLabel "Landarbeiterin. Landarbeiter"@de .
-
-<#n544060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544000> ;
-    skos:notation "544060" ;
-    skos:prefLabel "Landwirtschaftliche Betriebslehre"@de .
-
-<#n544090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544000> ;
-    skos:notation "544090" ;
-    skos:prefLabel "Landwirtschaftsgenossenschaft"@de .
-
-<#n544200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n544220>, <#n544230>, <#n544240>, <#n544250>, <#n544280> ;
-    skos:notation "544200" ;
-    skos:prefLabel "Agrarproduktion"@de .
-
-<#n544220>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544200> ;
-    skos:notation "544220" ;
-    skos:prefLabel "Ackerbau"@de .
-
-<#n544230>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544200> ;
-    skos:notation "544230" ;
-    skos:prefLabel "Grünlandwirtschaft"@de .
-
-<#n544240>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544200> ;
-    skos:narrower <#n544245> ;
-    skos:notation "544240" ;
-    skos:prefLabel "Gartenbau"@de .
-
-<#n544245>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544240> ;
-    skos:notation "544245" ;
-    skos:prefLabel "Baumschule"@de .
-
-<#n544250>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544200> ;
-    skos:notation "544250" ;
-    skos:prefLabel "Obstbau"@de .
-
-<#n544280>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544200> ;
-    skos:notation "544280" ;
-    skos:prefLabel "Tierzucht"@de .
-
-<#n544300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "544300" ;
-    skos:prefLabel "Weinbau"@de .
-
-<#n544310>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n544320>, <#n544340>, <#n544360> ;
-    skos:notation "544310" ;
-    skos:prefLabel "Weinbau / Geschichte"@de .
-
-<#n544320>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544310> ;
-    skos:narrower <#n544322>, <#n544325> ;
-    skos:notation "544320" ;
-    skos:prefLabel "Weinbaugebiet"@de .
-
-<#n544322>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544320> ;
-    skos:notation "544322" ;
-    skos:prefLabel "Großlage"@de .
-
-<#n544325>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544320> ;
-    skos:notation "544325" ;
-    skos:prefLabel "Weingut"@de .
-
-<#n544340>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544310> ;
-    skos:narrower <#n544341>, <#n544344> ;
-    skos:notation "544340" ;
-    skos:prefLabel "Weinherstellung"@de .
-
-<#n544341>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544340> ;
-    skos:notation "544341" ;
-    skos:prefLabel "Schaumweinherstellung"@de .
-
-<#n544344>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544340> ;
-    skos:notation "544344" ;
-    skos:prefLabel "Branntweinherstellung"@de .
-
-<#n544360>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544310> ;
-    skos:narrower <#n544361> ;
-    skos:notation "544360" ;
-    skos:prefLabel "Weinhandel"@de .
-
-<#n544361>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544360> ;
-    skos:notation "544361" ;
-    skos:prefLabel "Schaumwein / Handel"@de .
-
-<#n544400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n544410>, <#n544420>, <#n544440>, <#n544450>, <#n544460>, <#n544490> ;
-    skos:notation "544400" ;
-    skos:prefLabel "Forstwirtschaft"@de .
-
-<#n544410>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544400> ;
-    skos:notation "544410" ;
-    skos:prefLabel "Forstrecht"@de .
-
-<#n544420>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544400> ;
-    skos:notation "544420" ;
-    skos:prefLabel "Forstwirtschaft / Geschichte"@de .
-
-<#n544440>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544400> ;
-    skos:notation "544440" ;
-    skos:prefLabel "Forstproduktion"@de .
-
-<#n544450>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544400> ;
-    skos:notation "544450" ;
-    skos:prefLabel "Baumart"@de .
-
-<#n544460>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544400> ;
-    skos:notation "544460" ;
-    skos:prefLabel "Forst"@de .
-
-<#n544490>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544400> ;
-    skos:notation "544490" ;
-    skos:prefLabel "Försterin. Förster"@de .
-
-<#n544600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n544610>, <#n544620>, <#n544640>, <#n544650>, <#n544660>, <#n544670> ;
-    skos:notation "544600" ;
-    skos:prefLabel "Jagd. Fischfang"@de .
-
-<#n544610>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544600> ;
-    skos:notation "544610" ;
-    skos:prefLabel "Jagd"@de .
-
-<#n544620>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544600> ;
-    skos:notation "544620" ;
-    skos:prefLabel "Jagdrecht"@de .
-
-<#n544640>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544600> ;
-    skos:notation "544640" ;
-    skos:prefLabel "Wild"@de .
-
-<#n544650>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544600> ;
-    skos:notation "544650" ;
-    skos:prefLabel "Fischfang"@de .
-
-<#n544660>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544600> ;
-    skos:notation "544660" ;
-    skos:prefLabel "Fischereirecht"@de .
-
-<#n544670>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n544600> ;
-    skos:notation "544670" ;
-    skos:prefLabel "Fischzucht"@de .
-
-<#n545000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n545010>, <#n545020>, <#n545030>, <#n545040>, <#n545050>, <#n545060>, <#n545070>, <#n545080> ;
-    skos:notation "545000" ;
-    skos:prefLabel "Bergbau"@de .
-
-<#n545010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n545000> ;
-    skos:notation "545010" ;
-    skos:prefLabel "Bergrecht"@de .
-
-<#n545020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n545000> ;
-    skos:notation "545020" ;
-    skos:prefLabel "Bergbau / Geschichte"@de .
-
-<#n545030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n545000> ;
-    skos:notation "545030" ;
-    skos:prefLabel "Kohlenbergbau"@de .
-
-<#n545040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n545000> ;
-    skos:notation "545040" ;
-    skos:prefLabel "Gesteinsabbau"@de .
-
-<#n545050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n545000> ;
-    skos:notation "545050" ;
-    skos:prefLabel "Erzbergbau"@de .
-
-<#n545060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n545000> ;
-    skos:notation "545060" ;
-    skos:prefLabel "Salzbergbau. Kalibergbau"@de .
-
-<#n545070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n545000> ;
-    skos:notation "545070" ;
-    skos:prefLabel "Erdöl"@de .
-
-<#n545080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n545000> ;
-    skos:notation "545080" ;
-    skos:prefLabel "Erdgas"@de .
-
-<#n546000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n546020>, <#n546040>, <#n546060> ;
-    skos:notation "546000" ;
-    skos:prefLabel "Energiewirtschaft"@de .
-
-<#n546020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n546000> ;
-    skos:narrower <#n546022>, <#n546024>, <#n546026>, <#n546028> ;
-    skos:notation "546020" ;
-    skos:prefLabel "Elektrizitätsversorgung"@de .
-
-<#n546022>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n546020> ;
-    skos:notation "546022" ;
-    skos:prefLabel "Wasserkraftwerk"@de .
-
-<#n546024>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n546020> ;
-    skos:notation "546024" ;
-    skos:prefLabel "Wärmekraftwerk"@de .
-
-<#n546026>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n546020> ;
-    skos:notation "546026" ;
-    skos:prefLabel "Kernkraftwerk"@de .
-
-<#n546028>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n546020> ;
-    skos:notation "546028" ;
-    skos:prefLabel "Alternative Energiequelle"@de .
-
-<#n546040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n546000> ;
-    skos:notation "546040" ;
-    skos:prefLabel "Gasversorgung"@de .
-
-<#n546060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n546000> ;
-    skos:notation "546060" ;
-    skos:prefLabel "Verbundwirtschaft"@de .
-
-<#n547000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n547020>, <#n547030>, <#n547040>, <#n547400>, <#n547600> ;
-    skos:notation "547000" ;
-    skos:prefLabel "Handwerk"@de .
-
-<#n547020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547000> ;
-    skos:notation "547020" ;
-    skos:prefLabel "Handwerk / Geschichte"@de .
-
-<#n547030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547000> ;
-    skos:narrower <#n547035> ;
-    skos:notation "547030" ;
-    skos:prefLabel "Handwerk / Beruf"@de .
-
-<#n547035>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547030> ;
-    skos:notation "547035" ;
-    skos:prefLabel "Handwerksbetrieb"@de .
-
-<#n547040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547000> ;
-    skos:narrower <#n547042>, <#n547044> ;
-    skos:notation "547040" ;
-    skos:prefLabel "Handwerksorganisation"@de .
-
-<#n547042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547040> ;
-    skos:notation "547042" ;
-    skos:prefLabel "Handwerkskammer"@de .
-
-<#n547044>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547040> ;
-    skos:notation "547044" ;
-    skos:prefLabel "Innung"@de .
-
-<#n547400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547000> ;
-    skos:narrower <#n547420>, <#n547440>, <#n547460> ;
-    skos:notation "547400" ;
-    skos:prefLabel "Industrie"@de .
-
-<#n547420>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547400> ;
-    skos:notation "547420" ;
-    skos:prefLabel "Industrie / Geschichte"@de .
-
-<#n547440>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547400> ;
-    skos:notation "547440" ;
-    skos:prefLabel "Industriezweig"@de .
-
-<#n547460>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547400> ;
-    skos:notation "547460" ;
-    skos:prefLabel "Industriebetrieb"@de .
-
-<#n547600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n547000> ;
-    skos:notation "547600" ;
-    skos:prefLabel "Technik. Technologie"@de .
-
-<#n548000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n548010>, <#n548020>, <#n548030>, <#n548040>, <#n548050>, <#n548060>, <#n548090> ;
-    skos:notation "548000" ;
-    skos:prefLabel "Handel"@de .
-
-<#n548010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548000> ;
-    skos:notation "548010" ;
-    skos:prefLabel "Handelsrecht"@de .
-
-<#n548020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548000> ;
-    skos:notation "548020" ;
-    skos:prefLabel "Handel / Geschichte"@de .
-
-<#n548030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548000> ;
-    skos:notation "548030" ;
-    skos:prefLabel "Handelsform"@de .
-
-<#n548040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548000> ;
-    skos:narrower <#n548045> ;
-    skos:notation "548040" ;
-    skos:prefLabel "Messe / Wirtschaft"@de .
-
-<#n548045>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548040> ;
-    skos:notation "548045" ;
-    skos:prefLabel "Markt"@de .
-
-<#n548050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548000> ;
-    skos:notation "548050" ;
-    skos:prefLabel "Firma"@de .
-
-<#n548060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548000> ;
-    skos:notation "548060" ;
-    skos:prefLabel "Handelsgut"@de .
-
-<#n548090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548000> ;
-    skos:notation "548090" ;
-    skos:prefLabel "Handelsgenossenschaft"@de .
-
-<#n548200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n548250> ;
-    skos:notation "548200" ;
-    skos:prefLabel "Dienstleistungssektor"@de .
-
-<#n548250>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548200> ;
-    skos:notation "548250" ;
-    skos:prefLabel "Dienstleistungsbetrieb"@de .
-
-<#n548300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "548300" ;
-    skos:prefLabel "Öffentliches Unternehmen"@de .
-
-<#n548400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "548400" ;
-    skos:prefLabel "Bank"@de .
-
-<#n548600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:notation "548600" ;
-    skos:prefLabel "Versicherung"@de .
-
-<#n548800>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n540000> ;
-    skos:narrower <#n548820>, <#n548830>, <#n548840>, <#n548870> ;
-    skos:notation "548800" ;
-    skos:prefLabel "Tourismus"@de .
-
-<#n548820>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548800> ;
-    skos:notation "548820" ;
-    skos:prefLabel "Kurort"@de .
-
-<#n548830>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548800> ;
-    skos:notation "548830" ;
-    skos:prefLabel "Naherholung"@de .
-
-<#n548840>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548800> ;
-    skos:notation "548840" ;
-    skos:prefLabel "Gastgewerbe"@de .
-
-<#n548870>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n548800> ;
-    skos:notation "548870" ;
-    skos:prefLabel "Jugendherberge"@de .
-
-<#n550000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n550100>, <#n551000>, <#n552000>, <#n553000>, <#n554000>, <#n555000>, <#n556000>, <#n557000>, <#n558000> ;
-    skos:notation "550000" ;
-    skos:prefLabel "Verkehr"@de .
-
-<#n550100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n550000> ;
-    skos:notation "550100" ;
-    skos:prefLabel "Verkehr allgemein"@de .
-
-<#n551000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n550000> ;
-    skos:notation "551000" ;
-    skos:prefLabel "Verkehrsrecht"@de .
-
-<#n552000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n550000> ;
-    skos:notation "552000" ;
-    skos:prefLabel "Verkehr / Geschichte"@de .
-
-<#n553000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n550000> ;
-    skos:notation "553000" ;
-    skos:prefLabel "Straßenverkehr"@de .
-
-<#n554000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n550000> ;
-    skos:notation "554000" ;
-    skos:prefLabel "Öffentlicher Personennahverkehr"@de .
-
-<#n555000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n550000> ;
-    skos:narrower <#n555020> ;
-    skos:notation "555000" ;
-    skos:prefLabel "Eisenbahn"@de .
-
-<#n555020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n555000> ;
-    skos:notation "555020" ;
-    skos:prefLabel "Eisenbahn / Geschichte"@de .
-
-<#n556000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n550000> ;
-    skos:notation "556000" ;
-    skos:prefLabel "Luftverkehr"@de .
-
-<#n557000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n550000> ;
-    skos:narrower <#n557020>, <#n557040>, <#n557060> ;
-    skos:notation "557000" ;
-    skos:prefLabel "Schifffahrt"@de .
-
-<#n557020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n557000> ;
-    skos:notation "557020" ;
-    skos:prefLabel "Schifffahrt / Geschichte"@de .
-
-<#n557040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n557000> ;
-    skos:notation "557040" ;
-    skos:prefLabel "Kanal"@de .
-
-<#n557060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n557000> ;
-    skos:notation "557060" ;
-    skos:prefLabel "Hafen"@de .
-
-<#n558000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n550000> ;
-    skos:narrower <#n558020>, <#n558040>, <#n558050> ;
-    skos:notation "558000" ;
-    skos:prefLabel "Post. Fernmeldewesen"@de .
-
-<#n558020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n558000> ;
-    skos:notation "558020" ;
-    skos:prefLabel "Post / Geschichte"@de .
-
-<#n558040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n558000> ;
-    skos:notation "558040" ;
-    skos:prefLabel "Briefmarke"@de .
-
-<#n558050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n558000> ;
-    skos:notation "558050" ;
-    skos:prefLabel "Fernmeldewesen"@de .
-
-<#n560000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n560100>, <#n562000>, <#n562300>, <#n562600>, <#n563000>, <#n564000>, <#n566000> ;
-    skos:notation "560000" ;
-    skos:prefLabel "Siedlung"@de .
-
-<#n560100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n560000> ;
-    skos:notation "560100" ;
-    skos:prefLabel "Siedlung allgemein"@de .
-
-<#n562000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n560000> ;
-    skos:narrower <#n562040>, <#n562060> ;
-    skos:notation "562000" ;
-    skos:prefLabel "Siedlung / Geschichte"@de .
-
-<#n562040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n562000> ;
-    skos:notation "562040" ;
-    skos:prefLabel "Wüstung"@de .
-
-<#n562060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n562000> ;
-    skos:notation "562060" ;
-    skos:prefLabel "Allmende"@de .
-
-<#n562300>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n560000> ;
-    skos:notation "562300" ;
-    skos:prefLabel "Kulturlandschaft"@de .
-
-<#n562600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n560000> ;
-    skos:notation "562600" ;
-    skos:prefLabel "Siedlungsraum"@de .
-
-<#n563000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n560000> ;
-    skos:narrower <#n563020>, <#n563030>, <#n563040>, <#n563050> ;
-    skos:notation "563000" ;
-    skos:prefLabel "Siedlungsform"@de .
-
-<#n563020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n563000> ;
-    skos:notation "563020" ;
-    skos:prefLabel "Industriestadt"@de .
-
-<#n563030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n563000> ;
-    skos:notation "563030" ;
-    skos:prefLabel "Marktzentrum"@de .
-
-<#n563040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n563000> ;
-    skos:notation "563040" ;
-    skos:prefLabel "Wohnsiedlung"@de .
-
-<#n563050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n563000> ;
-    skos:notation "563050" ;
-    skos:prefLabel "Gewerbegebiet"@de .
-
-<#n564000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n560000> ;
-    skos:narrower <#n564040>, <#n564050>, <#n564080> ;
-    skos:notation "564000" ;
-    skos:prefLabel "Ländliche Siedlung"@de .
-
-<#n564040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n564000> ;
-    skos:notation "564040" ;
-    skos:prefLabel "Ländliche Siedlungsform"@de .
-
-<#n564050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n564000> ;
-    skos:notation "564050" ;
-    skos:prefLabel "Dorf / Topographie"@de .
-
-<#n564080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n564000> ;
-    skos:notation "564080" ;
-    skos:prefLabel "Dorferneuerung"@de .
-
-<#n566000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n560000> ;
-    skos:narrower <#n566010>, <#n566020>, <#n566040>, <#n566050>, <#n566060>, <#n566070>, <#n566080> ;
-    skos:notation "566000" ;
-    skos:prefLabel "Stadt"@de .
-
-<#n566010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566000> ;
-    skos:notation "566010" ;
-    skos:prefLabel "Stadttyp"@de .
-
-<#n566020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566000> ;
-    skos:notation "566020" ;
-    skos:prefLabel "Städtische Siedlungsform"@de .
-
-<#n566040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566000> ;
-    skos:narrower <#n566041>, <#n566042>, <#n566043>, <#n566045>, <#n566046> ;
-    skos:notation "566040" ;
-    skos:prefLabel "Stadtgliederung"@de .
-
-<#n566041>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566040> ;
-    skos:notation "566041" ;
-    skos:prefLabel "Stadtkern"@de .
-
-<#n566042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566040> ;
-    skos:notation "566042" ;
-    skos:prefLabel "Vorort"@de .
-
-<#n566043>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566040> ;
-    skos:notation "566043" ;
-    skos:prefLabel "Geschäftsviertel"@de .
-
-<#n566045>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566040> ;
-    skos:notation "566045" ;
-    skos:prefLabel "Stadtteil"@de .
-
-<#n566046>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566040> ;
-    skos:notation "566046" ;
-    skos:prefLabel "Stadt / Erholungsgebiet"@de .
-
-<#n566050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566000> ;
-    skos:narrower <#n566051>, <#n566052>, <#n566053> ;
-    skos:notation "566050" ;
-    skos:prefLabel "Stadt / Topographie"@de .
-
-<#n566051>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566050> ;
-    skos:notation "566051" ;
-    skos:prefLabel "Platz"@de .
-
-<#n566052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566050> ;
-    skos:notation "566052" ;
-    skos:prefLabel "Straße"@de .
-
-<#n566053>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566050> ;
-    skos:notation "566053" ;
-    skos:prefLabel "Öffentliches Gebäude"@de .
-
-<#n566060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566000> ;
-    skos:notation "566060" ;
-    skos:prefLabel "Verstädterung"@de .
-
-<#n566070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566000> ;
-    skos:notation "566070" ;
-    skos:prefLabel "Ballungsraum"@de .
-
-<#n566080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n566000> ;
-    skos:notation "566080" ;
-    skos:prefLabel "Stadt / Umland"@de .
-
-<#n570000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n570100>, <#n572000>, <#n574000> ;
-    skos:notation "570000" ;
-    skos:prefLabel "Raumordnung und Städtebau"@de .
-
-<#n570100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n570000> ;
-    skos:notation "570100" ;
-    skos:prefLabel "Raumordnung und Städtebau allgemein"@de .
-
-<#n572000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n570000> ;
-    skos:narrower <#n572020>, <#n572030>, <#n572040>, <#n572050>, <#n572060> ;
-    skos:notation "572000" ;
-    skos:prefLabel "Raumordnung"@de .
-
-<#n572020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n572000> ;
-    skos:notation "572020" ;
-    skos:prefLabel "Landesplanung"@de .
-
-<#n572030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n572000> ;
-    skos:notation "572030" ;
-    skos:prefLabel "Regionalplanung"@de .
-
-<#n572040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n572000> ;
-    skos:notation "572040" ;
-    skos:prefLabel "Kreisplanung"@de .
-
-<#n572050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n572000> ;
-    skos:notation "572050" ;
-    skos:prefLabel "Landschaftsplanung"@de .
-
-<#n572060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n572000> ;
-    skos:notation "572060" ;
-    skos:prefLabel "Gemeindeplanung"@de .
-
-<#n574000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n570000> ;
-    skos:narrower <#n574020>, <#n574030>, <#n574040>, <#n574050>, <#n574060> ;
-    skos:notation "574000" ;
-    skos:prefLabel "Bauwesen"@de .
-
-<#n574020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n574000> ;
-    skos:notation "574020" ;
-    skos:prefLabel "Bau- und Bodenrecht"@de .
-
-<#n574030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n574000> ;
-    skos:notation "574030" ;
-    skos:prefLabel "Städtebau"@de .
-
-<#n574040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n574000> ;
-    skos:notation "574040" ;
-    skos:prefLabel "Straßenbau"@de .
-
-<#n574050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n574000> ;
-    skos:notation "574050" ;
-    skos:prefLabel "Wohnungsbau"@de .
-
-<#n574060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n574000> ;
-    skos:notation "574060" ;
-    skos:prefLabel "Wohnungswirtschaft"@de .
-
-<#n580000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n580100>, <#n582000>, <#n584000>, <#n586000> ;
-    skos:notation "580000" ;
-    skos:prefLabel "Umwelt- und Naturschutz"@de .
-
-<#n580100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n580000> ;
-    skos:notation "580100" ;
-    skos:prefLabel "Umwelt- und Naturschutz allgemein"@de .
-
-<#n582000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n580000> ;
-    skos:narrower <#n582010>, <#n582020>, <#n582030>, <#n582040>, <#n582050>, <#n582060>, <#n582070> ;
-    skos:notation "582000" ;
-    skos:prefLabel "Umweltschutz"@de .
-
-<#n582010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n582000> ;
-    skos:notation "582010" ;
-    skos:prefLabel "Klimaschutz"@de .
-
-<#n582020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n582000> ;
-    skos:notation "582020" ;
-    skos:prefLabel "Bodenschutz"@de .
-
-<#n582030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n582000> ;
-    skos:notation "582030" ;
-    skos:prefLabel "Luftverschmutzung"@de .
-
-<#n582040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n582000> ;
-    skos:notation "582040" ;
-    skos:prefLabel "Lärmbelastung"@de .
-
-<#n582050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n582000> ;
-    skos:narrower <#n582052>, <#n582054> ;
-    skos:notation "582050" ;
-    skos:prefLabel "Gewässerschutz"@de .
-
-<#n582052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n582050> ;
-    skos:notation "582052" ;
-    skos:prefLabel "Abwasser"@de .
-
-<#n582054>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n582050> ;
-    skos:notation "582054" ;
-    skos:prefLabel "Kanalisation"@de .
-
-<#n582060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n582000> ;
-    skos:notation "582060" ;
-    skos:prefLabel "Abfallbeseitigung"@de .
-
-<#n582070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n582000> ;
-    skos:notation "582070" ;
-    skos:prefLabel "Strahlenbelastung"@de .
-
-<#n584000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n580000> ;
-    skos:narrower <#n584040>, <#n584050>, <#n584060>, <#n584070>, <#n584075>, <#n584080>, <#n584090> ;
-    skos:notation "584000" ;
-    skos:prefLabel "Naturschutz. Landschaftspflege"@de .
-
-<#n584040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n584000> ;
-    skos:notation "584040" ;
-    skos:prefLabel "Naturdenkmal"@de .
-
-<#n584050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n584000> ;
-    skos:notation "584050" ;
-    skos:prefLabel "Pflanzen / Artenschutz"@de .
-
-<#n584060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n584000> ;
-    skos:notation "584060" ;
-    skos:prefLabel "Tierschutz"@de .
-
-<#n584070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n584000> ;
-    skos:notation "584070" ;
-    skos:prefLabel "Naturschutzgebiet"@de .
-	
-<#n584075>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n584000> ;
-    skos:notation "584075" ;
-    skos:prefLabel "Nationalpark"@de .
-
-<#n584080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n584000> ;
-    skos:notation "584080" ;
-    skos:prefLabel "Naturpark"@de .
-
-<#n584090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n584000> ;
-    skos:notation "584090" ;
-    skos:prefLabel "Landschaftsentwicklung"@de .
-
-<#n586000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n580000> ;
-    skos:narrower <#n586020>, <#n586030>, <#n586040>, <#n586080> ;
-    skos:notation "586000" ;
-    skos:prefLabel "Grünanlage"@de .
-
-<#n586020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n586000> ;
-    skos:notation "586020" ;
-    skos:prefLabel "Park"@de .
-
-<#n586030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n586000> ;
-    skos:notation "586030" ;
-    skos:prefLabel "Botanischer Garten"@de .
-
-<#n586040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n586000> ;
-    skos:notation "586040" ;
-    skos:prefLabel "Zoologischer Garten"@de .
-
-<#n586080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n586000> ;
-    skos:notation "586080" ;
-    skos:prefLabel "Gartenbauausstellung"@de .
-
-<#n610000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n610100>, <#n611000>, <#n612000>, <#n612500>, <#n613000>, <#n615000>, <#n616000>, <#n617000> ;
-    skos:notation "610000" ;
-    skos:prefLabel "Kirche"@de .
-
-<#n610100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n610000> ;
-    skos:notation "610100" ;
-    skos:prefLabel "Kirche allgemein"@de .
-
-<#n611000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n610000> ;
-    skos:narrower <#n611010>, <#n611020>, <#n611025>, <#n611030>, <#n611040>, <#n611050>, <#n611060>, <#n611070>, <#n611080>, <#n611090> ;
-    skos:notation "611000" ;
-    skos:prefLabel "Katholische Kirche"@de .
-
-<#n611010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:notation "611010" ;
-    skos:prefLabel "Kirchengeschichte"@de .
-
-<#n611020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:notation "611020" ;
-    skos:prefLabel "Kirchenrecht"@de .
-
-<#n611025>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:notation "611025" ;
-    skos:prefLabel "Kirchenverwaltung"@de .
-
-<#n611030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:notation "611030" ;
-    skos:prefLabel "Kirchengemeinde"@de .
-
-<#n611040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:narrower <#n611042>, <#n611043>, <#n611044>, <#n611045> ;
-    skos:notation "611040" ;
-    skos:prefLabel "Kirchliches Leben"@de .
-
-<#n611042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611040> ;
-    skos:notation "611042" ;
-    skos:prefLabel "Seelsorge"@de .
-
-<#n611043>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611040> ;
-    skos:notation "611043" ;
-    skos:prefLabel "Laienamt"@de .
-
-<#n611044>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611040> ;
-    skos:notation "611044" ;
-    skos:prefLabel "Kirchlicher Verein"@de .
-
-<#n611045>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611040> ;
-    skos:notation "611045" ;
-    skos:prefLabel "Kirchliche Stiftung"@de .
-
-<#n611050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:notation "611050" ;
-    skos:prefLabel "Geistlicher. Ordensleute"@de .
-
-<#n611060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:notation "611060" ;
-    skos:prefLabel "Kloster. Stift"@de .
-
-<#n611070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:notation "611070" ;
-    skos:prefLabel "Orden"@de .
-
-<#n611080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:narrower <#n611082>, <#n611083>, <#n611084>, <#n611085> ;
-    skos:notation "611080" ;
-    skos:prefLabel "Gottesdienst"@de .
-
-<#n611082>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611080> ;
-    skos:notation "611082" ;
-    skos:prefLabel "Sakrament"@de .
-
-<#n611083>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611080> ;
-    skos:notation "611083" ;
-    skos:prefLabel "Kirchenfest"@de .
-
-<#n611084>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611080> ;
-    skos:notation "611084" ;
-    skos:prefLabel "Prozession"@de .
-
-<#n611085>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611080> ;
-    skos:notation "611085" ;
-    skos:prefLabel "Wallfahrt"@de .
-
-<#n611090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n611000> ;
-    skos:notation "611090" ;
-    skos:prefLabel "Heiligenverehrung"@de .
-
-<#n612000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n610000> ;
-    skos:narrower <#n612020>, <#n612030>, <#n612040>, <#n612050>, <#n612070>, <#n612080> ;
-    skos:notation "612000" ;
-    skos:prefLabel "Reformation"@de .
-
-<#n612020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n612000> ;
-    skos:narrower <#n612022> ;
-    skos:notation "612020" ;
-    skos:prefLabel "Calvinismus"@de .
-
-<#n612022>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n612020> ;
-    skos:notation "612022" ;
-    skos:prefLabel "Zwinglianer"@de .
-
-<#n612030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n612000> ;
-    skos:narrower <#n612032> ;
-    skos:notation "612030" ;
-    skos:prefLabel "Täufer"@de .
-
-<#n612032>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n612030> ;
-    skos:notation "612032" ;
-    skos:prefLabel "Mennoniten"@de .
-
-<#n612040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n612000> ;
-    skos:notation "612040" ;
-    skos:prefLabel "Schwärmer / Theologie"@de .
-
-<#n612050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n612000> ;
-    skos:notation "612050" ;
-    skos:prefLabel "Reformator"@de .
-
-<#n612070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n612000> ;
-    skos:notation "612070" ;
-    skos:prefLabel "Glaubensflüchtling"@de .
-
-<#n612080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n612000> ;
-    skos:notation "612080" ;
-    skos:prefLabel "Hugenotten"@de .
-
-<#n612500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n610000> ;
-    skos:notation "612500" ;
-    skos:prefLabel "Gegenreformation"@de .
-
-<#n613000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n610000> ;
-    skos:narrower <#n613010>, <#n613020>, <#n613025>, <#n613030>, <#n613040>, <#n613050>, <#n613070> ;
-    skos:notation "613000" ;
-    skos:prefLabel "Evangelische Kirche"@de .
-
-<#n613010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613000> ;
-    skos:notation "613010" ;
-    skos:prefLabel "Kirchengeschichte"@de .
-
-<#n613020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613000> ;
-    skos:notation "613020" ;
-    skos:prefLabel "Kirchenrecht"@de .
-
-<#n613025>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613000> ;
-    skos:notation "613025" ;
-    skos:prefLabel "Kirchenverwaltung"@de .
-
-<#n613030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613000> ;
-    skos:notation "613030" ;
-    skos:prefLabel "Kirchengemeinde"@de .
-
-<#n613040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613000> ;
-    skos:narrower <#n613042>, <#n613043>, <#n613044>, <#n613045> ;
-    skos:notation "613040" ;
-    skos:prefLabel "Kirchliches Leben"@de .
-
-<#n613042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613040> ;
-    skos:notation "613042" ;
-    skos:prefLabel "Seelsorge"@de .
-
-<#n613043>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613040> ;
-    skos:notation "613043" ;
-    skos:prefLabel "Diakonie"@de .
-
-<#n613044>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613040> ;
-    skos:notation "613044" ;
-    skos:prefLabel "Kirchlicher Verein"@de .
-
-<#n613045>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613040> ;
-    skos:notation "613045" ;
-    skos:prefLabel "Kirchliche Stiftung"@de .
-
-<#n613050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613000> ;
-    skos:notation "613050" ;
-    skos:prefLabel "Pfarrerin. Pfarrer. Geistliche"@de .
-
-<#n613070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613000> ;
-    skos:narrower <#n613072>, <#n613073> ;
-    skos:notation "613070" ;
-    skos:prefLabel "Gottesdienst"@de .
-
-<#n613072>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613070> ;
-    skos:notation "613072" ;
-    skos:prefLabel "Sakrament"@de .
-
-<#n613073>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n613070> ;
-    skos:notation "613073" ;
-    skos:prefLabel "Kirchenfest"@de .
-
-<#n615000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n610000> ;
-    skos:notation "615000" ;
-    skos:prefLabel "Sonstige christliche Religionsgemeinschaften"@de .
-
-<#n616000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n610000> ;
-    skos:notation "616000" ;
-    skos:prefLabel "Ökumene"@de .
-
-<#n617000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n610000> ;
-    skos:narrower <#n617030>, <#n617050> ;
-    skos:notation "617000" ;
-    skos:prefLabel "Bestattung"@de .
-
-<#n617030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n617000> ;
-    skos:notation "617030" ;
-    skos:prefLabel "Friedhof"@de .
-
-<#n617050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n617000> ;
-    skos:notation "617050" ;
-    skos:prefLabel "Grabmal"@de .
-
-<#n630000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n630100>, <#n631000>, <#n632000> ;
-    skos:notation "630000" ;
-    skos:prefLabel "Juden"@de .
-
-<#n630100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n630000> ;
-    skos:notation "630100" ;
-    skos:prefLabel "Juden allgemein"@de .
-
-<#n631000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n630000> ;
-    skos:notation "631000" ;
-    skos:prefLabel "Judentum"@de .
-
-<#n632000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n630000> ;
-    skos:narrower <#n632050> ;
-    skos:notation "632000" ;
-    skos:prefLabel "Juden / Geschichte"@de .
-
-<#n632050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n632000> ;
-    skos:notation "632050" ;
-    skos:prefLabel "Judenverfolgung"@de .
-
-<#n650000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n651000>, <#n655000> ;
-    skos:notation "650000" ;
-    skos:prefLabel "Nichtchristliche Religion"@de .
-
-<#n651000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n650000> ;
-    skos:narrower <#n651020>, <#n651030> ;
-    skos:notation "651000" ;
-    skos:prefLabel "Nichtchristliche Religion allgemein"@de .
-
-<#n651020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n651000> ;
-    skos:notation "651020" ;
-    skos:prefLabel "Islam"@de .
-
-<#n651030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n651000> ;
-    skos:notation "651030" ;
-    skos:prefLabel "Buddhismus"@de .
-
-<#n655000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n650000> ;
-    skos:narrower <#n655030> ;
-    skos:notation "655000" ;
-    skos:prefLabel "Weltanschauungsgemeinschaft"@de .
-
-<#n655030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n655000> ;
-    skos:notation "655030" ;
-    skos:prefLabel "Freimaurer"@de .
-
-<#n700000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n700100>, <#n702000>, <#n704000>, <#n704200>, <#n704400>, <#n704600>, <#n704700>, <#n706000>, <#n706200>, <#n708000>, <#n708400> ;
-    skos:notation "700000" ;
-    skos:prefLabel "Volkskunde"@de .
-
-<#n700100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:notation "700100" ;
-    skos:prefLabel "Volkskunde allgemein"@de .
-
-<#n702000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:notation "702000" ;
-    skos:prefLabel "Alltag"@de .
-
-<#n704000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:narrower <#n704020>, <#n704040>, <#n704060>, <#n704080>, <#n704090> ;
-    skos:notation "704000" ;
-    skos:prefLabel "Brauch"@de .
-
-<#n704020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704000> ;
-    skos:notation "704020" ;
-    skos:prefLabel "Brauch / Alltag"@de .
-
-<#n704040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704000> ;
-    skos:narrower <#n704042>, <#n704043>, <#n704044>, <#n704045>, <#n704046>, <#n704047> ;
-    skos:notation "704040" ;
-    skos:prefLabel "Brauch / Jahreslauf"@de .
-
-<#n704042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704040> ;
-    skos:notation "704042" ;
-    skos:prefLabel "Winter / Brauch. Weihnachten. Neujahr"@de .
-
-<#n704043>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704040> ;
-    skos:notation "704043" ;
-    skos:prefLabel "Karneval"@de .
-
-<#n704044>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704040> ;
-    skos:notation "704044" ;
-    skos:prefLabel "Frühling / Brauch. Ostern"@de .
-
-<#n704045>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704040> ;
-    skos:notation "704045" ;
-    skos:prefLabel "Mai / Brauch. Pfingsten. Sommer / Brauch"@de .
-
-<#n704046>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704040> ;
-    skos:notation "704046" ;
-    skos:prefLabel "Erntedankfest"@de .
-
-<#n704047>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704040> ;
-    skos:notation "704047" ;
-    skos:prefLabel "Kirchweih"@de .
-
-<#n704060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704000> ;
-    skos:narrower <#n704061>, <#n704063>, <#n704064> ;
-    skos:notation "704060" ;
-    skos:prefLabel "Lebenslauf / Brauch"@de .
-
-<#n704061>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704060> ;
-    skos:notation "704061" ;
-    skos:prefLabel "Geburt"@de .
-
-<#n704063>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704060> ;
-    skos:notation "704063" ;
-    skos:prefLabel "Liebe / Brauch. Verlobung. Hochzeit"@de .
-
-<#n704064>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704060> ;
-    skos:notation "704064" ;
-    skos:prefLabel "Tod / Brauch. Bestattung"@de .
-
-<#n704080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704000> ;
-    skos:narrower <#n704082> ;
-    skos:notation "704080" ;
-    skos:prefLabel "Beruf / Brauch"@de .
-
-<#n704082>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704080> ;
-    skos:notation "704082" ;
-    skos:prefLabel "Handwerk / Brauch"@de .
-
-<#n704090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704000> ;
-    skos:notation "704090" ;
-    skos:prefLabel "Brauchtumspflege / Verein"@de .
-
-<#n704200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:narrower <#n704220>, <#n704230>, <#n704240>, <#n704250>, <#n704260>, <#n704270>, <#n704280> ;
-    skos:notation "704200" ;
-    skos:prefLabel "Volkswissen"@de .
-
-<#n704220>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704200> ;
-    skos:notation "704220" ;
-    skos:prefLabel "Volksmedizin"@de .
-
-<#n704230>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704200> ;
-    skos:notation "704230" ;
-    skos:prefLabel "Ethnobotanik"@de .
-
-<#n704240>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704200> ;
-    skos:notation "704240" ;
-    skos:prefLabel "Volkszoologie"@de .
-
-<#n704250>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704200> ;
-    skos:notation "704250" ;
-    skos:prefLabel "Wetter / Bauernregel"@de .
-
-<#n704260>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704200> ;
-    skos:notation "704260" ;
-    skos:prefLabel "Astrologie"@de .
-
-<#n704270>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704200> ;
-    skos:notation "704270" ;
-    skos:prefLabel "Wahrsagen"@de .
-
-<#n704280>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704200> ;
-    skos:notation "704280" ;
-    skos:prefLabel "Alchemie"@de .
-
-<#n704400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:notation "704400" ;
-    skos:prefLabel "Rechtliche Volkskunde"@de .
-
-<#n704600>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:narrower <#n704630> ;
-    skos:notation "704600" ;
-    skos:prefLabel "Religiöse Volkskunde"@de .
-
-<#n704630>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704600> ;
-    skos:narrower <#n704634> ;
-    skos:notation "704630" ;
-    skos:prefLabel "Volksfrömmigkeit"@de .
-
-<#n704634>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n704630> ;
-    skos:notation "704634" ;
-    skos:prefLabel "Gegenstände der Volksfrömmigkeit"@de .
-
-<#n704700>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:notation "704700" ;
-    skos:prefLabel "Volksglaube"@de .
-
-<#n706000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:narrower <#n706020>, <#n706040>, <#n706050>, <#n706060>, <#n706070>, <#n706080>, <#n706090> ;
-    skos:notation "706000" ;
-    skos:prefLabel "Volksliteratur"@de .
-
-<#n706020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706000> ;
-    skos:notation "706020" ;
-    skos:prefLabel "Volksbuch"@de .
-
-<#n706040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706000> ;
-    skos:notation "706040" ;
-    skos:prefLabel "Märchen. Sage. Legende"@de .
-
-<#n706050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706000> ;
-    skos:narrower <#n706052> ;
-    skos:notation "706050" ;
-    skos:prefLabel "Schwank"@de .
-
-<#n706052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706050> ;
-    skos:notation "706052" ;
-    skos:prefLabel "Witz"@de .
-
-<#n706060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706000> ;
-    skos:notation "706060" ;
-    skos:prefLabel "Sprichwort"@de .
-
-<#n706070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706000> ;
-    skos:notation "706070" ;
-    skos:prefLabel "Inschrift"@de .
-
-<#n706080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706000> ;
-    skos:notation "706080" ;
-    skos:prefLabel "Rätsel"@de .
-
-<#n706090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706000> ;
-    skos:notation "706090" ;
-    skos:prefLabel "Mundartliteratur"@de .
-
-<#n706200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:narrower <#n706210>, <#n706230>, <#n706240> ;
-    skos:notation "706200" ;
-    skos:prefLabel "Volksmusik. Volkstanz"@de .
-
-<#n706210>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706200> ;
-    skos:notation "706210" ;
-    skos:prefLabel "Volksmusik"@de .
-
-<#n706230>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706200> ;
-    skos:notation "706230" ;
-    skos:prefLabel "Volkslied"@de .
-
-<#n706240>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n706200> ;
-    skos:notation "706240" ;
-    skos:prefLabel "Volkstanz"@de .
-
-<#n708000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:narrower <#n708020>, <#n708030>, <#n708040>, <#n708050>, <#n708060>, <#n708200> ;
-    skos:notation "708000" ;
-    skos:prefLabel "Sachkulturforschung"@de .
-
-<#n708020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708000> ;
-    skos:narrower <#n708024>, <#n708026>, <#n708028>, <#n708029> ;
-    skos:notation "708020" ;
-    skos:prefLabel "Hausform"@de .
-
-<#n708024>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708020> ;
-    skos:notation "708024" ;
-    skos:prefLabel "Bürgerhaus"@de .
-
-<#n708026>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708020> ;
-    skos:notation "708026" ;
-    skos:prefLabel "Bauernhaus"@de .
-
-<#n708028>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708020> ;
-    skos:notation "708028" ;
-    skos:prefLabel "Landwirtschaftliches Gebäude"@de .
-
-<#n708029>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708020> ;
-    skos:notation "708029" ;
-    skos:prefLabel "Mühle"@de .
-
-<#n708030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708000> ;
-    skos:notation "708030" ;
-    skos:prefLabel "Hausrat"@de .
-
-<#n708040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708000> ;
-    skos:notation "708040" ;
-    skos:prefLabel "Gerät"@de .
-
-<#n708050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708000> ;
-    skos:notation "708050" ;
-    skos:prefLabel "Spielzeug"@de .
-
-<#n708060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708000> ;
-    skos:notation "708060" ;
-    skos:prefLabel "Nahrung"@de .
-
-<#n708200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708000> ;
-    skos:narrower <#n708220>, <#n708230>, <#n708250>, <#n708260>, <#n708270>, <#n708280>, <#n708290> ;
-    skos:notation "708200" ;
-    skos:prefLabel "Volkskunst"@de .
-
-<#n708220>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708200> ;
-    skos:notation "708220" ;
-    skos:prefLabel "Holzbearbeitung"@de .
-
-<#n708230>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708200> ;
-    skos:notation "708230" ;
-    skos:prefLabel "Malerei"@de .
-
-<#n708250>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708200> ;
-    skos:notation "708250" ;
-    skos:prefLabel "Keramik"@de .
-
-<#n708260>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708200> ;
-    skos:notation "708260" ;
-    skos:prefLabel "Steinbearbeitung"@de .
-
-<#n708270>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708200> ;
-    skos:notation "708270" ;
-    skos:prefLabel "Metallbearbeitung"@de .
-
-<#n708280>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708200> ;
-    skos:notation "708280" ;
-    skos:prefLabel "Glas"@de .
-
-<#n708290>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708200> ;
-    skos:notation "708290" ;
-    skos:prefLabel "Textilien"@de .
-
-<#n708400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n700000> ;
-    skos:narrower <#n708420>, <#n708430>, <#n708450> ;
-    skos:notation "708400" ;
-    skos:prefLabel "Kleidung"@de .
-
-<#n708420>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708400> ;
-    skos:notation "708420" ;
-    skos:prefLabel "Kostümkunde"@de .
-
-<#n708430>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708400> ;
-    skos:notation "708430" ;
-    skos:prefLabel "Tracht"@de .
-
-<#n708450>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n708400> ;
-    skos:notation "708450" ;
-    skos:prefLabel "Schmuck"@de .
-
-<#n720000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n720100>, <#n722000>, <#n724000>, <#n725000>, <#n726000> ;
-    skos:notation "720000" ;
-    skos:prefLabel "Gesellschaft"@de .
-
-<#n720100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n720000> ;
-    skos:notation "720100" ;
-    skos:prefLabel "Gesellschaft allgemein"@de .
-
-<#n722000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n720000> ;
-    skos:notation "722000" ;
-    skos:prefLabel "Sozialgeschichte"@de .
-
-<#n724000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n720000> ;
-    skos:narrower <#n724020>, <#n724030>, <#n724040>, <#n724050>, <#n724060>, <#n724070> ;
-    skos:notation "724000" ;
-    skos:prefLabel "Sozialstruktur"@de .
-
-<#n724020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n724000> ;
-    skos:notation "724020" ;
-    skos:prefLabel "Kind"@de .
-
-<#n724030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n724000> ;
-    skos:notation "724030" ;
-    skos:prefLabel "Jugend"@de .
-
-<#n724040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n724000> ;
-    skos:notation "724040" ;
-    skos:prefLabel "Frau"@de .
-
-<#n724050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n724000> ;
-    skos:notation "724050" ;
-    skos:prefLabel "Mann"@de .
-
-<#n724060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n724000> ;
-    skos:notation "724060" ;
-    skos:prefLabel "Alter"@de .
-
-<#n724070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n724000> ;
-    skos:notation "724070" ;
-    skos:prefLabel "Original / Person"@de .
-
-<#n725000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n720000> ;
-    skos:narrower <#n725010>, <#n725020>, <#n725030>, <#n725040>, <#n725050>, <#n725060>, <#n725070>, <#n725080> ;
-    skos:notation "725000" ;
-    skos:prefLabel "Gruppe"@de .
-
-<#n725010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n725000> ;
-    skos:notation "725010" ;
-    skos:prefLabel "Familie"@de .
-
-<#n725020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n725000> ;
-    skos:notation "725020" ;
-    skos:prefLabel "Nachbarschaft"@de .
-
-<#n725030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n725000> ;
-    skos:notation "725030" ;
-    skos:prefLabel "Dorfgemeinschaft"@de .
-
-<#n725040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n725000> ;
-    skos:notation "725040" ;
-    skos:prefLabel "Alternativbewegung"@de .
-
-<#n725050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n725000> ;
-    skos:notation "725050" ;
-    skos:prefLabel "Interessenverband"@de .
-
-<#n725060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n725000> ;
-    skos:notation "725060" ;
-    skos:prefLabel "Randgruppe"@de .
-
-<#n725070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n725000> ;
-    skos:notation "725070" ;
-    skos:prefLabel "Ausländerin. Ausländer"@de .
-
-<#n725080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n725000> ;
-    skos:notation "725080" ;
-    skos:prefLabel "Behinderter Mensch"@de .
-
-<#n726000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n720000> ;
-    skos:notation "726000" ;
-    skos:prefLabel "Sozialer Wandel"@de .
-
-<#n730000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n730100>, <#n731000>, <#n732000>, <#n733000>, <#n734000>, <#n735000>, <#n736000> ;
-    skos:notation "730000" ;
-    skos:prefLabel "Kultur und Freizeit"@de .
-
-<#n730100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n730000> ;
-    skos:notation "730100" ;
-    skos:prefLabel "Kultur und Freizeit allgemein"@de .
-
-<#n731000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n730000> ;
-    skos:notation "731000" ;
-    skos:prefLabel "Kulturpolitik"@de .
-
-<#n732000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n730000> ;
-    skos:notation "732000" ;
-    skos:prefLabel "Kulturgeschichte"@de .
-
-<#n733000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n730000> ;
-    skos:narrower <#n733030>, <#n733050>, <#n733070> ;
-    skos:notation "733000" ;
-    skos:prefLabel "Kulturleben"@de .
-
-<#n733030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n733000> ;
-    skos:notation "733030" ;
-    skos:prefLabel "Kulturveranstaltung"@de .
-
-<#n733050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n733000> ;
-    skos:notation "733050" ;
-    skos:prefLabel "Kulturpreis"@de .
-
-<#n733070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n733000> ;
-    skos:notation "733070" ;
-    skos:prefLabel "Kulturverein"@de .
-
-<#n734000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n730000> ;
-    skos:notation "734000" ;
-    skos:prefLabel "Feier. Fest"@de .
-
-<#n735000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n730000> ;
-    skos:narrower <#n735020>, <#n735040>, <#n735090> ;
-    skos:notation "735000" ;
-    skos:prefLabel "Freizeit und Erholung"@de .
-
-<#n735020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n735000> ;
-    skos:notation "735020" ;
-    skos:prefLabel "Freizeiteinrichtung"@de .
-
-<#n735040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n735000> ;
-    skos:notation "735040" ;
-    skos:prefLabel "Freizeitgestaltung"@de .
-
-<#n735090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n735000> ;
-    skos:notation "735090" ;
-    skos:prefLabel "Verein"@de .
-
-<#n736000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n730000> ;
-    skos:narrower <#n736030>, <#n736050>, <#n736080> ;
-    skos:notation "736000" ;
-    skos:prefLabel "Sport und Spiel"@de .
-
-<#n736030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n736000> ;
-    skos:notation "736030" ;
-    skos:prefLabel "Sportart"@de .
-
-<#n736050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n736000> ;
-    skos:notation "736050" ;
-    skos:prefLabel "Sportverein"@de .
-
-<#n736080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n736000> ;
-    skos:notation "736080" ;
-    skos:prefLabel "Sportlerin. Sportler"@de .
-
-<#n740000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n740100>, <#n742000>, <#n743000>, <#n744000>, <#n745000>, <#n746000>, <#n747000> ;
-    skos:notation "740000" ;
-    skos:prefLabel "Sprache"@de .
-
-<#n740100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n740000> ;
-    skos:notation "740100" ;
-    skos:prefLabel "Sprache allgemein"@de .
-
-<#n742000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n740000> ;
-    skos:notation "742000" ;
-    skos:prefLabel "Sprache / Geschichte"@de .
-
-<#n743000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n740000> ;
-    skos:notation "743000" ;
-    skos:prefLabel "Grammatik"@de .
-
-<#n744000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n740000> ;
-    skos:notation "744000" ;
-    skos:prefLabel "Mundart"@de .
-
-<#n745000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n740000> ;
-    skos:notation "745000" ;
-    skos:prefLabel "Sprachgeographie"@de .
-
-<#n746000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n740000> ;
-    skos:narrower <#n746020>, <#n746030>, <#n746040>, <#n746050>, <#n746060> ;
-    skos:notation "746000" ;
-    skos:prefLabel "Namenkunde"@de .
-
-<#n746020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746000> ;
-    skos:notation "746020" ;
-    skos:prefLabel "Personenname"@de .
-
-<#n746030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746000> ;
-    skos:narrower <#n746032>, <#n746034> ;
-    skos:notation "746030" ;
-    skos:prefLabel "Hausname. Hofname"@de .
-
-<#n746032>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746030> ;
-    skos:notation "746032" ;
-    skos:prefLabel "Hausname"@de .
-
-<#n746034>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746030> ;
-    skos:notation "746034" ;
-    skos:prefLabel "Hofname"@de .
-
-<#n746040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746000> ;
-    skos:narrower <#n746042>, <#n746043>, <#n746044>, <#n746045>, <#n746046> ;
-    skos:notation "746040" ;
-    skos:prefLabel "Geographischer Name"@de .
-
-<#n746042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746040> ;
-    skos:notation "746042" ;
-    skos:prefLabel "Ortsname"@de .
-
-<#n746043>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746040> ;
-    skos:notation "746043" ;
-    skos:prefLabel "Straßenname"@de .
-
-<#n746044>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746040> ;
-    skos:notation "746044" ;
-    skos:prefLabel "Flurname"@de .
-
-<#n746045>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746040> ;
-    skos:notation "746045" ;
-    skos:prefLabel "Bergname"@de .
-
-<#n746046>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746040> ;
-    skos:notation "746046" ;
-    skos:prefLabel "Gewässername"@de .
-
-<#n746050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746000> ;
-    skos:notation "746050" ;
-    skos:prefLabel "Tiername"@de .
-
-<#n746060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n746000> ;
-    skos:notation "746060" ;
-    skos:prefLabel "Pflanzenname"@de .
-
-<#n747000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n740000> ;
-    skos:narrower <#n747010>, <#n747020>, <#n747030>, <#n747040>, <#n747050>, <#n747060> ;
-    skos:notation "747000" ;
-    skos:prefLabel "Soziolinguistik"@de .
-
-<#n747010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n747000> ;
-    skos:notation "747010" ;
-    skos:prefLabel "Umgangssprache"@de .
-
-<#n747020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n747000> ;
-    skos:notation "747020" ;
-    skos:prefLabel "Geheimsprache"@de .
-
-<#n747030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n747000> ;
-    skos:notation "747030" ;
-    skos:prefLabel "Fachsprache"@de .
-
-<#n747040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n747000> ;
-    skos:notation "747040" ;
-    skos:prefLabel "Spracherwerb"@de .
-
-<#n747050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n747000> ;
-    skos:notation "747050" ;
-    skos:prefLabel "Sprachunterricht"@de .
-
-<#n747060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n747000> ;
-    skos:notation "747060" ;
-    skos:prefLabel "Sprachpflege"@de .
-
-<#n760000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n760100>, <#n761000>, <#n762000>, <#n766000>, <#n767000>, <#n768000>, <#n769000> ;
-    skos:notation "760000" ;
-    skos:prefLabel "Literatur"@de .
-
-<#n760100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n760000> ;
-    skos:notation "760100" ;
-    skos:prefLabel "Literatur allgemein"@de .
-
-<#n761000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n760000> ;
-    skos:narrower <#n761020>, <#n761050> ;
-    skos:notation "761000" ;
-    skos:prefLabel "Literaturwissenschaft"@de .
-
-<#n761020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n761000> ;
-    skos:notation "761020" ;
-    skos:prefLabel "Literaturgeographie"@de .
-
-<#n761050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n761000> ;
-    skos:notation "761050" ;
-    skos:prefLabel "Stoff / Literatur. Motiv / Literatur"@de .
-
-<#n762000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n760000> ;
-    skos:notation "762000" ;
-    skos:prefLabel "Literatur / Geschichte"@de .
-
-<#n766000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n760000> ;
-    skos:narrower <#n766030>, <#n766050>, <#n766060> ;
-    skos:notation "766000" ;
-    skos:prefLabel "Literatursoziologie"@de .
-
-<#n766030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n766000> ;
-    skos:notation "766030" ;
-    skos:prefLabel "Leserin. Leser"@de .
-
-<#n766050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n766000> ;
-    skos:notation "766050" ;
-    skos:prefLabel "Literaturförderung"@de .
-
-<#n766060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n766000> ;
-    skos:notation "766060" ;
-    skos:prefLabel "Literaturausstellung"@de .
-
-<#n767000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n760000> ;
-    skos:narrower <#n767040> ;
-    skos:notation "767000" ;
-    skos:prefLabel "Literarischer Text"@de .
-
-<#n767040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n767000> ;
-    skos:notation "767040" ;
-    skos:prefLabel "Anthologie"@de .
-
-<#n768000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n760000> ;
-    skos:narrower <#n768010>, <#n768030> ;
-    skos:notation "768000" ;
-    skos:prefLabel "Schriftstellerin. Schriftsteller"@de .
-
-<#n768010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n768000> ;
-    skos:notation "768010" ;
-    skos:prefLabel "Schriftstellerin. Schriftsteller / Primärliteratur"@de .
-
-<#n768030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n768000> ;
-    skos:notation "768030" ;
-    skos:prefLabel "Schriftstellerin. Schriftsteller / Sekundärliteratur"@de .
-
-<#n769000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n760000> ;
-    skos:narrower <#n769020>, <#n769030>, <#n769040>, <#n769050> ;
-    skos:notation "769000" ;
-    skos:prefLabel "Literaturgattung"@de .
-
-<#n769020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n769000> ;
-    skos:notation "769020" ;
-    skos:prefLabel "Lyrik"@de .
-
-<#n769030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n769000> ;
-    skos:notation "769030" ;
-    skos:prefLabel "Drama"@de .
-
-<#n769040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n769000> ;
-    skos:notation "769040" ;
-    skos:prefLabel "Epik"@de .
-
-<#n769050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n769000> ;
-    skos:notation "769050" ;
-    skos:prefLabel "Kurzform"@de .
-
-<#n780000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n780100>, <#n781000>, <#n782000>, <#n783000>, <#n784000>, <#n785000>, <#n785500>, <#n786000> ;
-    skos:notation "780000" ;
-    skos:prefLabel "Bildung. Erziehung"@de .
-
-<#n780100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n780000> ;
-    skos:notation "780100" ;
-    skos:prefLabel "Bildung. Erziehung allgemein"@de .
-
-<#n781000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n780000> ;
-    skos:narrower <#n781040> ;
-    skos:notation "781000" ;
-    skos:prefLabel "Bildungspolitik"@de .
-
-<#n781040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n781000> ;
-    skos:notation "781040" ;
-    skos:prefLabel "Ausbildungsförderung"@de .
-
-<#n782000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n780000> ;
-    skos:narrower <#n782500> ;
-    skos:notation "782000" ;
-    skos:prefLabel "Erziehung"@de .
-
-<#n782500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n782000> ;
-    skos:notation "782500" ;
-    skos:prefLabel "Vorschulerziehung"@de .
-
-<#n783000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n780000> ;
-    skos:notation "783000" ;
-    skos:prefLabel "Schule / Geschichte"@de .
-
-<#n784000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n780000> ;
-    skos:narrower <#n784010>, <#n784016>, <#n784020>, <#n784025>, <#n784030>, <#n784035>, <#n784040>, <#n784041>, <#n784042>, <#n784043>, <#n784044>, <#n784045>, <#n784046>, <#n784047>, <#n784048>, <#n784049>, <#n784050>, <#n784060>, <#n784070>, <#n784080>, <#n784090> ;
-    skos:notation "784000" ;
-    skos:prefLabel "Allgemein bildende Schule"@de .
-
-<#n784010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:narrower <#n784012>, <#n784014> ;
-    skos:notation "784010" ;
-    skos:prefLabel "Schulpolitik"@de .
-
-<#n784012>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784010> ;
-    skos:notation "784012" ;
-    skos:prefLabel "Schulreform"@de .
-
-<#n784014>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784010> ;
-    skos:notation "784014" ;
-    skos:prefLabel "Schulversuch"@de .
-
-<#n784016>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784016" ;
-    skos:prefLabel "Privatschule"@de .
-
-<#n784020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784020" ;
-    skos:prefLabel "Schulrecht"@de .
-
-<#n784025>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784025" ;
-    skos:prefLabel "Elternarbeit"@de .
-
-<#n784030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784030" ;
-    skos:prefLabel "Schulverwaltung"@de .
-
-<#n784035>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784035" ;
-    skos:prefLabel "Schulbau"@de .
-
-<#n784040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784040" ;
-    skos:prefLabel "Schulgliederung"@de .
-
-<#n784041>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784041" ;
-    skos:prefLabel "Grundschule"@de .
-
-<#n784042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784042" ;
-    skos:prefLabel "Hauptschule"@de .
-
-<#n784043>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:narrower <#n784033> ;
-    skos:notation "784043" ;
-    skos:prefLabel "Realschule"@de .
-
-<#n784033>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784043> ;
-    skos:notation "784033" ;
-    skos:prefLabel "Realschule Plus"@de .
-
-<#n784044>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784044" ;
-    skos:prefLabel "Gymnasium"@de .
-
-<#n784045>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784045" ;
-    skos:prefLabel "Gesamtschule"@de .
-
-<#n784046>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784046" ;
-    skos:prefLabel "Kollegschule"@de .
-
-<#n784047>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784047" ;
-    skos:prefLabel "Sonderschule"@de .
-
-<#n784048>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784048" ;
-    skos:prefLabel "Regionale Schule"@de .
-
-<#n784049>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784049" ;
-    skos:prefLabel "Duale Oberschule"@de .
-
-<#n784050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:narrower <#n784052>, <#n784053>, <#n784054> ;
-    skos:notation "784050" ;
-    skos:prefLabel "Schulstufe"@de .
-
-<#n784052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784050> ;
-    skos:notation "784052" ;
-    skos:prefLabel "Primarstufe"@de .
-
-<#n784053>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784050> ;
-    skos:notation "784053" ;
-    skos:prefLabel "Sekundarstufe 1"@de .
-
-<#n784054>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784050> ;
-    skos:notation "784054" ;
-    skos:prefLabel "Sekundarstufe 2"@de .
-
-<#n784060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:narrower <#n784062>, <#n784064>, <#n784066> ;
-    skos:notation "784060" ;
-    skos:prefLabel "Lehrerin. Lehrer"@de .
-
-<#n784062>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784060> ;
-    skos:notation "784062" ;
-    skos:prefLabel "Lehrerbildung"@de .
-
-<#n784064>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784060> ;
-    skos:notation "784064" ;
-    skos:prefLabel "Lehrerfortbildung"@de .
-
-<#n784066>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784060> ;
-    skos:notation "784066" ;
-    skos:prefLabel "Lehrerin. Lehrer / Besoldung"@de .
-
-<#n784070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:narrower <#n784072>, <#n784074>, <#n784076>, <#n784078> ;
-    skos:notation "784070" ;
-  skos:prefLabel "Schülerin. Schüler"@de .
-
-<#n784072>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784070> ;
-    skos:notation "784072" ;
-    skos:prefLabel "Schülermitverwaltung"@de .
-
-<#n784074>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784070> ;
-    skos:notation "784074" ;
-    skos:prefLabel "Schülertransport"@de .
-
-<#n784076>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784070> ;
-    skos:notation "784076" ;
-    skos:prefLabel "Schulverpflegung"@de .
-
-<#n784078>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784070> ;
-    skos:notation "784078" ;
-    skos:prefLabel "Schüleraustausch"@de .
-
-<#n784080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784080" ;
-    skos:prefLabel "Unterricht"@de .
-
-<#n784090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n784000> ;
-    skos:notation "784090" ;
-    skos:prefLabel "Schulleben"@de .
-
-<#n785000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n780000> ;
-    skos:narrower <#n785020>, <#n785030>, <#n785040>, <#n785050>, <#n785060>, <#n785070>, <#n785080> ;
-    skos:notation "785000" ;
-    skos:prefLabel "Berufsbildende Schule"@de .
-
-<#n785020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n785000> ;
-    skos:notation "785020" ;
-    skos:prefLabel "Berufsschule"@de .
-
-<#n785030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n785000> ;
-    skos:notation "785030" ;
-    skos:prefLabel "Berufsfachschule"@de .
-
-<#n785040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n785000> ;
-    skos:notation "785040" ;
-    skos:prefLabel "Berufsaufbauschule"@de .
-
-<#n785050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n785000> ;
-    skos:notation "785050" ;
-    skos:prefLabel "Fachoberschule"@de .
-
-<#n785060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n785000> ;
-    skos:notation "785060" ;
-    skos:prefLabel "Berufliches Gymnasium"@de .
-
-<#n785070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n785000> ;
-    skos:notation "785070" ;
-    skos:prefLabel "Fachschule"@de .
-
-<#n785080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n785000> ;
-    skos:notation "785080" ;
-    skos:prefLabel "Nichtstaatliche Berufsschule"@de .
-
-<#n785500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n780000> ;
-    skos:notation "785500" ;
-    skos:prefLabel "Berufsausbildung"@de .
-
-<#n786000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n780000> ;
-    skos:notation "786000" ;
-    skos:prefLabel "Außerschulische Bildung"@de .
-
-<#n790000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n790100>, <#n791000>, <#n792000>, <#n794000>, <#n796000>, <#n797000>, <#n798000>, <#n798200>, <#n799000> ;
-    skos:notation "790000" ;
-    skos:prefLabel "Hochschule. Wissenschaft"@de .
-
-<#n790100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n790000> ;
-    skos:notation "790100" ;
-    skos:prefLabel "Hochschule. Wissenschaft allgemein"@de .
-
-<#n791000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n790000> ;
-    skos:notation "791000" ;
-    skos:prefLabel "Hochschulrecht"@de .
-
-<#n792000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n790000> ;
-    skos:notation "792000" ;
-    skos:prefLabel "Hochschulpolitik"@de .
-
-<#n794000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n790000> ;
-    skos:narrower <#n794010> ;
-    skos:notation "794000" ;
-    skos:prefLabel "Hochschule"@de .
-
-<#n794010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n794000> ;
-    skos:notation "794010" ;
-    skos:prefLabel "Einzelne Hochschule"@de .
-
-<#n796000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n790000> ;
-    skos:notation "796000" ;
-    skos:prefLabel "Fachhochschule"@de .
-
-<#n797000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n790000> ;
-    skos:notation "797000" ;
-    skos:prefLabel "Hochschullehrerin. Hochschullehrer. Wissenschaft"@de .
-
-<#n798000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n790000> ;
-    skos:notation "798000" ;
-    skos:prefLabel "Studentin. Student"@de .
-
-<#n798200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n790000> ;
-    skos:notation "798200" ;
-    skos:prefLabel "Außeruniversitäre Forschung"@de .
-
-<#n799000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n790000> ;
-    skos:narrower <#n799200> ;
-    skos:notation "799000" ;
-    skos:prefLabel "Wissenschaftsförderung"@de .
-
-<#n799200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n799000> ;
-    skos:notation "799200" ;
-    skos:prefLabel "Wissenschaftliche Gesellschaft"@de .
-
-<#n800000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n800100>, <#n802000>, <#n803000>, <#n804000>, <#n806000> ;
-    skos:notation "800000" ;
-    skos:prefLabel "Darstellende Kunst"@de .
-
-<#n800100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n800000> ;
-    skos:notation "800100" ;
-    skos:prefLabel "Darstellende Kunst allgemein"@de .
-
-<#n802000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n800000> ;
-    skos:narrower <#n802020>, <#n802030>, <#n802040>, <#n802050>, <#n802060>, <#n802070>, <#n802080> ;
-    skos:notation "802000" ;
-    skos:prefLabel "Theater"@de .
-
-<#n802020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n802000> ;
-    skos:notation "802020" ;
-    skos:prefLabel "Theater / Geschichte"@de .
-
-<#n802030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n802000> ;
-    skos:notation "802030" ;
-    skos:prefLabel "Volksschauspiel"@de .
-
-<#n802040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n802000> ;
-    skos:notation "802040" ;
-    skos:prefLabel "Laienspiel"@de .
-
-<#n802050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n802000> ;
-    skos:notation "802050" ;
-    skos:prefLabel "Kindertheater. Jugendtheater"@de .
-
-<#n802060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n802000> ;
-    skos:notation "802060" ;
-    skos:prefLabel "Einzelne Theater"@de .
-
-<#n802070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n802000> ;
-    skos:notation "802070" ;
-    skos:prefLabel "Inszenierung"@de .
-
-<#n802080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n802000> ;
-    skos:notation "802080" ;
-    skos:prefLabel "Schauspielerin. Schauspieler"@de .
-
-<#n803000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n800000> ;
-    skos:notation "803000" ;
-    skos:prefLabel "Ballett"@de .
-
-<#n804000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n800000> ;
-    skos:narrower <#n804020> ;
-    skos:notation "804000" ;
-    skos:prefLabel "Film"@de .
-
-<#n804020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n804000> ;
-    skos:notation "804020" ;
-    skos:prefLabel "Filmtheater"@de .
-
-<#n806000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n800000> ;
-    skos:narrower <#n806020> ;
-    skos:notation "806000" ;
-    skos:prefLabel "Kleinkunst"@de .
-
-<#n806020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n806000> ;
-    skos:notation "806020" ;
-    skos:prefLabel "Kabarett"@de .
-
-<#n820000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n820100>, <#n821000>, <#n822000>, <#n822400>, <#n822500>, <#n823000>, <#n824000>, <#n824500>, <#n825000>, <#n826000>, <#n827000>, <#n828000>, <#n829000> ;
-    skos:notation "820000" ;
-    skos:prefLabel "Musik"@de .
-
-<#n820100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "820100" ;
-    skos:prefLabel "Musik allgemein"@de .
-
-<#n821000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "821000" ;
-    skos:prefLabel "Musikwissenschaft"@de .
-
-<#n822000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "822000" ;
-    skos:prefLabel "Musikerin. Musiker / Ausbildung"@de .
-
-<#n822400>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "822400" ;
-    skos:prefLabel "Musikförderung"@de .
-
-<#n822500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "822500" ;
-    skos:prefLabel "Musikpreis"@de .
-
-<#n823000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "823000" ;
-    skos:prefLabel "Musik / Geschichte"@de .
-
-<#n824000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:narrower <#n824020>, <#n824040>, <#n824060>, <#n824080> ;
-    skos:notation "824000" ;
-    skos:prefLabel "Musikerin. Musiker"@de .
-
-<#n824020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n824000> ;
-    skos:notation "824020" ;
-    skos:prefLabel "Instrumentalmusikerin. Instrumentalmusiker"@de .
-
-<#n824040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n824000> ;
-    skos:notation "824040" ;
-    skos:prefLabel "Komponistin. Komponist"@de .
-
-<#n824060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n824000> ;
-    skos:notation "824060" ;
-    skos:prefLabel "Dirigentin. Dirigent"@de .
-
-<#n824080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n824000> ;
-    skos:notation "824080" ;
-    skos:prefLabel "Sängerin. Sänger"@de .
-
-<#n824500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "824500" ;
-    skos:prefLabel "Chor"@de .
-
-<#n825000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "825000" ;
-    skos:prefLabel "Orchester"@de .
-
-<#n826000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:narrower <#n826020> ;
-    skos:notation "826000" ;
-    skos:prefLabel "Konzert. Musikveranstaltung"@de .
-
-<#n826020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n826000> ;
-    skos:notation "826020" ;
-    skos:prefLabel "Einzelne Aufführungen"@de .
-
-<#n827000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:narrower <#n827010> ;
-    skos:notation "827000" ;
-    skos:prefLabel "Kirchenmusik"@de .
-
-<#n827010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n827000> ;
-    skos:notation "827010" ;
-    skos:prefLabel "Kirchenmusik / Aufführung"@de .
-
-<#n828000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "828000" ;
-    skos:prefLabel "Musikinstrument"@de .
-
-<#n829000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n820000> ;
-    skos:notation "829000" ;
-    skos:prefLabel "Laienmusik"@de .
-
-<#n840000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n840100>, <#n841000>, <#n842000>, <#n843000>, <#n844000>, <#n844200>, <#n844500>, <#n845000>, <#n846000>, <#n847000>, <#n847500>, <#n848000>, <#n849000> ;
-    skos:notation "840000" ;
-    skos:prefLabel "Kunst. Architektur"@de .
-
-<#n840100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:notation "840100" ;
-    skos:prefLabel "Kunst. Architektur allgemein"@de .
-
-<#n841000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:narrower <#n841020>, <#n841040>, <#n841050>, <#n841060>, <#n841070>, <#n841080>, <#n841090> ;
-    skos:notation "841000" ;
-    skos:prefLabel "Kunst"@de .
-
-<#n841020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841000> ;
-    skos:notation "841020" ;
-    skos:prefLabel "Kunststudium"@de .
-
-<#n841040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841000> ;
-    skos:notation "841040" ;
-    skos:prefLabel "Kunstmuseum. Kunstsammlung"@de .
-
-<#n841050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841000> ;
-    skos:notation "841050" ;
-    skos:prefLabel "Kunstgalerie"@de .
-
-<#n841060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841000> ;
-    skos:notation "841060" ;
-    skos:prefLabel "Kunstausstellung"@de .
-
-<#n841070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841000> ;
-	skos:narrower <#n841072>, <#n841074>, <#n841076>, <#n841078>, <#n841079> ;
-    skos:notation "841070" ;
-    skos:prefLabel "Künstlerin.Künstler"@de .
-
-<#n841072>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841070> ;
-    skos:notation "841072" ;
-    skos:prefLabel "Bildhauerin. Bildhauer"@de .
-
-<#n841074>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841070> ;
-    skos:notation "841074" ;
-    skos:prefLabel "Malerin. Maler"@de .
-	
-<#n841076>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841070> ;
-    skos:notation "841076" ;
-    skos:prefLabel "Zeichnerin. Zeichner"@de .
-
-<#n841078>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841070> ;
-    skos:notation "841078" ;
-    skos:prefLabel "Grafikerin. Grafiker"@de .
-	
-<#n841079>
-	a skos:Concept ;
-    skos:broader <#n841070> ;
-    skos:notation "841079" ;
-    skos:prefLabel "Fotografin. Fotograf"@de .
-
-<#n841080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841000> ;
-    skos:notation "841080" ;
-    skos:prefLabel "Künstlervereinigung"@de .
-
-<#n841090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n841000> ;
-    skos:notation "841090" ;
-    skos:prefLabel "Kunstförderung"@de .
-
-<#n842000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:notation "842000" ;
-    skos:prefLabel "Kunst / Geschichte"@de .
-
-<#n843000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:narrower <#n843010>, <#n843020>, <#n843040>, <#n843050>, <#n843060>, <#n843090> ;
-    skos:notation "843000" ;
-    skos:prefLabel "Architektur"@de .
-
-<#n843010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n843000> ;
-    skos:notation "843010" ;
-    skos:prefLabel "Baukonstruktion. Bautechnik"@de .
-
-<#n843020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n843000> ;
-    skos:notation "843020" ;
-    skos:prefLabel "Öffentliches Gebäude"@de .
-
-<#n843040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n843000> ;
-    skos:narrower <#n843042>, <#n843044>, <#n843046> ;
-    skos:notation "843040" ;
-    skos:prefLabel "Büro-, Geschäfts- und Industriebauten"@de .
-
-<#n843042>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n843040> ;
-    skos:notation "843042" ;
-    skos:prefLabel "Bürohaus"@de .
-
-<#n843044>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n843040> ;
-    skos:notation "843044" ;
-    skos:prefLabel "Geschäftshaus"@de .
-
-<#n843046>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n843040> ;
-    skos:notation "843046" ;
-    skos:prefLabel "Industriebau"@de .
-
-<#n843050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n843000> ;
-    skos:notation "843050" ;
-    skos:prefLabel "Bauernhaus"@de .
-
-<#n843060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n843000> ;
-    skos:notation "843060" ;
-    skos:prefLabel "Wohnhaus"@de .
-
-<#n843090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n843000> ;
-    skos:notation "843090" ;
-    skos:prefLabel "Architektin. Architekt"@de .
-
-<#n844000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:narrower <#n844010>, <#n844020>, <#n844030>, <#n844040>, <#n844050>, <#n844060>, <#n844070>, <#n844080> ;
-    skos:notation "844000" ;
-    skos:prefLabel "Baudenkmal. Kunstwerk"@de .
-
-<#n844010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n844000> ;
-    skos:notation "844010" ;
-    skos:prefLabel "Kunst / Inventar"@de .
-
-<#n844020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n844000> ;
-    skos:notation "844020" ;
-    skos:prefLabel "Baustil"@de .
-
-<#n844030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n844000> ;
-    skos:notation "844030" ;
-    skos:prefLabel "Sakralbau"@de .
-
-<#n844040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n844000> ;
-    skos:notation "844040" ;
-    skos:prefLabel "Burg. Schloss"@de .
-
-<#n844050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n844000> ;
-    skos:notation "844050" ;
-    skos:prefLabel "Profanarchitektur"@de .
-
-<#n844060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n844000> ;
-    skos:notation "844060" ;
-    skos:prefLabel "Park. Garten"@de .
-
-<#n844070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n844000> ;
-    skos:notation "844070" ;
-    skos:prefLabel "Brunnen"@de .
-
-<#n844080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n844000> ;
-    skos:notation "844080" ;
-    skos:prefLabel "Denkmal"@de .
-
-<#n844200>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:notation "844200" ;
-    skos:prefLabel "Denkmalpflege. Denkmalschutz"@de .
-
-<#n844500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:notation "844500" ;
-    skos:prefLabel "Städtebau"@de .
-
-<#n845000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:narrower <#n845020> ;
-    skos:notation "845000" ;
-    skos:prefLabel "Plastik"@de .
-
-<#n845020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n845000> ;
-    skos:notation "845020" ;
-    skos:prefLabel "Plastik / Einzelne Objekte"@de .
-
-<#n846000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:narrower <#n846020> ;
-    skos:notation "846000" ;
-    skos:prefLabel "Malerei"@de .
-
-<#n846020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n846000> ;
-    skos:notation "846020" ;
-    skos:prefLabel "Malerei / Einzelne Objekte"@de .
-
-<#n847000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:notation "847000" ;
-    skos:prefLabel "Zeichnung"@de .
-
-<#n847500>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:notation "847500" ;
-    skos:prefLabel "Druckgrafik"@de .
-
-<#n848000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:notation "848000" ;
-    skos:prefLabel "Fotografie"@de .
-
-<#n849000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n840000> ;
-    skos:narrower <#n849020>, <#n849030>, <#n849032>, <#n849034>, <#n849040>, <#n849050>, <#n849060>, <#n849070>, <#n849080>, <#n849090> ;
-    skos:notation "849000" ;
-    skos:prefLabel "Kunsthandwerk"@de .
-
-<#n849020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:notation "849020" ;
-    skos:prefLabel "Goldschmiedekunst. Silberschmiedekunst. Schmuck"@de .
-
-<#n849030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:notation "849030" ;
-    skos:prefLabel "Eisenguss"@de .
-
-<#n849032>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:notation "849032" ;
-    skos:prefLabel "Bronzeguss"@de .
-
-<#n849034>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:notation "849034" ;
-    skos:prefLabel "Zinnguss"@de .
-
-<#n849040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:notation "849040" ;
-    skos:prefLabel "Keramik"@de .
-
-<#n849050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:narrower <#n849052>, <#n849054>, <#n849056> ;
-    skos:notation "849050" ;
-    skos:prefLabel "Porzellan. Glas. Fayence"@de .
-
-<#n849052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849050> ;
-    skos:notation "849052" ;
-    skos:prefLabel "Porzellan"@de .
-
-<#n849054>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849050> ;
-    skos:notation "849054" ;
-    skos:prefLabel "Fayence"@de .
-
-<#n849056>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849050> ;
-    skos:notation "849056" ;
-    skos:prefLabel "Glas"@de .
-
-<#n849060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:notation "849060" ;
-    skos:prefLabel "Hausrat"@de .
-
-<#n849070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:notation "849070" ;
-    skos:prefLabel "Möbel"@de .
-
-<#n849080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:narrower <#n849082>, <#n849084>, <#n849086> ;
-    skos:notation "849080" ;
-    skos:prefLabel "Textilien. Teppich. Tapete"@de .
-
-<#n849082>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849080> ;
-    skos:notation "849082" ;
-    skos:prefLabel "Textilien"@de .
-
-<#n849084>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849080> ;
-    skos:notation "849084" ;
-    skos:prefLabel "Teppich"@de .
-
-<#n849086>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849080> ;
-    skos:notation "849086" ;
-    skos:prefLabel "Tapete"@de .
-
-<#n849090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n849000> ;
-    skos:notation "849090" ;
-    skos:prefLabel "Uhr. Musikinstrument"@de .
-
-<#n860000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n860100>, <#n861000>, <#n865000> ;
-    skos:notation "860000" ;
-    skos:prefLabel "Buch. Bibliothek"@de .
-
-<#n860100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n860000> ;
-    skos:notation "860100" ;
-    skos:prefLabel "Buch. Bibliothek allgemein"@de .
-
-<#n861000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n860000> ;
-    skos:narrower <#n861010>, <#n861020>, <#n861030>, <#n861040>, <#n861050>, <#n861060> ;
-    skos:notation "861000" ;
-    skos:prefLabel "Buch"@de .
-
-<#n861010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n861000> ;
-    skos:notation "861010" ;
-    skos:prefLabel "Schrift / Geschichte"@de .
-
-<#n861020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n861000> ;
-    skos:notation "861020" ;
-    skos:prefLabel "Handschrift"@de .
-
-<#n861030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n861000> ;
-    skos:notation "861030" ;
-    skos:prefLabel "Buch / Geschichte"@de .
-
-<#n861040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n861000> ;
-    skos:notation "861040" ;
-    skos:prefLabel "Buchdruck"@de .
-
-<#n861050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n861000> ;
-    skos:narrower <#n861052>, <#n861054>, <#n861056> ;
-    skos:notation "861050" ;
-    skos:prefLabel "Verlag"@de .
-
-<#n861052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n861050> ;
-    skos:notation "861052" ;
-    skos:prefLabel "Urheberrecht"@de .
-
-<#n861054>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n861050> ;
-    skos:notation "861054" ;
-    skos:prefLabel "Verlagsrecht"@de .
-
-<#n861056>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n861050> ;
-    skos:notation "861056" ;
-    skos:prefLabel "Verlegerin. Verleger"@de .
-
-<#n861060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n861000> ;
-    skos:notation "861060" ;
-    skos:prefLabel "Buchhandel"@de .
-
-<#n865000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n860000> ;
-    skos:narrower <#n865010>, <#n865020>, <#n865030>, <#n865040>, <#n865050>, <#n865060>, <#n865070>, <#n865080>, <#n865090> ;
-    skos:notation "865000" ;
-    skos:prefLabel "Bibliothek"@de .
-
-<#n865010>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865000> ;
-    skos:notation "865010" ;
-    skos:prefLabel "Bibliotheksrecht"@de .
-
-<#n865020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865000> ;
-    skos:notation "865020" ;
-    skos:prefLabel "Bibliothek / Geschichte"@de .
-
-<#n865030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865000> ;
-    skos:notation "865030" ;
-    skos:prefLabel "Bibliotheksplanung"@de .
-
-<#n865040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865000> ;
-    skos:notation "865040" ;
-    skos:prefLabel "Wissenschaftliche Bibliothek"@de .
-
-<#n865050>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865000> ;
-    skos:narrower <#n865052>, <#n865054> ;
-    skos:notation "865050" ;
-    skos:prefLabel "Öffentliche Bibliothek"@de .
-
-<#n865052>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865050> ;
-    skos:notation "865052" ;
-    skos:prefLabel "Stadtbibliothek"@de .
-
-<#n865054>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865050> ;
-    skos:notation "865054" ;
-    skos:prefLabel "Kommunale Bibliothek"@de .
-
-<#n865060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865000> ;
-    skos:notation "865060" ;
-    skos:prefLabel "Spezialbibliothek"@de .
-
-<#n865070>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865000> ;
-    skos:notation "865070" ;
-    skos:prefLabel "Schulbibliothek"@de .
-
-<#n865080>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865000> ;
-    skos:notation "865080" ;
-    skos:prefLabel "Privatbibliothek"@de .
-
-<#n865090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n865000> ;
-    skos:notation "865090" ;
-    skos:prefLabel "Bibliothekarin. Bibliothekar"@de .
-
-<#n880000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:narrower <#n880100>, <#n882000>, <#n884000> ;
-    skos:notation "880000" ;
-    skos:prefLabel "Publizistik. Information. Dokumentation"@de .
-
-<#n880100>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n880000> ;
-    skos:notation "880100" ;
-    skos:prefLabel "Publizistik. Information. Dokumentation allgemein"@de .
-
-<#n882000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n880000> ;
-    skos:narrower <#n882020>, <#n882030>, <#n882040>, <#n882060>, <#n882090> ;
-    skos:notation "882000" ;
-    skos:prefLabel "Publizistik"@de .
-
-<#n882020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n882000> ;
-    skos:narrower <#n882022>, <#n882026> ;
-    skos:notation "882020" ;
-    skos:prefLabel "Presse"@de .
-
-<#n882022>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n882020> ;
-    skos:notation "882022" ;
-    skos:prefLabel "Presserecht"@de .
-
-<#n882026>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n882020> ;
-    skos:notation "882026" ;
-    skos:prefLabel "Zeitung. Zeitschrift"@de .
-
-<#n882030>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n882000> ;
-    skos:notation "882030" ;
-    skos:prefLabel "Audiovisuelle Medien"@de .
-
-<#n882040>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n882000> ;
-    skos:notation "882040" ;
-    skos:prefLabel "Hörfunk"@de .
-
-<#n882060>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n882000> ;
-    skos:notation "882060" ;
-    skos:prefLabel "Fernsehen"@de .
-
-<#n882090>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n882000> ;
-    skos:notation "882090" ;
-    skos:prefLabel "Journalistin. Journalist"@de .
-
-<#n884000>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n880000> ;
-    skos:narrower <#n884020> ;
-    skos:notation "884000" ;
-    skos:prefLabel "Information und Dokumentation"@de .
-
-<#n884020>
-    a skos:Concept ;
-    skos:inScheme <> ;
-    skos:broader <#n884000> ;
-    skos:notation "884020" ;
-    skos:prefLabel "Internet"@de .
+@prefix :      <http://purl.org/lobid/rpb#> .
+@prefix dct:   <http://purl.org/dc/terms/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix vann:  <http://purl.org/vocab/vann/> .
+
+<http://purl.org/lobid/rpb>
+        a                              skos:ConceptScheme ;
+        dct:description                "This classification was created for use in the bibliography of Rhineland-Palatinate (RPB). The transformation to SKOS was carried out by Felix Ostrowski for the hbz."@en ;
+        dct:issued                     "2014-01-28" ;
+        dct:license                    <http://creativecommons.org/publicdomain/zero/1.0/> ;
+        dct:modified                   "2026-01-15" ;
+        dct:publisher                  <http://lobid.org/organisations/DE-605> ;
+        dct:title                      "Systematik der Rheinland-Pfälzischen Bibliographie"@de , "Classification scheme for the bibliography of Rhineland-Palatinate"@en ;
+        vann:preferredNamespacePrefix  "rpb-spatial" ;
+        vann:preferredNamespaceUri     "http://purl.org/lobid/rpb#" ;
+        skos:hasTopConcept             :n560000 , :n260000 , :n550000 , :n420000 , :n630000 , :n500000 , :n580000 , :n700000 , :n820000 , :n650000 , :n240000 , :n100000 , :n520000 , :n120000 , :n840000 , :n760000 , :n160000 , :n800000 , :n530000 , :n860000 , :n220000 , :n210000 , :n610000 , :n140000 , :n440000 , :n570000 , :n540000 , :n400000 , :n720000 , :n200000 , :n780000 , :n880000 , :n790000 , :n740000 , :n730000 .
+
+:n100000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Landeskunde"@de .
+
+:n100100  a              skos:Concept ;
+        skos:broader     :n100000 ;
+        skos:definition  "Landeskunde (n100000) > Landeskunde allgemein (n100100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "100100" ;
+        skos:prefLabel   "Landeskunde allgemein"@de .
+
+:n101000  a              skos:Concept ;
+        skos:broader     :n100000 ;
+        skos:definition  "Landeskunde (n100000) > Bibliografie (n101000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "101000" ;
+        skos:prefLabel   "Bibliografie"@de .
+
+:n102000  a              skos:Concept ;
+        skos:broader     :n100000 ;
+        skos:definition  "Landeskunde (n100000) > Landesbeschreibung (n102000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "102000" ;
+        skos:prefLabel   "Landesbeschreibung"@de .
+
+:n102040  a              skos:Concept ;
+        skos:broader     :n102000 ;
+        skos:definition  "Landeskunde (n100000) > Landesbeschreibung (n102000) > Kreisbeschreibung (n102040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "102040" ;
+        skos:prefLabel   "Kreisbeschreibung"@de .
+
+:n102042  a              skos:Concept ;
+        skos:broader     :n102000 ;
+        skos:definition  "Landeskunde (n100000) > Landesbeschreibung (n102000) > Verbandsgemeindebeschreibung (n102042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "102042" ;
+        skos:prefLabel   "Verbandsgemeindebeschreibung"@de .
+
+:n102045  a              skos:Concept ;
+        skos:broader     :n102000 ;
+        skos:definition  "Landeskunde (n100000) > Landesbeschreibung (n102000) > Regionenbeschreibung (n102045)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "102045" ;
+        skos:prefLabel   "Regionenbeschreibung"@de .
+
+:n102050  a              skos:Concept ;
+        skos:broader     :n102000 ;
+        skos:definition  "Landeskunde (n100000) > Landesbeschreibung (n102000) > Ortsbeschreibung (n102050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "102050" ;
+        skos:prefLabel   "Ortsbeschreibung"@de .
+
+:n102060  a              skos:Concept ;
+        skos:broader     :n102000 ;
+        skos:definition  "Landeskunde (n100000) > Landesbeschreibung (n102000) > Reisebericht (n102060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "102060" ;
+        skos:prefLabel   "Reisebericht"@de .
+
+:n102070  a              skos:Concept ;
+        skos:broader     :n102000 ;
+        skos:definition  "Landeskunde (n100000) > Landesbeschreibung (n102000) > Wandern / Führer (n102070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "102070" ;
+        skos:prefLabel   "Wandern / Führer"@de .
+
+:n105000  a              skos:Concept ;
+        skos:broader     :n100000 ;
+        skos:definition  "Landeskunde (n100000) > Heimatpflege (n105000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "105000" ;
+        skos:prefLabel   "Heimatpflege"@de .
+
+:n106000  a              skos:Concept ;
+        skos:broader     :n100000 ;
+        skos:definition  "Landeskunde (n100000) > Heimatverein (n106000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "106000" ;
+        skos:prefLabel   "Heimatverein"@de .
+
+:n109000  a              skos:Concept ;
+        skos:broader     :n100000 ;
+        skos:definition  "Landeskunde (n100000) > Biografie (n109000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "109000" ;
+        skos:prefLabel   "Biografie"@de .
+
+:n120000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Kartografie. Geodäsie"@de .
+
+:n120100  a              skos:Concept ;
+        skos:broader     :n120000 ;
+        skos:definition  "Kartografie. Geodäsie (n120000) > Kartografie. Geodäsie allgemein (n120100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "120100" ;
+        skos:prefLabel   "Kartografie. Geodäsie allgemein"@de .
+
+:n122000  a              skos:Concept ;
+        skos:broader     :n120000 ;
+        skos:definition  "Kartografie. Geodäsie (n120000) > Kartografie (n122000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "122000" ;
+        skos:prefLabel   "Kartografie"@de .
+
+:n122030  a              skos:Concept ;
+        skos:broader     :n122000 ;
+        skos:definition  "Kartografie. Geodäsie (n120000) > Kartografie (n122000) > Kartenauswertung (n122030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "122030" ;
+        skos:prefLabel   "Kartenauswertung"@de .
+
+:n122050  a              skos:Concept ;
+        skos:broader     :n122000 ;
+        skos:definition  "Kartografie. Geodäsie (n120000) > Kartografie (n122000) > Computerkartografie (n122050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "122050" ;
+        skos:prefLabel   "Computerkartografie"@de .
+
+:n122070  a              skos:Concept ;
+        skos:broader     :n122000 ;
+        skos:definition  "Kartografie. Geodäsie (n120000) > Kartografie (n122000) > Luftbildauswertung (n122070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "122070" ;
+        skos:prefLabel   "Luftbildauswertung"@de .
+
+:n124000  a              skos:Concept ;
+        skos:broader     :n120000 ;
+        skos:definition  "Kartografie. Geodäsie (n120000) > Geodäsie (n124000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "124000" ;
+        skos:prefLabel   "Geodäsie"@de .
+
+:n126000  a              skos:Concept ;
+        skos:broader     :n120000 ;
+        skos:definition  "Kartografie. Geodäsie (n120000) > Karte (n126000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "126000" ;
+        skos:prefLabel   "Karte"@de .
+
+:n140000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Geowissenschaften"@de .
+
+:n140100  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Geowissenschaften allgemein (n140100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "140100" ;
+        skos:prefLabel   "Geowissenschaften allgemein"@de .
+
+:n141000  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Geophysik (n141000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141000" ;
+        skos:prefLabel   "Geophysik"@de .
+
+:n141020  a              skos:Concept ;
+        skos:broader     :n141000 ;
+        skos:definition  "Geowissenschaften (n140000) > Geophysik (n141000) > Erdmagnetismus (n141020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141020" ;
+        skos:prefLabel   "Erdmagnetismus"@de .
+
+:n141030  a              skos:Concept ;
+        skos:broader     :n141000 ;
+        skos:definition  "Geowissenschaften (n140000) > Geophysik (n141000) > Schwere (n141030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141030" ;
+        skos:prefLabel   "Schwere"@de .
+
+:n141040  a              skos:Concept ;
+        skos:broader     :n141000 ;
+        skos:definition  "Geowissenschaften (n140000) > Geophysik (n141000) > Erdbeben (n141040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141040" ;
+        skos:prefLabel   "Erdbeben"@de .
+
+:n141200  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Geologie (n141200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141200" ;
+        skos:prefLabel   "Geologie"@de .
+
+:n141220  a              skos:Concept ;
+        skos:broader     :n141200 ;
+        skos:definition  "Geowissenschaften (n140000) > Geologie (n141200) > Tektonik (n141220)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141220" ;
+        skos:prefLabel   "Tektonik"@de .
+
+:n141230  a              skos:Concept ;
+        skos:broader     :n141200 ;
+        skos:definition  "Geowissenschaften (n140000) > Geologie (n141200) > Ingenieurgeologie (n141230)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141230" ;
+        skos:prefLabel   "Ingenieurgeologie"@de .
+
+:n141240  a              skos:Concept ;
+        skos:broader     :n141200 ;
+        skos:definition  "Geowissenschaften (n140000) > Geologie (n141200) > Stratigraphie (n141240)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141240" ;
+        skos:prefLabel   "Stratigraphie"@de .
+
+:n141400  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141400" ;
+        skos:prefLabel   "Mineralogie. Gesteinskunde"@de .
+
+:n141420  a              skos:Concept ;
+        skos:broader     :n141400 ;
+        skos:definition  "Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Mineralogie (n141420)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141420" ;
+        skos:prefLabel   "Mineralogie"@de .
+
+:n141430  a              skos:Concept ;
+        skos:broader     :n141400 ;
+        skos:definition  "Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Gesteinskunde (n141430)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141430" ;
+        skos:prefLabel   "Gesteinskunde"@de .
+
+:n141440  a              skos:Concept ;
+        skos:broader     :n141400 ;
+        skos:definition  "Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Geochemie (n141440)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141440" ;
+        skos:prefLabel   "Geochemie"@de .
+
+:n141450  a              skos:Concept ;
+        skos:broader     :n141400 ;
+        skos:definition  "Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Lagerstättenkunde (n141450)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141450" ;
+        skos:prefLabel   "Lagerstättenkunde"@de .
+
+:n141460  a              skos:Concept ;
+        skos:broader     :n141400 ;
+        skos:definition  "Geowissenschaften (n140000) > Mineralogie. Gesteinskunde (n141400) > Mineralquelle. Thermalquelle (n141460)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141460" ;
+        skos:prefLabel   "Mineralquelle. Thermalquelle"@de .
+
+:n141600  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Paläontologie (n141600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141600" ;
+        skos:prefLabel   "Paläontologie"@de .
+
+:n141620  a              skos:Concept ;
+        skos:broader     :n141600 ;
+        skos:definition  "Geowissenschaften (n140000) > Paläontologie (n141600) > Paläobotanik (n141620)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141620" ;
+        skos:prefLabel   "Paläobotanik"@de .
+
+:n141622  a              skos:Concept ;
+        skos:broader     :n141620 ;
+        skos:definition  "Geowissenschaften (n140000) > Paläontologie (n141600) > Paläobotanik (n141620) > Fossile Sporenpflanzen (n141622)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141622" ;
+        skos:prefLabel   "Fossile Sporenpflanzen"@de .
+
+:n141624  a              skos:Concept ;
+        skos:broader     :n141620 ;
+        skos:definition  "Geowissenschaften (n140000) > Paläontologie (n141600) > Paläobotanik (n141620) > Fossile Samenpflanzen (n141624)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141624" ;
+        skos:prefLabel   "Fossile Samenpflanzen"@de .
+
+:n141630  a              skos:Concept ;
+        skos:broader     :n141600 ;
+        skos:definition  "Geowissenschaften (n140000) > Paläontologie (n141600) > Paläozoologie (n141630)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141630" ;
+        skos:prefLabel   "Paläozoologie"@de .
+
+:n141632  a              skos:Concept ;
+        skos:broader     :n141630 ;
+        skos:definition  "Geowissenschaften (n140000) > Paläontologie (n141600) > Paläozoologie (n141630) > Fossile Wirbellose (n141632)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141632" ;
+        skos:prefLabel   "Fossile Wirbellose"@de .
+
+:n141634  a              skos:Concept ;
+        skos:broader     :n141630 ;
+        skos:definition  "Geowissenschaften (n140000) > Paläontologie (n141600) > Paläozoologie (n141630) > Fossile Wirbeltiere (n141634)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141634" ;
+        skos:prefLabel   "Fossile Wirbeltiere"@de .
+
+:n141640  a              skos:Concept ;
+        skos:broader     :n141600 ;
+        skos:definition  "Geowissenschaften (n140000) > Paläontologie (n141600) > Mikropaläontologie (n141640)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "141640" ;
+        skos:prefLabel   "Mikropaläontologie"@de .
+
+:n142000  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Bodenkunde (n142000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142000" ;
+        skos:prefLabel   "Bodenkunde"@de .
+
+:n142020  a              skos:Concept ;
+        skos:broader     :n142000 ;
+        skos:definition  "Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenentwicklung (n142020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142020" ;
+        skos:prefLabel   "Bodenentwicklung"@de .
+
+:n142030  a              skos:Concept ;
+        skos:broader     :n142000 ;
+        skos:definition  "Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenphysik (n142030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142030" ;
+        skos:prefLabel   "Bodenphysik"@de .
+
+:n142040  a              skos:Concept ;
+        skos:broader     :n142000 ;
+        skos:definition  "Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenbiologie (n142040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142040" ;
+        skos:prefLabel   "Bodenbiologie"@de .
+
+:n142050  a              skos:Concept ;
+        skos:broader     :n142000 ;
+        skos:definition  "Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenmechanik (n142050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142050" ;
+        skos:prefLabel   "Bodenmechanik"@de .
+
+:n142060  a              skos:Concept ;
+        skos:broader     :n142000 ;
+        skos:definition  "Geowissenschaften (n140000) > Bodenkunde (n142000) > Bodenchemie (n142060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142060" ;
+        skos:prefLabel   "Bodenchemie"@de .
+
+:n142100  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Geomorphologie (n142100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142100" ;
+        skos:prefLabel   "Geomorphologie"@de .
+
+:n142110  a              skos:Concept ;
+        skos:broader     :n142100 ;
+        skos:definition  "Geowissenschaften (n140000) > Geomorphologie (n142100) > Relief / Geografie (n142110)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142110" ;
+        skos:prefLabel   "Relief / Geografie"@de .
+
+:n142120  a              skos:Concept ;
+        skos:broader     :n142100 ;
+        skos:definition  "Geowissenschaften (n140000) > Geomorphologie (n142100) > Abtragung (n142120)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142120" ;
+        skos:prefLabel   "Abtragung"@de .
+
+:n142130  a              skos:Concept ;
+        skos:broader     :n142100 ;
+        skos:definition  "Geowissenschaften (n140000) > Geomorphologie (n142100) > Klimamorphologie (n142130)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142130" ;
+        skos:prefLabel   "Klimamorphologie"@de .
+
+:n142140  a              skos:Concept ;
+        skos:broader     :n142100 ;
+        skos:definition  "Geowissenschaften (n140000) > Geomorphologie (n142100) > Glazialmorphologie. Periglazialgeomorphologie (n142140)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142140" ;
+        skos:prefLabel   "Glazialmorphologie. Periglazialgeomorphologie"@de .
+
+:n142150  a              skos:Concept ;
+        skos:broader     :n142100 ;
+        skos:definition  "Geowissenschaften (n140000) > Geomorphologie (n142100) > Vulkanismus (n142150)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142150" ;
+        skos:prefLabel   "Vulkanismus"@de .
+
+:n142170  a              skos:Concept ;
+        skos:broader     :n142100 ;
+        skos:definition  "Geowissenschaften (n140000) > Geomorphologie (n142100) > Karst (n142170)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142170" ;
+        skos:prefLabel   "Karst"@de .
+
+:n142180  a              skos:Concept ;
+        skos:broader     :n142100 ;
+        skos:definition  "Geowissenschaften (n140000) > Geomorphologie (n142100) > Höhle (n142180)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142180" ;
+        skos:prefLabel   "Höhle"@de .
+
+:n142190  a              skos:Concept ;
+        skos:broader     :n142100 ;
+        skos:definition  "Geowissenschaften (n140000) > Geomorphologie (n142100) > Angewandte Geomorphologie (n142190)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142190" ;
+        skos:prefLabel   "Angewandte Geomorphologie"@de .
+
+:n142300  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142300" ;
+        skos:prefLabel   "Wasser"@de .
+
+:n142310  a              skos:Concept ;
+        skos:broader     :n142300 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Wasserrecht (n142310)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142310" ;
+        skos:prefLabel   "Wasserrecht"@de .
+
+:n142320  a              skos:Concept ;
+        skos:broader     :n142300 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Fließgewässer (n142320)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142320" ;
+        skos:prefLabel   "Fließgewässer"@de .
+
+:n142323  a              skos:Concept ;
+        skos:broader     :n142320 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Fließgewässer (n142320) > Hochwasser (n142323)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142323" ;
+        skos:prefLabel   "Hochwasser"@de .
+
+:n142325  a              skos:Concept ;
+        skos:broader     :n142320 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Fließgewässer (n142320) > Niedrigwasser (n142325)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142325" ;
+        skos:prefLabel   "Niedrigwasser"@de .
+
+:n142330  a              skos:Concept ;
+        skos:broader     :n142300 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > See (n142330)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142330" ;
+        skos:prefLabel   "See"@de .
+
+:n142340  a              skos:Concept ;
+        skos:broader     :n142300 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Moor (n142340)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142340" ;
+        skos:prefLabel   "Moor"@de .
+
+:n142350  a              skos:Concept ;
+        skos:broader     :n142300 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Hydrogeologie (n142350)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142350" ;
+        skos:prefLabel   "Hydrogeologie"@de .
+
+:n142352  a              skos:Concept ;
+        skos:broader     :n142350 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Hydrogeologie (n142350) > Bodenwasser (n142352)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142352" ;
+        skos:prefLabel   "Bodenwasser"@de .
+
+:n142360  a              skos:Concept ;
+        skos:broader     :n142300 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Wasserhaushalt (n142360)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142360" ;
+        skos:prefLabel   "Wasserhaushalt"@de .
+
+:n142370  a              skos:Concept ;
+        skos:broader     :n142300 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Wasserwirtschaft (n142370)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142370" ;
+        skos:prefLabel   "Wasserwirtschaft"@de .
+
+:n142372  a              skos:Concept ;
+        skos:broader     :n142370 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Wasserwirtschaft (n142370) > Trinkwasserversorgung (n142372)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142372" ;
+        skos:prefLabel   "Trinkwasserversorgung"@de .
+
+:n142375  a              skos:Concept ;
+        skos:broader     :n142370 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Wasserwirtschaft (n142370) > Brauchwasser (n142375)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142375" ;
+        skos:prefLabel   "Brauchwasser"@de .
+
+:n142380  a              skos:Concept ;
+        skos:broader     :n142300 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Hydroökologie (n142380)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142380" ;
+        skos:prefLabel   "Hydroökologie"@de .
+
+:n142382  a              skos:Concept ;
+        skos:broader     :n142380 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Hydroökologie (n142380) > Wasseranalyse (n142382)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142382" ;
+        skos:prefLabel   "Wasseranalyse"@de .
+
+:n142390  a              skos:Concept ;
+        skos:broader     :n142300 ;
+        skos:definition  "Geowissenschaften (n140000) > Wasser (n142300) > Wasserstatistik (n142390)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142390" ;
+        skos:prefLabel   "Wasserstatistik"@de .
+
+:n142500  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142500" ;
+        skos:prefLabel   "Klima"@de .
+
+:n142520  a              skos:Concept ;
+        skos:broader     :n142500 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142520" ;
+        skos:prefLabel   "Klimaelement"@de .
+
+:n142522  a              skos:Concept ;
+        skos:broader     :n142520 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Sonnenstrahlung (n142522)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142522" ;
+        skos:prefLabel   "Sonnenstrahlung"@de .
+
+:n142523  a              skos:Concept ;
+        skos:broader     :n142520 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Lufttemperatur (n142523)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142523" ;
+        skos:prefLabel   "Lufttemperatur"@de .
+
+:n142524  a              skos:Concept ;
+        skos:broader     :n142520 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Luftfeuchtigkeit (n142524)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142524" ;
+        skos:prefLabel   "Luftfeuchtigkeit"@de .
+
+:n142525  a              skos:Concept ;
+        skos:broader     :n142520 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Luftdruck (n142525)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142525" ;
+        skos:prefLabel   "Luftdruck"@de .
+
+:n142526  a              skos:Concept ;
+        skos:broader     :n142520 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Luftbewegung (n142526)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142526" ;
+        skos:prefLabel   "Luftbewegung"@de .
+
+:n142527  a              skos:Concept ;
+        skos:broader     :n142520 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimaelement (n142520) > Luftelektrizität (n142527)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142527" ;
+        skos:prefLabel   "Luftelektrizität"@de .
+
+:n142530  a              skos:Concept ;
+        skos:broader     :n142500 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimatologie (n142530)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142530" ;
+        skos:prefLabel   "Klimatologie"@de .
+
+:n142540  a              skos:Concept ;
+        skos:broader     :n142500 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Wetterdienst (n142540)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142540" ;
+        skos:prefLabel   "Wetterdienst"@de .
+
+:n142541  a              skos:Concept ;
+        skos:broader     :n142500 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Wetterlage (n142541)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142541" ;
+        skos:prefLabel   "Wetterlage"@de .
+
+:n142550  a              skos:Concept ;
+        skos:broader     :n142500 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimafaktor (n142550)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142550" ;
+        skos:prefLabel   "Klimafaktor"@de .
+
+:n142560  a              skos:Concept ;
+        skos:broader     :n142500 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Klimaschwankung (n142560)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142560" ;
+        skos:prefLabel   "Klimaschwankung"@de .
+
+:n142570  a              skos:Concept ;
+        skos:broader     :n142500 ;
+        skos:definition  "Geowissenschaften (n140000) > Klima (n142500) > Paläoklimatologie (n142570)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "142570" ;
+        skos:prefLabel   "Paläoklimatologie"@de .
+
+:n146000  a              skos:Concept ;
+        skos:broader     :n140000 ;
+        skos:definition  "Geowissenschaften (n140000) > Geoökologie (n146000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "146000" ;
+        skos:prefLabel   "Geoökologie"@de .
+
+:n160000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Biowissenschaften"@de .
+
+:n160100  a              skos:Concept ;
+        skos:broader     :n160000 ;
+        skos:definition  "Biowissenschaften (n160000) > Biowissenschaften allgemein (n160100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "160100" ;
+        skos:prefLabel   "Biowissenschaften allgemein"@de .
+
+:n161000  a              skos:Concept ;
+        skos:broader     :n160000 ;
+        skos:definition  "Biowissenschaften (n160000) > Biologie (n161000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "161000" ;
+        skos:prefLabel   "Biologie"@de .
+
+:n161030  a              skos:Concept ;
+        skos:broader     :n161000 ;
+        skos:definition  "Biowissenschaften (n160000) > Biologie (n161000) > Ökologie (n161030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "161030" ;
+        skos:prefLabel   "Ökologie"@de .
+
+:n161040  a              skos:Concept ;
+        skos:broader     :n161000 ;
+        skos:definition  "Biowissenschaften (n160000) > Biologie (n161000) > Biozönose (n161040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "161040" ;
+        skos:prefLabel   "Biozönose"@de .
+
+:n161050  a              skos:Concept ;
+        skos:broader     :n161000 ;
+        skos:definition  "Biowissenschaften (n160000) > Biologie (n161000) > Mikrobiologie (n161050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "161050" ;
+        skos:prefLabel   "Mikrobiologie"@de .
+
+:n162000  a              skos:Concept ;
+        skos:broader     :n160000 ;
+        skos:definition  "Biowissenschaften (n160000) > Pflanzen (n162000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "162000" ;
+        skos:prefLabel   "Pflanzen"@de .
+
+:n162030  a              skos:Concept ;
+        skos:broader     :n162000 ;
+        skos:definition  "Biowissenschaften (n160000) > Pflanzen (n162000) > Kryptogamen (n162030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "162030" ;
+        skos:prefLabel   "Kryptogamen"@de .
+
+:n162040  a              skos:Concept ;
+        skos:broader     :n162000 ;
+        skos:definition  "Biowissenschaften (n160000) > Pflanzen (n162000) > Samenpflanzen (n162040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "162040" ;
+        skos:prefLabel   "Samenpflanzen"@de .
+
+:n163000  a              skos:Concept ;
+        skos:broader     :n160000 ;
+        skos:definition  "Biowissenschaften (n160000) > Tiere (n163000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "163000" ;
+        skos:prefLabel   "Tiere"@de .
+
+:n163020  a              skos:Concept ;
+        skos:broader     :n163000 ;
+        skos:definition  "Biowissenschaften (n160000) > Tiere (n163000) > Wirbellose (n163020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "163020" ;
+        skos:prefLabel   "Wirbellose"@de .
+
+:n163030  a              skos:Concept ;
+        skos:broader     :n163000 ;
+        skos:definition  "Biowissenschaften (n160000) > Tiere (n163000) > Insekten (n163030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "163030" ;
+        skos:prefLabel   "Insekten"@de .
+
+:n163040  a              skos:Concept ;
+        skos:broader     :n163000 ;
+        skos:definition  "Biowissenschaften (n160000) > Tiere (n163000) > Wirbeltiere (n163040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "163040" ;
+        skos:prefLabel   "Wirbeltiere"@de .
+
+:n163050  a              skos:Concept ;
+        skos:broader     :n163000 ;
+        skos:definition  "Biowissenschaften (n160000) > Tiere (n163000) > Fische (n163050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "163050" ;
+        skos:prefLabel   "Fische"@de .
+
+:n163060  a              skos:Concept ;
+        skos:broader     :n163000 ;
+        skos:definition  "Biowissenschaften (n160000) > Tiere (n163000) > Lurche (n163060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "163060" ;
+        skos:prefLabel   "Lurche"@de .
+
+:n163070  a              skos:Concept ;
+        skos:broader     :n163000 ;
+        skos:definition  "Biowissenschaften (n160000) > Tiere (n163000) > Reptilien (n163070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "163070" ;
+        skos:prefLabel   "Reptilien"@de .
+
+:n163080  a              skos:Concept ;
+        skos:broader     :n163000 ;
+        skos:definition  "Biowissenschaften (n160000) > Tiere (n163000) > Vögel (n163080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "163080" ;
+        skos:prefLabel   "Vögel"@de .
+
+:n163090  a              skos:Concept ;
+        skos:broader     :n163000 ;
+        skos:definition  "Biowissenschaften (n160000) > Tiere (n163000) > Säugetiere (n163090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "163090" ;
+        skos:prefLabel   "Säugetiere"@de .
+
+:n164000  a              skos:Concept ;
+        skos:broader     :n160000 ;
+        skos:definition  "Biowissenschaften (n160000) > Humanbiologie (n164000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "164000" ;
+        skos:prefLabel   "Humanbiologie"@de .
+
+:n164020  a              skos:Concept ;
+        skos:broader     :n164000 ;
+        skos:definition  "Biowissenschaften (n160000) > Humanbiologie (n164000) > Menschenrasse (n164020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "164020" ;
+        skos:prefLabel   "Menschenrasse"@de .
+
+:n164030  a              skos:Concept ;
+        skos:broader     :n164000 ;
+        skos:definition  "Biowissenschaften (n160000) > Humanbiologie (n164000) > Skelettfund (n164030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "164030" ;
+        skos:prefLabel   "Skelettfund"@de .
+
+:n164040  a              skos:Concept ;
+        skos:broader     :n164000 ;
+        skos:definition  "Biowissenschaften (n160000) > Humanbiologie (n164000) > Paläoanthropologie (n164040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "164040" ;
+        skos:prefLabel   "Paläoanthropologie"@de .
+
+:n200000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Historische Hilfswissenschaften"@de .
+
+:n200100  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Historische Hilfswissenschaften allgemein (n200100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "200100" ;
+        skos:prefLabel   "Historische Hilfswissenschaften allgemein"@de .
+
+:n202000  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Chronologie (n202000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "202000" ;
+        skos:prefLabel   "Chronologie"@de .
+
+:n202500  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Metrologie (n202500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "202500" ;
+        skos:prefLabel   "Metrologie"@de .
+
+:n203000  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Urkundenlehre (n203000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "203000" ;
+        skos:prefLabel   "Urkundenlehre"@de .
+
+:n203500  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Paläografie (n203500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "203500" ;
+        skos:prefLabel   "Paläografie"@de .
+
+:n204000  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Siegelkunde (n204000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "204000" ;
+        skos:prefLabel   "Siegelkunde"@de .
+
+:n205000  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Numismatik (n205000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "205000" ;
+        skos:prefLabel   "Numismatik"@de .
+
+:n205020  a              skos:Concept ;
+        skos:broader     :n205000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Numismatik (n205000) > Münze (n205020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "205020" ;
+        skos:prefLabel   "Münze"@de .
+
+:n205030  a              skos:Concept ;
+        skos:broader     :n205000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Numismatik (n205000) > Papiergeld (n205030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "205030" ;
+        skos:prefLabel   "Papiergeld"@de .
+
+:n206000  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Epigraphik (n206000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "206000" ;
+        skos:prefLabel   "Epigraphik"@de .
+
+:n207000  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Genealogie (n207000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "207000" ;
+        skos:prefLabel   "Genealogie"@de .
+
+:n207020  a              skos:Concept ;
+        skos:broader     :n207000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Genealogie (n207000) > Familie (n207020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "207020" ;
+        skos:prefLabel   "Familie"@de .
+
+:n208000  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Heraldik (n208000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "208000" ;
+        skos:prefLabel   "Heraldik"@de .
+
+:n208500  a              skos:Concept ;
+        skos:broader     :n208000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Heraldik (n208000) > Flagge (n208500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "208500" ;
+        skos:prefLabel   "Flagge"@de .
+
+:n209000  a              skos:Concept ;
+        skos:broader     :n200000 ;
+        skos:definition  "Historische Hilfswissenschaften (n200000) > Orden / Ehrenzeichen (n209000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "209000" ;
+        skos:prefLabel   "Orden / Ehrenzeichen"@de .
+
+:n210000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Archiv. Museum"@de .
+
+:n210100  a              skos:Concept ;
+        skos:broader     :n210000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv. Museum allgemein (n210100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "210100" ;
+        skos:prefLabel   "Archiv. Museum allgemein"@de .
+
+:n213000  a              skos:Concept ;
+        skos:broader     :n210000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213000" ;
+        skos:prefLabel   "Archiv"@de .
+
+:n213010  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Bundesarchiv Koblenz (n213010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213010" ;
+        skos:prefLabel   "Bundesarchiv Koblenz"@de .
+
+:n213020  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Staatsarchiv (n213020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213020" ;
+        skos:prefLabel   "Staatsarchiv"@de .
+
+:n213030  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Kreisarchiv. Gemeindearchiv (n213030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213030" ;
+        skos:prefLabel   "Kreisarchiv. Gemeindearchiv"@de .
+
+:n213031  a              skos:Concept ;
+        skos:broader     :n213030 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Kreisarchiv. Gemeindearchiv (n213030) > Kreisarchiv (n213031)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213031" ;
+        skos:prefLabel   "Kreisarchiv"@de .
+
+:n213033  a              skos:Concept ;
+        skos:broader     :n213030 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Kreisarchiv. Gemeindearchiv (n213030) > Gemeindearchiv (n213033)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213033" ;
+        skos:prefLabel   "Gemeindearchiv"@de .
+
+:n213040  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Kirchenarchiv (n213040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213040" ;
+        skos:prefLabel   "Kirchenarchiv"@de .
+
+:n213050  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Archiv für Literatur, Kunst und Wissenschaft (n213050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213050" ;
+        skos:prefLabel   "Archiv für Literatur, Kunst und Wissenschaft"@de .
+
+:n213052  a              skos:Concept ;
+        skos:broader     :n213050 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Archiv für Literatur, Kunst und Wissenschaft (n213050) > Literaturarchiv (n213052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213052" ;
+        skos:prefLabel   "Literaturarchiv"@de .
+
+:n213053  a              skos:Concept ;
+        skos:broader     :n213050 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Archiv für Literatur, Kunst und Wissenschaft (n213050) > Kunstarchiv (n213053)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213053" ;
+        skos:prefLabel   "Kunstarchiv"@de .
+
+:n213054  a              skos:Concept ;
+        skos:broader     :n213050 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Archiv für Literatur, Kunst und Wissenschaft (n213050) > Wissenschaftsarchiv (n213054)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213054" ;
+        skos:prefLabel   "Wissenschaftsarchiv"@de .
+
+:n213060  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Parteiarchiv (n213060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213060" ;
+        skos:prefLabel   "Parteiarchiv"@de .
+
+:n213070  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Medienarchiv (n213070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213070" ;
+        skos:prefLabel   "Medienarchiv"@de .
+
+:n213072  a              skos:Concept ;
+        skos:broader     :n213070 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Medienarchiv (n213070) > Rundfunkarchiv (n213072)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213072" ;
+        skos:prefLabel   "Rundfunkarchiv"@de .
+
+:n213073  a              skos:Concept ;
+        skos:broader     :n213070 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Medienarchiv (n213070) > Pressearchiv (n213073)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213073" ;
+        skos:prefLabel   "Pressearchiv"@de .
+
+:n213074  a              skos:Concept ;
+        skos:broader     :n213070 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Medienarchiv (n213070) > Filmarchiv (n213074)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213074" ;
+        skos:prefLabel   "Filmarchiv"@de .
+
+:n213080  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Wirtschaftsarchiv (n213080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213080" ;
+        skos:prefLabel   "Wirtschaftsarchiv"@de .
+
+:n213082  a              skos:Concept ;
+        skos:broader     :n213080 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Wirtschaftsarchiv (n213080) > Firmenarchiv (n213082)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213082" ;
+        skos:prefLabel   "Firmenarchiv"@de .
+
+:n213090  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Familienarchiv (n213090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213090" ;
+        skos:prefLabel   "Familienarchiv"@de .
+
+:n213092  a              skos:Concept ;
+        skos:broader     :n213000 ;
+        skos:definition  "Archiv. Museum (n210000) > Archiv (n213000) > Sonstige Archive (n213092)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "213092" ;
+        skos:prefLabel   "Sonstige Archive"@de .
+
+:n217000  a              skos:Concept ;
+        skos:broader     :n210000 ;
+        skos:definition  "Archiv. Museum (n210000) > Museum (n217000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "217000" ;
+        skos:prefLabel   "Museum"@de .
+
+:n217010  a              skos:Concept ;
+        skos:broader     :n217000 ;
+        skos:definition  "Archiv. Museum (n210000) > Museum (n217000) > Museumspädagogik (n217010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "217010" ;
+        skos:prefLabel   "Museumspädagogik"@de .
+
+:n217020  a              skos:Concept ;
+        skos:broader     :n217000 ;
+        skos:definition  "Archiv. Museum (n210000) > Museum (n217000) > Naturkundemuseum (n217020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "217020" ;
+        skos:prefLabel   "Naturkundemuseum"@de .
+
+:n217030  a              skos:Concept ;
+        skos:broader     :n217000 ;
+        skos:definition  "Archiv. Museum (n210000) > Museum (n217000) > Technisches Museum (n217030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "217030" ;
+        skos:prefLabel   "Technisches Museum"@de .
+
+:n217040  a              skos:Concept ;
+        skos:broader     :n217000 ;
+        skos:definition  "Archiv. Museum (n210000) > Museum (n217000) > Historisches Museum. Heimatmuseum (n217040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "217040" ;
+        skos:prefLabel   "Historisches Museum. Heimatmuseum"@de .
+
+:n217050  a              skos:Concept ;
+        skos:broader     :n217000 ;
+        skos:definition  "Archiv. Museum (n210000) > Museum (n217000) > Volkskundemuseum (n217050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "217050" ;
+        skos:prefLabel   "Volkskundemuseum"@de .
+
+:n217090  a              skos:Concept ;
+        skos:broader     :n217000 ;
+        skos:definition  "Archiv. Museum (n210000) > Museum (n217000) > Sonstige Museen (n217090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "217090" ;
+        skos:prefLabel   "Sonstige Museen"@de .
+
+:n220000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Vor- und Frühgeschichte. Archäologie"@de .
+
+:n220100  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Vor- und Frühgeschichte. Archäologie allgemein (n220100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "220100" ;
+        skos:prefLabel   "Vor- und Frühgeschichte. Archäologie allgemein"@de .
+
+:n220500  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Archäologie (n220500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "220500" ;
+        skos:prefLabel   "Archäologie"@de .
+
+:n221000  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Vor- und Frühgeschichte (n221000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "221000" ;
+        skos:prefLabel   "Vor- und Frühgeschichte"@de .
+
+:n222000  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Paläolithikum. Mesolithikum (n222000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "222000" ;
+        skos:prefLabel   "Paläolithikum. Mesolithikum"@de .
+
+:n223000  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "223000" ;
+        skos:prefLabel   "Neolithikum"@de .
+
+:n223020  a              skos:Concept ;
+        skos:broader     :n223000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Bandkeramik (n223020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "223020" ;
+        skos:prefLabel   "Bandkeramik"@de .
+
+:n223030  a              skos:Concept ;
+        skos:broader     :n223000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Rössener Kultur (n223030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "223030" ;
+        skos:prefLabel   "Rössener Kultur"@de .
+
+:n223040  a              skos:Concept ;
+        skos:broader     :n223000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Michelsberger Kultur (n223040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "223040" ;
+        skos:prefLabel   "Michelsberger Kultur"@de .
+
+:n223050  a              skos:Concept ;
+        skos:broader     :n223000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Megalithkultur (n223050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "223050" ;
+        skos:prefLabel   "Megalithkultur"@de .
+
+:n223060  a              skos:Concept ;
+        skos:broader     :n223000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Schnurkeramik (n223060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "223060" ;
+        skos:prefLabel   "Schnurkeramik"@de .
+
+:n223070  a              skos:Concept ;
+        skos:broader     :n223000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Neolithikum (n223000) > Glockenbecherkultur (n223070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "223070" ;
+        skos:prefLabel   "Glockenbecherkultur"@de .
+
+:n224000  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Bronzezeit (n224000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "224000" ;
+        skos:prefLabel   "Bronzezeit"@de .
+
+:n224050  a              skos:Concept ;
+        skos:broader     :n224000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Bronzezeit (n224000) > Hügelgräberkultur (n224050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "224050" ;
+        skos:prefLabel   "Hügelgräberkultur"@de .
+
+:n224060  a              skos:Concept ;
+        skos:broader     :n224000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Bronzezeit (n224000) > Urnenfelderkultur (n224060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "224060" ;
+        skos:prefLabel   "Urnenfelderkultur"@de .
+
+:n225000  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "225000" ;
+        skos:prefLabel   "Vorrömische Eisenzeit"@de .
+
+:n225020  a              skos:Concept ;
+        skos:broader     :n225000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Hallstattkultur (n225020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "225020" ;
+        skos:prefLabel   "Hallstattkultur"@de .
+
+:n225025  a              skos:Concept ;
+        skos:broader     :n225000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Hunsrück-Eifel-Kultur (n225025)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "225025" ;
+        skos:prefLabel   "Hunsrück-Eifel-Kultur"@de .
+
+:n225030  a              skos:Concept ;
+        skos:broader     :n225000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Latène-Zeit (n225030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "225030" ;
+        skos:prefLabel   "Latène-Zeit"@de .
+
+:n225040  a              skos:Concept ;
+        skos:broader     :n225000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Kelten (n225040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "225040" ;
+        skos:prefLabel   "Kelten"@de .
+
+:n225050  a              skos:Concept ;
+        skos:broader     :n225000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Vorrömische Eisenzeit (n225000) > Germanen (n225050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "225050" ;
+        skos:prefLabel   "Germanen"@de .
+
+:n226000  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "226000" ;
+        skos:prefLabel   "Römerzeit"@de .
+
+:n226020  a              skos:Concept ;
+        skos:broader     :n226000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000) > Kelten (n226020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "226020" ;
+        skos:prefLabel   "Kelten"@de .
+
+:n226030  a              skos:Concept ;
+        skos:broader     :n226000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000) > Römer (n226030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "226030" ;
+        skos:prefLabel   "Römer"@de .
+
+:n226040  a              skos:Concept ;
+        skos:broader     :n226000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000) > Germanen (n226040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "226040" ;
+        skos:prefLabel   "Germanen"@de .
+
+:n226050  a              skos:Concept ;
+        skos:broader     :n226000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Römerzeit (n226000) > Franken &lt;Volk&gt; (n226050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "226050" ;
+        skos:prefLabel   "Franken <Volk>"@de .
+
+:n227000  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Völkerwanderung (n227000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "227000" ;
+        skos:prefLabel   "Völkerwanderung"@de .
+
+:n227020  a              skos:Concept ;
+        skos:broader     :n227000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Völkerwanderung (n227000) > Römer (n227020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "227020" ;
+        skos:prefLabel   "Römer"@de .
+
+:n227030  a              skos:Concept ;
+        skos:broader     :n227000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Völkerwanderung (n227000) > Germanen (n227030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "227030" ;
+        skos:prefLabel   "Germanen"@de .
+
+:n227040  a              skos:Concept ;
+        skos:broader     :n227000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Völkerwanderung (n227000) > Franken &lt;Volk&gt; (n227040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "227040" ;
+        skos:prefLabel   "Franken <Volk>"@de .
+
+:n228000  a              skos:Concept ;
+        skos:broader     :n220000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Mittelalterliche Archäologie. Neuzeitliche Archäologie (n228000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "228000" ;
+        skos:prefLabel   "Mittelalterliche Archäologie. Neuzeitliche Archäologie"@de .
+
+:n228020  a              skos:Concept ;
+        skos:broader     :n228000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Mittelalterliche Archäologie. Neuzeitliche Archäologie (n228000) > Bestattung (n228020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "228020" ;
+        skos:prefLabel   "Bestattung"@de .
+
+:n228030  a              skos:Concept ;
+        skos:broader     :n228000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Mittelalterliche Archäologie. Neuzeitliche Archäologie (n228000) > Funde (n228030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "228030" ;
+        skos:prefLabel   "Funde"@de .
+
+:n228080  a              skos:Concept ;
+        skos:broader     :n228000 ;
+        skos:definition  "Vor- und Frühgeschichte. Archäologie (n220000) > Mittelalterliche Archäologie. Neuzeitliche Archäologie (n228000) > Industriearchäologie (n228080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "228080" ;
+        skos:prefLabel   "Industriearchäologie"@de .
+
+:n240000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Geschichte"@de .
+
+:n240100  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Quelle (n240100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "240100" ;
+        skos:prefLabel   "Quelle"@de .
+
+:n240200  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Geschichtsschreibung (n240200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "240200" ;
+        skos:prefLabel   "Geschichtsschreibung"@de .
+
+:n240300  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Regionalgeschichte (n240300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "240300" ;
+        skos:prefLabel   "Regionalgeschichte"@de .
+
+:n240350  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Verbandsgemeindegeschichte (n240350)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "240350" ;
+        skos:prefLabel   "Verbandsgemeindegeschichte"@de .
+
+:n240400  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Ortsgeschichte (n240400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "240400" ;
+        skos:prefLabel   "Ortsgeschichte"@de .
+
+:n240500  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Historische Ausstellung (n240500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "240500" ;
+        skos:prefLabel   "Historische Ausstellung"@de .
+
+:n240600  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Gedenkstätte (n240600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "240600" ;
+        skos:prefLabel   "Gedenkstätte"@de .
+
+:n241050  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Rheinland-Pfalz (gesamt) / Geschichte Anfänge-1945 (n241050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "241050" ;
+        skos:prefLabel   "Rheinland-Pfalz (gesamt) / Geschichte Anfänge-1945"@de .
+
+:n241100  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Rheinland / Geschichte Anfänge-1945 (n241100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "241100" ;
+        skos:prefLabel   "Rheinland / Geschichte Anfänge-1945"@de .
+
+:n241200  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Pfalz / Geschichte Anfänge-1945 (n241200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "241200" ;
+        skos:prefLabel   "Pfalz / Geschichte Anfänge-1945"@de .
+
+:n241400  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Rheinhessen / Geschichte Anfänge-1945 (n241400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "241400" ;
+        skos:prefLabel   "Rheinhessen / Geschichte Anfänge-1945"@de .
+
+:n242100  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Kurpfalz (n242100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242100" ;
+        skos:prefLabel   "Kurpfalz"@de .
+
+:n242200  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Hochstift Trier (n242200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242200" ;
+        skos:prefLabel   "Hochstift Trier"@de .
+
+:n242300  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Hochstift Mainz (n242300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242300" ;
+        skos:prefLabel   "Hochstift Mainz"@de .
+
+:n242500  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Hochstift Speyer (n242500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242500" ;
+        skos:prefLabel   "Hochstift Speyer"@de .
+
+:n242600  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Hochstift Worms (n242600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242600" ;
+        skos:prefLabel   "Hochstift Worms"@de .
+
+:n242700  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242700" ;
+        skos:prefLabel   "Reichsterritorium. Reichsbeziehung"@de .
+
+:n242720  a              skos:Concept ;
+        skos:broader     :n242700 ;
+        skos:definition  "Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichstag (n242720)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242720" ;
+        skos:prefLabel   "Reichstag"@de .
+
+:n242730  a              skos:Concept ;
+        skos:broader     :n242700 ;
+        skos:definition  "Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsrecht (n242730)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242730" ;
+        skos:prefLabel   "Reichsrecht"@de .
+
+:n242740  a              skos:Concept ;
+        skos:broader     :n242700 ;
+        skos:definition  "Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242740" ;
+        skos:prefLabel   "Reichsgut"@de .
+
+:n242743  a              skos:Concept ;
+        skos:broader     :n242740 ;
+        skos:definition  "Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740) > Königshof (n242743)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242743" ;
+        skos:prefLabel   "Königshof"@de .
+
+:n242744  a              skos:Concept ;
+        skos:broader     :n242740 ;
+        skos:definition  "Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740) > Königspfalz (n242744)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242744" ;
+        skos:prefLabel   "Königspfalz"@de .
+
+:n242746  a              skos:Concept ;
+        skos:broader     :n242740 ;
+        skos:definition  "Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740) > Reichsabtei (n242746)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242746" ;
+        skos:prefLabel   "Reichsabtei"@de .
+
+:n242747  a              skos:Concept ;
+        skos:broader     :n242740 ;
+        skos:definition  "Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsgut (n242740) > Reichsstadt (n242747)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242747" ;
+        skos:prefLabel   "Reichsstadt"@de .
+
+:n242760  a              skos:Concept ;
+        skos:broader     :n242700 ;
+        skos:definition  "Geschichte (n240000) > Reichsterritorium. Reichsbeziehung (n242700) > Reichsritterschaft (n242760)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242760" ;
+        skos:prefLabel   "Reichsritterschaft"@de .
+
+:n242800  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242800" ;
+        skos:prefLabel   "Kleinere Territorien und Teile auswärtiger Territorien"@de .
+
+:n242810  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Luxemburg (n242810)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242810" ;
+        skos:prefLabel   "Luxemburg"@de .
+
+:n242812  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Hochstift Köln (n242812)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242812" ;
+        skos:prefLabel   "Hochstift Köln"@de .
+
+:n242814  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Homburg, Saar (n242814)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242814" ;
+        skos:prefLabel   "Grafschaft Homburg, Saar"@de .
+
+:n242816  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Saarbrücken (n242816)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242816" ;
+        skos:prefLabel   "Grafschaft Saarbrücken"@de .
+
+:n242818  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Staat Leiningen (n242818)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242818" ;
+        skos:prefLabel   "Staat Leiningen"@de .
+
+:n242830  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Virneburg (n242830)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242830" ;
+        skos:prefLabel   "Grafschaft Virneburg"@de .
+
+:n242832  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Manderscheid (n242832)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242832" ;
+        skos:prefLabel   "Grafschaft Manderscheid"@de .
+
+:n242834  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Herzogtum Arenberg (n242834)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242834" ;
+        skos:prefLabel   "Herzogtum Arenberg"@de .
+
+:n242836  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Fürstentum Löwenstein-Wertheim (n242836)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242836" ;
+        skos:prefLabel   "Fürstentum Löwenstein-Wertheim"@de .
+
+:n242850  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Wied (n242850)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242850" ;
+        skos:prefLabel   "Grafschaft Wied"@de .
+
+:n242852  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Fürstentum Isenburg. Grafschaft Isenburg (n242852)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242852" ;
+        skos:prefLabel   "Fürstentum Isenburg. Grafschaft Isenburg"@de .
+
+:n242854  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Sayn (n242854)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242854" ;
+        skos:prefLabel   "Grafschaft Sayn"@de .
+
+:n242856  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Katzenelnbogen (n242856)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242856" ;
+        skos:prefLabel   "Grafschaft Katzenelnbogen"@de .
+
+:n242870  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Veldenz (n242870)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242870" ;
+        skos:prefLabel   "Grafschaft Veldenz"@de .
+
+:n242872  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Grafschaft Sponheim (n242872)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242872" ;
+        skos:prefLabel   "Grafschaft Sponheim"@de .
+
+:n242874  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Wild- und Rheingrafen (n242874)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242874" ;
+        skos:prefLabel   "Wild- und Rheingrafen"@de .
+
+:n242876  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Pfalz-Simmern (n242876)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242876" ;
+        skos:prefLabel   "Pfalz-Simmern"@de .
+
+:n242878  a              skos:Concept ;
+        skos:broader     :n242800 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien und Teile auswärtiger Territorien (n242800) > Hanau-Lichtenberg (n242878)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "242878" ;
+        skos:prefLabel   "Hanau-Lichtenberg"@de .
+
+:n243100  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Pfalz-Zweibrücken (n243100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "243100" ;
+        skos:prefLabel   "Pfalz-Zweibrücken"@de .
+
+:n243400  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Staat Nassau (n243400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "243400" ;
+        skos:prefLabel   "Staat Nassau"@de .
+
+:n245100  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "245100" ;
+        skos:prefLabel   "Französische Besetzung / 1792-1815"@de .
+
+:n245120  a              skos:Concept ;
+        skos:broader     :n245100 ;
+        skos:definition  "Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Mainzer Republik (n245120)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "245120" ;
+        skos:prefLabel   "Mainzer Republik"@de .
+
+:n245130  a              skos:Concept ;
+        skos:broader     :n245100 ;
+        skos:definition  "Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Wälderdepartement (n245130)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "245130" ;
+        skos:prefLabel   "Wälderdepartement"@de .
+
+:n245140  a              skos:Concept ;
+        skos:broader     :n245100 ;
+        skos:definition  "Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Rhein-Mosel-Département (n245140)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "245140" ;
+        skos:prefLabel   "Rhein-Mosel-Département"@de .
+
+:n245160  a              skos:Concept ;
+        skos:broader     :n245100 ;
+        skos:definition  "Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Département Donnersberg (n245160)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "245160" ;
+        skos:prefLabel   "Département Donnersberg"@de .
+
+:n245180  a              skos:Concept ;
+        skos:broader     :n245100 ;
+        skos:definition  "Geschichte (n240000) > Französische Besetzung / 1792-1815 (n245100) > Saardepartement (n245180)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "245180" ;
+        skos:prefLabel   "Saardepartement"@de .
+
+:n245300  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Rheinbund / 1806-1813 (n245300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "245300" ;
+        skos:prefLabel   "Rheinbund / 1806-1813"@de .
+
+:n246100  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Rheinprovinz (n246100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "246100" ;
+        skos:prefLabel   "Rheinprovinz"@de .
+
+:n246200  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Hessen-Darmstadt (n246200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "246200" ;
+        skos:prefLabel   "Hessen-Darmstadt"@de .
+
+:n246300  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Hessen-Nassau (n246300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "246300" ;
+        skos:prefLabel   "Hessen-Nassau"@de .
+
+:n246500  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Bayerische Pfalz (n246500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "246500" ;
+        skos:prefLabel   "Bayerische Pfalz"@de .
+
+:n246700  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien des 19. Jahrhunderts (n246700)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "246700" ;
+        skos:prefLabel   "Kleinere Territorien des 19. Jahrhunderts"@de .
+
+:n246720  a              skos:Concept ;
+        skos:broader     :n246700 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien des 19. Jahrhunderts (n246700) > Fürstentum Birkenfeld (n246720)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "246720" ;
+        skos:prefLabel   "Fürstentum Birkenfeld"@de .
+
+:n246740  a              skos:Concept ;
+        skos:broader     :n246700 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien des 19. Jahrhunderts (n246700) > Fürstentum Lichtenberg (n246740)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "246740" ;
+        skos:prefLabel   "Fürstentum Lichtenberg"@de .
+
+:n246760  a              skos:Concept ;
+        skos:broader     :n246700 ;
+        skos:definition  "Geschichte (n240000) > Kleinere Territorien des 19. Jahrhunderts (n246700) > Oberamt Meisenheim (n246760)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "246760" ;
+        skos:prefLabel   "Oberamt Meisenheim"@de .
+
+:n248000  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Rheinland-Pfalz / Geschichte 1945-1947 (n248000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "248000" ;
+        skos:prefLabel   "Rheinland-Pfalz / Geschichte 1945-1947"@de .
+
+:n248100  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Rheinland / Geschichte 1945- (n248100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "248100" ;
+        skos:prefLabel   "Rheinland / Geschichte 1945-"@de .
+
+:n248300  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Rheinhessen / Geschichte 1945- (n248300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "248300" ;
+        skos:prefLabel   "Rheinhessen / Geschichte 1945-"@de .
+
+:n248500  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Pfalz / Geschichte 1945- (n248500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "248500" ;
+        skos:prefLabel   "Pfalz / Geschichte 1945-"@de .
+
+:n249100  a              skos:Concept ;
+        skos:broader     :n240000 ;
+        skos:definition  "Geschichte (n240000) > Rheinland-Pfalz / Geschichte 1947- (n249100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "249100" ;
+        skos:prefLabel   "Rheinland-Pfalz / Geschichte 1947-"@de .
+
+:n260000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Militär- und Wehrwesen"@de .
+
+:n260100  a              skos:Concept ;
+        skos:broader     :n260000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär- und Wehrwesen allgemein (n260100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "260100" ;
+        skos:prefLabel   "Militär- und Wehrwesen allgemein"@de .
+
+:n262000  a              skos:Concept ;
+        skos:broader     :n260000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262000" ;
+        skos:prefLabel   "Militär"@de .
+
+:n262010  a              skos:Concept ;
+        skos:broader     :n262000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262010" ;
+        skos:prefLabel   "Militärbau"@de .
+
+:n262011  a              skos:Concept ;
+        skos:broader     :n262010 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010) > Burg (n262011)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262011" ;
+        skos:prefLabel   "Burg"@de .
+
+:n262012  a              skos:Concept ;
+        skos:broader     :n262010 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010) > Festung (n262012)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262012" ;
+        skos:prefLabel   "Festung"@de .
+
+:n262014  a              skos:Concept ;
+        skos:broader     :n262010 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010) > Schanze (n262014)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262014" ;
+        skos:prefLabel   "Schanze"@de .
+
+:n262016  a              skos:Concept ;
+        skos:broader     :n262010 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militärbau (n262010) > Standort (n262016)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262016" ;
+        skos:prefLabel   "Standort"@de .
+
+:n262020  a              skos:Concept ;
+        skos:broader     :n262000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262020" ;
+        skos:prefLabel   "Militär / Ausrüstung"@de .
+
+:n262022  a              skos:Concept ;
+        skos:broader     :n262020 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Kriegswaffe (n262022)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262022" ;
+        skos:prefLabel   "Kriegswaffe"@de .
+
+:n262023  a              skos:Concept ;
+        skos:broader     :n262020 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Rüstung (n262023)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262023" ;
+        skos:prefLabel   "Rüstung"@de .
+
+:n262024  a              skos:Concept ;
+        skos:broader     :n262020 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Uniform (n262024)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262024" ;
+        skos:prefLabel   "Uniform"@de .
+
+:n262025  a              skos:Concept ;
+        skos:broader     :n262020 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Feldzeichen (n262025)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262025" ;
+        skos:prefLabel   "Feldzeichen"@de .
+
+:n262026  a              skos:Concept ;
+        skos:broader     :n262020 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Militär (n262000) > Militär / Ausrüstung (n262020) > Orden / Ehrenzeichen (n262026)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "262026" ;
+        skos:prefLabel   "Orden / Ehrenzeichen"@de .
+
+:n263000  a              skos:Concept ;
+        skos:broader     :n260000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Wehrwesen (n263000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "263000" ;
+        skos:prefLabel   "Wehrwesen"@de .
+
+:n263010  a              skos:Concept ;
+        skos:broader     :n263000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Bürgerwehr (n263010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "263010" ;
+        skos:prefLabel   "Bürgerwehr"@de .
+
+:n263020  a              skos:Concept ;
+        skos:broader     :n263000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Militär / Geschichte Anfänge-1918 (n263020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "263020" ;
+        skos:prefLabel   "Militär / Geschichte Anfänge-1918"@de .
+
+:n263030  a              skos:Concept ;
+        skos:broader     :n263000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Deutschland / Reichswehr (n263030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "263030" ;
+        skos:prefLabel   "Deutschland / Reichswehr"@de .
+
+:n263040  a              skos:Concept ;
+        skos:broader     :n263000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Deutschland / Wehrmacht (n263040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "263040" ;
+        skos:prefLabel   "Deutschland / Wehrmacht"@de .
+
+:n263050  a              skos:Concept ;
+        skos:broader     :n263000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Ausländisches Militär (n263050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "263050" ;
+        skos:prefLabel   "Ausländisches Militär"@de .
+
+:n263060  a              skos:Concept ;
+        skos:broader     :n263000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Deutschland / Bundeswehr (n263060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "263060" ;
+        skos:prefLabel   "Deutschland / Bundeswehr"@de .
+
+:n263090  a              skos:Concept ;
+        skos:broader     :n263000 ;
+        skos:definition  "Militär- und Wehrwesen (n260000) > Wehrwesen (n263000) > Soldat (n263090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "263090" ;
+        skos:prefLabel   "Soldat"@de .
+
+:n400000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Staat. Politik"@de .
+
+:n400100  a              skos:Concept ;
+        skos:broader     :n400000 ;
+        skos:definition  "Staat. Politik (n400000) > Staat. Politik allgemein (n400100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "400100" ;
+        skos:prefLabel   "Staat. Politik allgemein"@de .
+
+:n402000  a              skos:Concept ;
+        skos:broader     :n400000 ;
+        skos:definition  "Staat. Politik (n400000) > Staatsgrundlage (n402000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402000" ;
+        skos:prefLabel   "Staatsgrundlage"@de .
+
+:n402020  a              skos:Concept ;
+        skos:broader     :n402000 ;
+        skos:definition  "Staat. Politik (n400000) > Staatsgrundlage (n402000) > Staatsrecht (n402020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402020" ;
+        skos:prefLabel   "Staatsrecht"@de .
+
+:n402030  a              skos:Concept ;
+        skos:broader     :n402000 ;
+        skos:definition  "Staat. Politik (n400000) > Staatsgrundlage (n402000) > Staatsangehörigkeit (n402030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402030" ;
+        skos:prefLabel   "Staatsangehörigkeit"@de .
+
+:n402040  a              skos:Concept ;
+        skos:broader     :n402000 ;
+        skos:definition  "Staat. Politik (n400000) > Staatsgrundlage (n402000) > Staatsgebiet (n402040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402040" ;
+        skos:prefLabel   "Staatsgebiet"@de .
+
+:n402050  a              skos:Concept ;
+        skos:broader     :n402000 ;
+        skos:definition  "Staat. Politik (n400000) > Staatsgrundlage (n402000) > Hoheitsrecht (n402050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402050" ;
+        skos:prefLabel   "Hoheitsrecht"@de .
+
+:n402060  a              skos:Concept ;
+        skos:broader     :n402000 ;
+        skos:definition  "Staat. Politik (n400000) > Staatsgrundlage (n402000) > Staatsform (n402060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402060" ;
+        skos:prefLabel   "Staatsform"@de .
+
+:n402070  a              skos:Concept ;
+        skos:broader     :n402000 ;
+        skos:definition  "Staat. Politik (n400000) > Staatsgrundlage (n402000) > Föderalismus (n402070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402070" ;
+        skos:prefLabel   "Föderalismus"@de .
+
+:n402300  a              skos:Concept ;
+        skos:broader     :n400000 ;
+        skos:definition  "Staat. Politik (n400000) > Verfassung (n402300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402300" ;
+        skos:prefLabel   "Verfassung"@de .
+
+:n402330  a              skos:Concept ;
+        skos:broader     :n402300 ;
+        skos:definition  "Staat. Politik (n400000) > Verfassung (n402300) > Verfassung / Geschichte (n402330)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402330" ;
+        skos:prefLabel   "Verfassung / Geschichte"@de .
+
+:n402340  a              skos:Concept ;
+        skos:broader     :n402300 ;
+        skos:definition  "Staat. Politik (n400000) > Verfassung (n402300) > Grundrecht (n402340)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402340" ;
+        skos:prefLabel   "Grundrecht"@de .
+
+:n402344  a              skos:Concept ;
+        skos:broader     :n402340 ;
+        skos:definition  "Staat. Politik (n400000) > Verfassung (n402300) > Grundrecht (n402340) > Datenschutz (n402344)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402344" ;
+        skos:prefLabel   "Datenschutz"@de .
+
+:n402350  a              skos:Concept ;
+        skos:broader     :n402300 ;
+        skos:definition  "Staat. Politik (n400000) > Verfassung (n402300) > Gewaltenteilung (n402350)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "402350" ;
+        skos:prefLabel   "Gewaltenteilung"@de .
+
+:n404000  a              skos:Concept ;
+        skos:broader     :n400000 ;
+        skos:definition  "Staat. Politik (n400000) > Politisches System (n404000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404000" ;
+        skos:prefLabel   "Politisches System"@de .
+
+:n404030  a              skos:Concept ;
+        skos:broader     :n404000 ;
+        skos:definition  "Staat. Politik (n400000) > Politisches System (n404000) > Regierungsbildung (n404030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404030" ;
+        skos:prefLabel   "Regierungsbildung"@de .
+
+:n404040  a              skos:Concept ;
+        skos:broader     :n404000 ;
+        skos:definition  "Staat. Politik (n400000) > Politisches System (n404000) > Regierungschef (n404040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404040" ;
+        skos:prefLabel   "Regierungschef"@de .
+
+:n404050  a              skos:Concept ;
+        skos:broader     :n404000 ;
+        skos:definition  "Staat. Politik (n400000) > Politisches System (n404000) > Regierung (n404050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404050" ;
+        skos:prefLabel   "Regierung"@de .
+
+:n404060  a              skos:Concept ;
+        skos:broader     :n404000 ;
+        skos:definition  "Staat. Politik (n400000) > Politisches System (n404000) > Ministerium (n404060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404060" ;
+        skos:prefLabel   "Ministerium"@de .
+
+:n404070  a              skos:Concept ;
+        skos:broader     :n404000 ;
+        skos:definition  "Staat. Politik (n400000) > Politisches System (n404000) > Regierungspolitik (n404070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404070" ;
+        skos:prefLabel   "Regierungspolitik"@de .
+
+:n404090  a              skos:Concept ;
+        skos:broader     :n404000 ;
+        skos:definition  "Staat. Politik (n400000) > Politisches System (n404000) > Landespartnerschaft (n404090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404090" ;
+        skos:prefLabel   "Landespartnerschaft"@de .
+
+:n404300  a              skos:Concept ;
+        skos:broader     :n400000 ;
+        skos:definition  "Staat. Politik (n400000) > Parlament (n404300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404300" ;
+        skos:prefLabel   "Parlament"@de .
+
+:n404320  a              skos:Concept ;
+        skos:broader     :n404300 ;
+        skos:definition  "Staat. Politik (n400000) > Parlament (n404300) > Parlament / Geschichte (n404320)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404320" ;
+        skos:prefLabel   "Parlament / Geschichte"@de .
+
+:n404340  a              skos:Concept ;
+        skos:broader     :n404300 ;
+        skos:definition  "Staat. Politik (n400000) > Parlament (n404300) > Regierungspartei (n404340)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404340" ;
+        skos:prefLabel   "Regierungspartei"@de .
+
+:n404350  a              skos:Concept ;
+        skos:broader     :n404300 ;
+        skos:definition  "Staat. Politik (n400000) > Parlament (n404300) > Opposition (n404350)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404350" ;
+        skos:prefLabel   "Opposition"@de .
+
+:n404360  a              skos:Concept ;
+        skos:broader     :n404300 ;
+        skos:definition  "Staat. Politik (n400000) > Parlament (n404300) > Parlamentsorganisation (n404360)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404360" ;
+        skos:prefLabel   "Parlamentsorganisation"@de .
+
+:n404361  a              skos:Concept ;
+        skos:broader     :n404360 ;
+        skos:definition  "Staat. Politik (n400000) > Parlament (n404300) > Parlamentsorganisation (n404360) > Parlamentsausschuss (n404361)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404361" ;
+        skos:prefLabel   "Parlamentsausschuss"@de .
+
+:n404365  a              skos:Concept ;
+        skos:broader     :n404360 ;
+        skos:definition  "Staat. Politik (n400000) > Parlament (n404300) > Parlamentsorganisation (n404360) > Ombudsmann (n404365)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404365" ;
+        skos:prefLabel   "Ombudsmann"@de .
+
+:n404380  a              skos:Concept ;
+        skos:broader     :n404300 ;
+        skos:definition  "Staat. Politik (n400000) > Parlament (n404300) > Abgeordneter (n404380)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "404380" ;
+        skos:prefLabel   "Abgeordneter"@de .
+
+:n406000  a              skos:Concept ;
+        skos:broader     :n400000 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406000" ;
+        skos:prefLabel   "Politische Willensbildung"@de .
+
+:n406020  a              skos:Concept ;
+        skos:broader     :n406000 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Öffentlichkeitsarbeit (n406020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406020" ;
+        skos:prefLabel   "Öffentlichkeitsarbeit"@de .
+
+:n406030  a              skos:Concept ;
+        skos:broader     :n406000 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Bildung (n406030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406030" ;
+        skos:prefLabel   "Politische Bildung"@de .
+
+:n406040  a              skos:Concept ;
+        skos:broader     :n406000 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Öffentliche Meinung (n406040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406040" ;
+        skos:prefLabel   "Öffentliche Meinung"@de .
+
+:n406060  a              skos:Concept ;
+        skos:broader     :n406000 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Bewegung (n406060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406060" ;
+        skos:prefLabel   "Politische Bewegung"@de .
+
+:n406080  a              skos:Concept ;
+        skos:broader     :n406000 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Parteistiftung (n406080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406080" ;
+        skos:prefLabel   "Parteistiftung"@de .
+
+:n406100  a              skos:Concept ;
+        skos:broader     :n406000 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Partei. Politikerin. Politiker (n406100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406100" ;
+        skos:prefLabel   "Partei. Politikerin. Politiker"@de .
+
+:n406120  a              skos:Concept ;
+        skos:broader     :n406100 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Partei. Politikerin. Politiker (n406100) > Partei (n406120)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406120" ;
+        skos:prefLabel   "Partei"@de .
+
+:n406130  a              skos:Concept ;
+        skos:broader     :n406100 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Partei. Politikerin. Politiker (n406100) > Politikerin. Politiker (n406130)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406130" ;
+        skos:prefLabel   "Politikerin. Politiker"@de .
+
+:n406200  a              skos:Concept ;
+        skos:broader     :n406000 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Gruppe (n406200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406200" ;
+        skos:prefLabel   "Politische Gruppe"@de .
+
+:n406230  a              skos:Concept ;
+        skos:broader     :n406200 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Gruppe (n406200) > Politischer Verein (n406230)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406230" ;
+        skos:prefLabel   "Politischer Verein"@de .
+
+:n406250  a              skos:Concept ;
+        skos:broader     :n406200 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Gruppe (n406200) > Bürgerinitiative (n406250)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406250" ;
+        skos:prefLabel   "Bürgerinitiative"@de .
+
+:n406270  a              skos:Concept ;
+        skos:broader     :n406200 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Politische Gruppe (n406200) > Projektgruppe (n406270)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406270" ;
+        skos:prefLabel   "Projektgruppe"@de .
+
+:n406300  a              skos:Concept ;
+        skos:broader     :n406000 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406300" ;
+        skos:prefLabel   "Wahl"@de .
+
+:n406310  a              skos:Concept ;
+        skos:broader     :n406300 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Wahlrecht (n406310)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406310" ;
+        skos:prefLabel   "Wahlrecht"@de .
+
+:n406320  a              skos:Concept ;
+        skos:broader     :n406300 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Wahlkreiseinteilung (n406320)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406320" ;
+        skos:prefLabel   "Wahlkreiseinteilung"@de .
+
+:n406330  a              skos:Concept ;
+        skos:broader     :n406300 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Volksabstimmung (n406330)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406330" ;
+        skos:prefLabel   "Volksabstimmung"@de .
+
+:n406340  a              skos:Concept ;
+        skos:broader     :n406300 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Europawahl (n406340)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406340" ;
+        skos:prefLabel   "Europawahl"@de .
+
+:n406350  a              skos:Concept ;
+        skos:broader     :n406300 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Bundestagswahl (n406350)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406350" ;
+        skos:prefLabel   "Bundestagswahl"@de .
+
+:n406360  a              skos:Concept ;
+        skos:broader     :n406300 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Landtagswahl (n406360)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406360" ;
+        skos:prefLabel   "Landtagswahl"@de .
+
+:n406370  a              skos:Concept ;
+        skos:broader     :n406300 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Kreistag / Wahl (n406370)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406370" ;
+        skos:prefLabel   "Kreistag / Wahl"@de .
+
+:n406380  a              skos:Concept ;
+        skos:broader     :n406300 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Bezirkstag / Wahl (n406380)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406380" ;
+        skos:prefLabel   "Bezirkstag / Wahl"@de .
+
+:n406390  a              skos:Concept ;
+        skos:broader     :n406300 ;
+        skos:definition  "Staat. Politik (n400000) > Politische Willensbildung (n406000) > Wahl (n406300) > Kommunalwahl (n406390)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "406390" ;
+        skos:prefLabel   "Kommunalwahl"@de .
+
+:n420000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Verwaltung"@de .
+
+:n420100  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Verwaltung allgemein (n420100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "420100" ;
+        skos:prefLabel   "Verwaltung allgemein"@de .
+
+:n421000  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Verwaltungsrecht (n421000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "421000" ;
+        skos:prefLabel   "Verwaltungsrecht"@de .
+
+:n421400  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Verwaltungskontrolle (n421400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "421400" ;
+        skos:prefLabel   "Verwaltungskontrolle"@de .
+
+:n422000  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Verwaltung / Geschichte (n422000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "422000" ;
+        skos:prefLabel   "Verwaltung / Geschichte"@de .
+
+:n423000  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423000" ;
+        skos:prefLabel   "Allgemeine Verwaltung"@de .
+
+:n423020  a              skos:Concept ;
+        skos:broader     :n423000 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltung / Struktur (n423020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423020" ;
+        skos:prefLabel   "Verwaltung / Struktur"@de .
+
+:n423030  a              skos:Concept ;
+        skos:broader     :n423000 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Behörde / Organisation (n423030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423030" ;
+        skos:prefLabel   "Behörde / Organisation"@de .
+
+:n423050  a              skos:Concept ;
+        skos:broader     :n423000 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Behörde / Datenverarbeitung (n423050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423050" ;
+        skos:prefLabel   "Behörde / Datenverarbeitung"@de .
+
+:n423400  a              skos:Concept ;
+        skos:broader     :n423000 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltungsreform (n423400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423400" ;
+        skos:prefLabel   "Verwaltungsreform"@de .
+
+:n423420  a              skos:Concept ;
+        skos:broader     :n423400 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltungsreform (n423400) > Länderneugliederung (n423420)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423420" ;
+        skos:prefLabel   "Länderneugliederung"@de .
+
+:n423430  a              skos:Concept ;
+        skos:broader     :n423400 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltungsreform (n423400) > Gebietsreform (n423430)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423430" ;
+        skos:prefLabel   "Gebietsreform"@de .
+
+:n423440  a              skos:Concept ;
+        skos:broader     :n423400 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Verwaltungsreform (n423400) > Funktionalreform (n423440)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423440" ;
+        skos:prefLabel   "Funktionalreform"@de .
+
+:n423600  a              skos:Concept ;
+        skos:broader     :n423000 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Öffentlicher Dienst (n423600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423600" ;
+        skos:prefLabel   "Öffentlicher Dienst"@de .
+
+:n423610  a              skos:Concept ;
+        skos:broader     :n423600 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Öffentlicher Dienst (n423600) > Dienstrecht (n423610)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423610" ;
+        skos:prefLabel   "Dienstrecht"@de .
+
+:n423620  a              skos:Concept ;
+        skos:broader     :n423600 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Öffentlicher Dienst (n423600) > Personalwesen (n423620)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423620" ;
+        skos:prefLabel   "Personalwesen"@de .
+
+:n423640  a              skos:Concept ;
+        skos:broader     :n423600 ;
+        skos:definition  "Verwaltung (n420000) > Allgemeine Verwaltung (n423000) > Öffentlicher Dienst (n423600) > Beamter (n423640)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "423640" ;
+        skos:prefLabel   "Beamter"@de .
+
+:n424000  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424000" ;
+        skos:prefLabel   "Öffentlicher Haushalt"@de .
+
+:n424020  a              skos:Concept ;
+        skos:broader     :n424000 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424020" ;
+        skos:prefLabel   "Finanzverwaltung"@de .
+
+:n424021  a              skos:Concept ;
+        skos:broader     :n424020 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Finanzamt (n424021)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424021" ;
+        skos:prefLabel   "Finanzamt"@de .
+
+:n424022  a              skos:Concept ;
+        skos:broader     :n424020 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Finanzausgleich (n424022)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424022" ;
+        skos:prefLabel   "Finanzausgleich"@de .
+
+:n424024  a              skos:Concept ;
+        skos:broader     :n424020 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Finanzreform (n424024)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424024" ;
+        skos:prefLabel   "Finanzreform"@de .
+
+:n424026  a              skos:Concept ;
+        skos:broader     :n424020 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Öffentliche Beschaffung (n424026)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424026" ;
+        skos:prefLabel   "Öffentliche Beschaffung"@de .
+
+:n424028  a              skos:Concept ;
+        skos:broader     :n424020 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Finanzverwaltung (n424020) > Rechnungshof (n424028)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424028" ;
+        skos:prefLabel   "Rechnungshof"@de .
+
+:n424030  a              skos:Concept ;
+        skos:broader     :n424000 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Abgabe (n424030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424030" ;
+        skos:prefLabel   "Abgabe"@de .
+
+:n424040  a              skos:Concept ;
+        skos:broader     :n424000 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Steuer (n424040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424040" ;
+        skos:prefLabel   "Steuer"@de .
+
+:n424042  a              skos:Concept ;
+        skos:broader     :n424040 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Steuer (n424040) > Steuerberatung (n424042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424042" ;
+        skos:prefLabel   "Steuerberatung"@de .
+
+:n424050  a              skos:Concept ;
+        skos:broader     :n424000 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Gebühr (n424050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424050" ;
+        skos:prefLabel   "Gebühr"@de .
+
+:n424060  a              skos:Concept ;
+        skos:broader     :n424000 ;
+        skos:definition  "Verwaltung (n420000) > Öffentlicher Haushalt (n424000) > Zoll (n424060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "424060" ;
+        skos:prefLabel   "Zoll"@de .
+
+:n425000  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425000" ;
+        skos:prefLabel   "Bezirksverwaltung"@de .
+
+:n425020  a              skos:Concept ;
+        skos:broader     :n425000 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungspräsident (n425020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425020" ;
+        skos:prefLabel   "Regierungspräsident"@de .
+
+:n425030  a              skos:Concept ;
+        skos:broader     :n425000 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungsbezirk Koblenz (n425030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425030" ;
+        skos:prefLabel   "Regierungsbezirk Koblenz"@de .
+
+:n425040  a              skos:Concept ;
+        skos:broader     :n425000 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungsbezirk Trier (n425040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425040" ;
+        skos:prefLabel   "Regierungsbezirk Trier"@de .
+
+:n425050  a              skos:Concept ;
+        skos:broader     :n425000 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungsbezirk Rheinhessen-Pfalz (n425050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425050" ;
+        skos:prefLabel   "Regierungsbezirk Rheinhessen-Pfalz"@de .
+
+:n425052  a              skos:Concept ;
+        skos:broader     :n425050 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000) > Regierungsbezirk Rheinhessen-Pfalz (n425050) > Bezirksverband Pfalz (n425052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425052" ;
+        skos:prefLabel   "Bezirksverband Pfalz"@de .
+
+:n425200  a              skos:Concept ;
+        skos:broader     :n425000 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000) > Kreisverwaltung (n425200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425200" ;
+        skos:prefLabel   "Kreisverwaltung"@de .
+
+:n425220  a              skos:Concept ;
+        skos:broader     :n425200 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000) > Kreisverwaltung (n425200) > Kreisrecht (n425220)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425220" ;
+        skos:prefLabel   "Kreisrecht"@de .
+
+:n425230  a              skos:Concept ;
+        skos:broader     :n425200 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000) > Kreisverwaltung (n425200) > Kreisparlament (n425230)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425230" ;
+        skos:prefLabel   "Kreisparlament"@de .
+
+:n425290  a              skos:Concept ;
+        skos:broader     :n425200 ;
+        skos:definition  "Verwaltung (n420000) > Bezirksverwaltung (n425000) > Kreisverwaltung (n425200) > Kreispartnerschaft (n425290)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "425290" ;
+        skos:prefLabel   "Kreispartnerschaft"@de .
+
+:n426000  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Gemeindeverwaltung (n426000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "426000" ;
+        skos:prefLabel   "Gemeindeverwaltung"@de .
+
+:n426020  a              skos:Concept ;
+        skos:broader     :n426000 ;
+        skos:definition  "Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Ortsrecht (n426020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "426020" ;
+        skos:prefLabel   "Ortsrecht"@de .
+
+:n426030  a              skos:Concept ;
+        skos:broader     :n426000 ;
+        skos:definition  "Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Gemeinderat (n426030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "426030" ;
+        skos:prefLabel   "Gemeinderat"@de .
+
+:n426040  a              skos:Concept ;
+        skos:broader     :n426000 ;
+        skos:definition  "Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Kommunale Selbstverwaltung (n426040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "426040" ;
+        skos:prefLabel   "Kommunale Selbstverwaltung"@de .
+
+:n426050  a              skos:Concept ;
+        skos:broader     :n426000 ;
+        skos:definition  "Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Auftragsverwaltung (n426050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "426050" ;
+        skos:prefLabel   "Auftragsverwaltung"@de .
+
+:n426060  a              skos:Concept ;
+        skos:broader     :n426000 ;
+        skos:definition  "Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Kommunaler Spitzenverband (n426060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "426060" ;
+        skos:prefLabel   "Kommunaler Spitzenverband"@de .
+
+:n426070  a              skos:Concept ;
+        skos:broader     :n426000 ;
+        skos:definition  "Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Verbandsgemeinde (n426070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "426070" ;
+        skos:prefLabel   "Verbandsgemeinde"@de .
+
+:n426090  a              skos:Concept ;
+        skos:broader     :n426000 ;
+        skos:definition  "Verwaltung (n420000) > Gemeindeverwaltung (n426000) > Kommunale Partnerschaft (n426090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "426090" ;
+        skos:prefLabel   "Kommunale Partnerschaft"@de .
+
+:n427000  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Obere Landesbehörde (n427000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "427000" ;
+        skos:prefLabel   "Obere Landesbehörde"@de .
+
+:n427010  a              skos:Concept ;
+        skos:broader     :n427000 ;
+        skos:definition  "Verwaltung (n420000) > Obere Landesbehörde (n427000) > Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Nord (n427010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "427010" ;
+        skos:prefLabel   "Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Nord"@de .
+
+:n427020  a              skos:Concept ;
+        skos:broader     :n427000 ;
+        skos:definition  "Verwaltung (n420000) > Obere Landesbehörde (n427000) > Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Süd (n427020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "427020" ;
+        skos:prefLabel   "Rheinland-Pfalz / Struktur- und Genehmigungsdirektion Süd"@de .
+
+:n427030  a              skos:Concept ;
+        skos:broader     :n427000 ;
+        skos:definition  "Verwaltung (n420000) > Obere Landesbehörde (n427000) > Rheinland-Pfalz / Aufsichts- und Dienstleistungsdirektion (n427030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "427030" ;
+        skos:prefLabel   "Rheinland-Pfalz / Aufsichts- und Dienstleistungsdirektion"@de .
+
+:n427040  a              skos:Concept ;
+        skos:broader     :n427000 ;
+        skos:definition  "Verwaltung (n420000) > Obere Landesbehörde (n427000) > Rheinland-Pfalz / Landesuntersuchungsamt (n427040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "427040" ;
+        skos:prefLabel   "Rheinland-Pfalz / Landesuntersuchungsamt"@de .
+
+:n428000  a              skos:Concept ;
+        skos:broader     :n420000 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428000" ;
+        skos:prefLabel   "Sicherheit und Ordnung"@de .
+
+:n428020  a              skos:Concept ;
+        skos:broader     :n428000 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Ordnungsrecht (n428020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428020" ;
+        skos:prefLabel   "Ordnungsrecht"@de .
+
+:n428030  a              skos:Concept ;
+        skos:broader     :n428000 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Polizei (n428030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428030" ;
+        skos:prefLabel   "Polizei"@de .
+
+:n428032  a              skos:Concept ;
+        skos:broader     :n428030 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Polizei (n428030) > Polizeiorganisation (n428032)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428032" ;
+        skos:prefLabel   "Polizeiorganisation"@de .
+
+:n428033  a              skos:Concept ;
+        skos:broader     :n428030 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Polizei (n428030) > Polizei / Ausrüstung (n428033)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428033" ;
+        skos:prefLabel   "Polizei / Ausrüstung"@de .
+
+:n428040  a              skos:Concept ;
+        skos:broader     :n428000 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Zivilschutz (n428040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428040" ;
+        skos:prefLabel   "Zivilschutz"@de .
+
+:n428050  a              skos:Concept ;
+        skos:broader     :n428000 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Staatsschutz (n428050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428050" ;
+        skos:prefLabel   "Staatsschutz"@de .
+
+:n428052  a              skos:Concept ;
+        skos:broader     :n428050 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Staatsschutz (n428050) > Grenzschutz (n428052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428052" ;
+        skos:prefLabel   "Grenzschutz"@de .
+
+:n428054  a              skos:Concept ;
+        skos:broader     :n428050 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Staatsschutz (n428050) > Verfassungsschutz (n428054)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428054" ;
+        skos:prefLabel   "Verfassungsschutz"@de .
+
+:n428060  a              skos:Concept ;
+        skos:broader     :n428000 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Personenstandswesen (n428060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428060" ;
+        skos:prefLabel   "Personenstandswesen"@de .
+
+:n428070  a              skos:Concept ;
+        skos:broader     :n428000 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428070" ;
+        skos:prefLabel   "Sicherheitsbehörde"@de .
+
+:n428072  a              skos:Concept ;
+        skos:broader     :n428070 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070) > Technischer Überwachungsverein (n428072)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428072" ;
+        skos:prefLabel   "Technischer Überwachungsverein"@de .
+
+:n428074  a              skos:Concept ;
+        skos:broader     :n428070 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070) > Feuerwehr (n428074)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428074" ;
+        skos:prefLabel   "Feuerwehr"@de .
+
+:n428076  a              skos:Concept ;
+        skos:broader     :n428070 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070) > Rettungswesen (n428076)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428076" ;
+        skos:prefLabel   "Rettungswesen"@de .
+
+:n428078  a              skos:Concept ;
+        skos:broader     :n428070 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Sicherheitsbehörde (n428070) > Katastrophe. Unfall (n428078)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428078" ;
+        skos:prefLabel   "Katastrophe. Unfall"@de .
+
+:n428080  a              skos:Concept ;
+        skos:broader     :n428000 ;
+        skos:definition  "Verwaltung (n420000) > Sicherheit und Ordnung (n428000) > Friedhofsordnung (n428080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "428080" ;
+        skos:prefLabel   "Friedhofsordnung"@de .
+
+:n440000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Recht"@de .
+
+:n440100  a              skos:Concept ;
+        skos:broader     :n440000 ;
+        skos:definition  "Recht (n440000) > Recht allgemein (n440100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "440100" ;
+        skos:prefLabel   "Recht allgemein"@de .
+
+:n442000  a              skos:Concept ;
+        skos:broader     :n440000 ;
+        skos:definition  "Recht (n440000) > Recht / Geschichte (n442000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "442000" ;
+        skos:prefLabel   "Recht / Geschichte"@de .
+
+:n442050  a              skos:Concept ;
+        skos:broader     :n442000 ;
+        skos:definition  "Recht (n440000) > Recht / Geschichte (n442000) > Recht / Geschichte / Quelle (n442050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "442050" ;
+        skos:prefLabel   "Recht / Geschichte / Quelle"@de .
+
+:n443000  a              skos:Concept ;
+        skos:broader     :n440000 ;
+        skos:definition  "Recht (n440000) > Privatrecht (n443000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "443000" ;
+        skos:prefLabel   "Privatrecht"@de .
+
+:n444000  a              skos:Concept ;
+        skos:broader     :n440000 ;
+        skos:definition  "Recht (n440000) > Strafrecht (n444000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "444000" ;
+        skos:prefLabel   "Strafrecht"@de .
+
+:n444030  a              skos:Concept ;
+        skos:broader     :n444000 ;
+        skos:definition  "Recht (n440000) > Strafrecht (n444000) > Strafvollzug (n444030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "444030" ;
+        skos:prefLabel   "Strafvollzug"@de .
+
+:n444050  a              skos:Concept ;
+        skos:broader     :n444000 ;
+        skos:definition  "Recht (n440000) > Strafrecht (n444000) > Kriminalität (n444050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "444050" ;
+        skos:prefLabel   "Kriminalität"@de .
+
+:n444070  a              skos:Concept ;
+        skos:broader     :n444000 ;
+        skos:definition  "Recht (n440000) > Strafrecht (n444000) > Kriminalfall (n444070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "444070" ;
+        skos:prefLabel   "Kriminalfall"@de .
+
+:n446000  a              skos:Concept ;
+        skos:broader     :n440000 ;
+        skos:definition  "Recht (n440000) > Gerichtsbarkeit (n446000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "446000" ;
+        skos:prefLabel   "Gerichtsbarkeit"@de .
+
+:n446010  a              skos:Concept ;
+        skos:broader     :n446000 ;
+        skos:definition  "Recht (n440000) > Gerichtsbarkeit (n446000) > Verfassungsgerichtsbarkeit (n446010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "446010" ;
+        skos:prefLabel   "Verfassungsgerichtsbarkeit"@de .
+
+:n446030  a              skos:Concept ;
+        skos:broader     :n446000 ;
+        skos:definition  "Recht (n440000) > Gerichtsbarkeit (n446000) > Ordentliche Gerichtsbarkeit (n446030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "446030" ;
+        skos:prefLabel   "Ordentliche Gerichtsbarkeit"@de .
+
+:n446032  a              skos:Concept ;
+        skos:broader     :n446030 ;
+        skos:definition  "Recht (n440000) > Gerichtsbarkeit (n446000) > Ordentliche Gerichtsbarkeit (n446030) > Strafgerichtsbarkeit (n446032)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "446032" ;
+        skos:prefLabel   "Strafgerichtsbarkeit"@de .
+
+:n446034  a              skos:Concept ;
+        skos:broader     :n446030 ;
+        skos:definition  "Recht (n440000) > Gerichtsbarkeit (n446000) > Ordentliche Gerichtsbarkeit (n446030) > Zivilgerichtsbarkeit (n446034)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "446034" ;
+        skos:prefLabel   "Zivilgerichtsbarkeit"@de .
+
+:n446050  a              skos:Concept ;
+        skos:broader     :n446000 ;
+        skos:definition  "Recht (n440000) > Gerichtsbarkeit (n446000) > Verwaltungsgerichtsbarkeit (n446050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "446050" ;
+        skos:prefLabel   "Verwaltungsgerichtsbarkeit"@de .
+
+:n446060  a              skos:Concept ;
+        skos:broader     :n446000 ;
+        skos:definition  "Recht (n440000) > Gerichtsbarkeit (n446000) > Finanzgerichtsbarkeit (n446060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "446060" ;
+        skos:prefLabel   "Finanzgerichtsbarkeit"@de .
+
+:n446070  a              skos:Concept ;
+        skos:broader     :n446000 ;
+        skos:definition  "Recht (n440000) > Gerichtsbarkeit (n446000) > Arbeitsgerichtsbarkeit (n446070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "446070" ;
+        skos:prefLabel   "Arbeitsgerichtsbarkeit"@de .
+
+:n446080  a              skos:Concept ;
+        skos:broader     :n446000 ;
+        skos:definition  "Recht (n440000) > Gerichtsbarkeit (n446000) > Sozialgerichtsbarkeit (n446080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "446080" ;
+        skos:prefLabel   "Sozialgerichtsbarkeit"@de .
+
+:n447000  a              skos:Concept ;
+        skos:broader     :n440000 ;
+        skos:definition  "Recht (n440000) > Rechtsprechung (n447000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "447000" ;
+        skos:prefLabel   "Rechtsprechung"@de .
+
+:n448000  a              skos:Concept ;
+        skos:broader     :n440000 ;
+        skos:definition  "Recht (n440000) > Rechtspflege (n448000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "448000" ;
+        skos:prefLabel   "Rechtspflege"@de .
+
+:n500000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Bevölkerung"@de .
+
+:n500100  a              skos:Concept ;
+        skos:broader     :n500000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerung allgemein (n500100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "500100" ;
+        skos:prefLabel   "Bevölkerung allgemein"@de .
+
+:n502000  a              skos:Concept ;
+        skos:broader     :n500000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerung / Geschichte (n502000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "502000" ;
+        skos:prefLabel   "Bevölkerung / Geschichte"@de .
+
+:n503000  a              skos:Concept ;
+        skos:broader     :n500000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsstruktur (n503000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503000" ;
+        skos:prefLabel   "Bevölkerungsstruktur"@de .
+
+:n503020  a              skos:Concept ;
+        skos:broader     :n503000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Altersstruktur (n503020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503020" ;
+        skos:prefLabel   "Altersstruktur"@de .
+
+:n503030  a              skos:Concept ;
+        skos:broader     :n503000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Geschlechtsverhältnis (n503030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503030" ;
+        skos:prefLabel   "Geschlechtsverhältnis"@de .
+
+:n503040  a              skos:Concept ;
+        skos:broader     :n503000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Volkszählung (n503040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503040" ;
+        skos:prefLabel   "Volkszählung"@de .
+
+:n503050  a              skos:Concept ;
+        skos:broader     :n503000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Einwohnerverzeichnis (n503050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503050" ;
+        skos:prefLabel   "Einwohnerverzeichnis"@de .
+
+:n503060  a              skos:Concept ;
+        skos:broader     :n503000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Haushaltsgrösse (n503060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503060" ;
+        skos:prefLabel   "Haushaltsgrösse"@de .
+
+:n503070  a              skos:Concept ;
+        skos:broader     :n503000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Wohnstandard (n503070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503070" ;
+        skos:prefLabel   "Wohnstandard"@de .
+
+:n503080  a              skos:Concept ;
+        skos:broader     :n503000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Einkommensstatistik (n503080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503080" ;
+        skos:prefLabel   "Einkommensstatistik"@de .
+
+:n503090  a              skos:Concept ;
+        skos:broader     :n503000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsstruktur (n503000) > Denomination / Religion (n503090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503090" ;
+        skos:prefLabel   "Denomination / Religion"@de .
+
+:n503200  a              skos:Concept ;
+        skos:broader     :n500000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503200" ;
+        skos:prefLabel   "Bevölkerungsentwicklung"@de .
+
+:n503220  a              skos:Concept ;
+        skos:broader     :n503200 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Bevölkerungspolitik (n503220)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503220" ;
+        skos:prefLabel   "Bevölkerungspolitik"@de .
+
+:n503230  a              skos:Concept ;
+        skos:broader     :n503200 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Geburt / Statistik (n503230)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503230" ;
+        skos:prefLabel   "Geburt / Statistik"@de .
+
+:n503240  a              skos:Concept ;
+        skos:broader     :n503200 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Heirat / Statistik (n503240)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503240" ;
+        skos:prefLabel   "Heirat / Statistik"@de .
+
+:n503250  a              skos:Concept ;
+        skos:broader     :n503200 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Tod / Statistik (n503250)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503250" ;
+        skos:prefLabel   "Tod / Statistik"@de .
+
+:n503260  a              skos:Concept ;
+        skos:broader     :n503200 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsentwicklung (n503200) > Bevölkerungsentwicklung / Prognose (n503260)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503260" ;
+        skos:prefLabel   "Bevölkerungsentwicklung / Prognose"@de .
+
+:n503400  a              skos:Concept ;
+        skos:broader     :n500000 ;
+        skos:definition  "Bevölkerung (n500000) > Migration (n503400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503400" ;
+        skos:prefLabel   "Migration"@de .
+
+:n503420  a              skos:Concept ;
+        skos:broader     :n503400 ;
+        skos:definition  "Bevölkerung (n500000) > Migration (n503400) > Binnenwanderung (n503420)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503420" ;
+        skos:prefLabel   "Binnenwanderung"@de .
+
+:n503424  a              skos:Concept ;
+        skos:broader     :n503420 ;
+        skos:definition  "Bevölkerung (n500000) > Migration (n503400) > Binnenwanderung (n503420) > Berufspendlerin. Berufspendler (n503424)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503424" ;
+        skos:prefLabel   "Berufspendlerin. Berufspendler"@de .
+
+:n503430  a              skos:Concept ;
+        skos:broader     :n503400 ;
+        skos:definition  "Bevölkerung (n500000) > Migration (n503400) > Auswanderung (n503430)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503430" ;
+        skos:prefLabel   "Auswanderung"@de .
+
+:n503440  a              skos:Concept ;
+        skos:broader     :n503400 ;
+        skos:definition  "Bevölkerung (n500000) > Migration (n503400) > Einwanderung (n503440)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503440" ;
+        skos:prefLabel   "Einwanderung"@de .
+
+:n503600  a              skos:Concept ;
+        skos:broader     :n500000 ;
+        skos:definition  "Bevölkerung (n500000) > Bevölkerungsdichte (n503600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "503600" ;
+        skos:prefLabel   "Bevölkerungsdichte"@de .
+
+:n520000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Sozialwesen"@de .
+
+:n520100  a              skos:Concept ;
+        skos:broader     :n520000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialwesen allgemein (n520100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "520100" ;
+        skos:prefLabel   "Sozialwesen allgemein"@de .
+
+:n521000  a              skos:Concept ;
+        skos:broader     :n520000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialpolitik (n521000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "521000" ;
+        skos:prefLabel   "Sozialpolitik"@de .
+
+:n521200  a              skos:Concept ;
+        skos:broader     :n520000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialrecht (n521200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "521200" ;
+        skos:prefLabel   "Sozialrecht"@de .
+
+:n521400  a              skos:Concept ;
+        skos:broader     :n520000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialversicherung (n521400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "521400" ;
+        skos:prefLabel   "Sozialversicherung"@de .
+
+:n521410  a              skos:Concept ;
+        skos:broader     :n521400 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialversicherung (n521400) > Krankenversicherung (n521410)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "521410" ;
+        skos:prefLabel   "Krankenversicherung"@de .
+
+:n521420  a              skos:Concept ;
+        skos:broader     :n521400 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialversicherung (n521400) > Unfallversicherung (n521420)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "521420" ;
+        skos:prefLabel   "Unfallversicherung"@de .
+
+:n521430  a              skos:Concept ;
+        skos:broader     :n521400 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialversicherung (n521400) > Rentenversicherung (n521430)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "521430" ;
+        skos:prefLabel   "Rentenversicherung"@de .
+
+:n521450  a              skos:Concept ;
+        skos:broader     :n521400 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialversicherung (n521400) > Arbeitslosenversicherung (n521450)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "521450" ;
+        skos:prefLabel   "Arbeitslosenversicherung"@de .
+
+:n522000  a              skos:Concept ;
+        skos:broader     :n520000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "522000" ;
+        skos:prefLabel   "Sozialhilfe / Kostenträger"@de .
+
+:n522010  a              skos:Concept ;
+        skos:broader     :n522000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000) > Öffentlicher Träger (n522010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "522010" ;
+        skos:prefLabel   "Öffentlicher Träger"@de .
+
+:n522020  a              skos:Concept ;
+        skos:broader     :n522000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000) > Kirchlicher Träger (n522020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "522020" ;
+        skos:prefLabel   "Kirchlicher Träger"@de .
+
+:n522030  a              skos:Concept ;
+        skos:broader     :n522000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000) > Privater Träger (n522030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "522030" ;
+        skos:prefLabel   "Privater Träger"@de .
+
+:n522050  a              skos:Concept ;
+        skos:broader     :n522000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe / Kostenträger (n522000) > Karitative Stiftung (n522050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "522050" ;
+        skos:prefLabel   "Karitative Stiftung"@de .
+
+:n523000  a              skos:Concept ;
+        skos:broader     :n520000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523000" ;
+        skos:prefLabel   "Sozialhilfe"@de .
+
+:n523010  a              skos:Concept ;
+        skos:broader     :n523000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Arbeitslosenunterstützung (n523010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523010" ;
+        skos:prefLabel   "Arbeitslosenunterstützung"@de .
+
+:n523030  a              skos:Concept ;
+        skos:broader     :n523000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Fürsorge (n523030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523030" ;
+        skos:prefLabel   "Fürsorge"@de .
+
+:n523035  a              skos:Concept ;
+        skos:broader     :n523030 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Fürsorge (n523030) > Obdachlosenhilfe (n523035)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523035" ;
+        skos:prefLabel   "Obdachlosenhilfe"@de .
+
+:n523040  a              skos:Concept ;
+        skos:broader     :n523000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Unfallfürsorge (n523040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523040" ;
+        skos:prefLabel   "Unfallfürsorge"@de .
+
+:n523050  a              skos:Concept ;
+        skos:broader     :n523000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Krankenfürsorge (n523050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523050" ;
+        skos:prefLabel   "Krankenfürsorge"@de .
+
+:n523060  a              skos:Concept ;
+        skos:broader     :n523000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Behindertenhilfe (n523060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523060" ;
+        skos:prefLabel   "Behindertenhilfe"@de .
+
+:n523070  a              skos:Concept ;
+        skos:broader     :n523000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Kriegsopferfürsorge (n523070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523070" ;
+        skos:prefLabel   "Kriegsopferfürsorge"@de .
+
+:n523075  a              skos:Concept ;
+        skos:broader     :n523000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Gefangenenfürsorge (n523075)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523075" ;
+        skos:prefLabel   "Gefangenenfürsorge"@de .
+
+:n523080  a              skos:Concept ;
+        skos:broader     :n523000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Waisenfürsorge (n523080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523080" ;
+        skos:prefLabel   "Waisenfürsorge"@de .
+
+:n523090  a              skos:Concept ;
+        skos:broader     :n523000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialhilfe (n523000) > Altenhilfe (n523090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "523090" ;
+        skos:prefLabel   "Altenhilfe"@de .
+
+:n524000  a              skos:Concept ;
+        skos:broader     :n520000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialpädagogik (n524000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "524000" ;
+        skos:prefLabel   "Sozialpädagogik"@de .
+
+:n524010  a              skos:Concept ;
+        skos:broader     :n524000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialpädagogik (n524000) > Jugendhilfe (n524010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "524010" ;
+        skos:prefLabel   "Jugendhilfe"@de .
+
+:n524050  a              skos:Concept ;
+        skos:broader     :n524000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialpädagogik (n524000) > Bewährungshilfe (n524050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "524050" ;
+        skos:prefLabel   "Bewährungshilfe"@de .
+
+:n524060  a              skos:Concept ;
+        skos:broader     :n524000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialpädagogik (n524000) > Erziehungsberatung (n524060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "524060" ;
+        skos:prefLabel   "Erziehungsberatung"@de .
+
+:n524070  a              skos:Concept ;
+        skos:broader     :n524000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialpädagogik (n524000) > Familienfürsorge (n524070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "524070" ;
+        skos:prefLabel   "Familienfürsorge"@de .
+
+:n524080  a              skos:Concept ;
+        skos:broader     :n524000 ;
+        skos:definition  "Sozialwesen (n520000) > Sozialpädagogik (n524000) > Berufsbetreuung (n524080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "524080" ;
+        skos:prefLabel   "Berufsbetreuung"@de .
+
+:n530000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Gesundheitswesen"@de .
+
+:n530100  a              skos:Concept ;
+        skos:broader     :n530000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Gesundheitswesen allgemein (n530100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "530100" ;
+        skos:prefLabel   "Gesundheitswesen allgemein"@de .
+
+:n532000  a              skos:Concept ;
+        skos:broader     :n530000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Medizin (n532000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "532000" ;
+        skos:prefLabel   "Medizin"@de .
+
+:n532010  a              skos:Concept ;
+        skos:broader     :n532000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Medizin (n532000) > Medizin / Geschichte (n532010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "532010" ;
+        skos:prefLabel   "Medizin / Geschichte"@de .
+
+:n532030  a              skos:Concept ;
+        skos:broader     :n532000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Medizin (n532000) > Medizinische Versorgung (n532030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "532030" ;
+        skos:prefLabel   "Medizinische Versorgung"@de .
+
+:n532050  a              skos:Concept ;
+        skos:broader     :n532000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Medizin (n532000) > Ärztin. Arzt. Heilberuf (n532050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "532050" ;
+        skos:prefLabel   "Ärztin. Arzt. Heilberuf"@de .
+
+:n532070  a              skos:Concept ;
+        skos:broader     :n532000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Medizin (n532000) > Gesundheitsvorsorge (n532070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "532070" ;
+        skos:prefLabel   "Gesundheitsvorsorge"@de .
+
+:n533000  a              skos:Concept ;
+        skos:broader     :n530000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Apotheke (n533000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "533000" ;
+        skos:prefLabel   "Apotheke"@de .
+
+:n534000  a              skos:Concept ;
+        skos:broader     :n530000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Krankenversorgung (n534000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "534000" ;
+        skos:prefLabel   "Krankenversorgung"@de .
+
+:n534010  a              skos:Concept ;
+        skos:broader     :n534000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Krankenpflege (n534010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "534010" ;
+        skos:prefLabel   "Krankenpflege"@de .
+
+:n534020  a              skos:Concept ;
+        skos:broader     :n534000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Krankenpflege / Beruf (n534020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "534020" ;
+        skos:prefLabel   "Krankenpflege / Beruf"@de .
+
+:n534030  a              skos:Concept ;
+        skos:broader     :n534000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Krankenhaus (n534030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "534030" ;
+        skos:prefLabel   "Krankenhaus"@de .
+
+:n534050  a              skos:Concept ;
+        skos:broader     :n534000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Sanatorium (n534050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "534050" ;
+        skos:prefLabel   "Sanatorium"@de .
+
+:n534060  a              skos:Concept ;
+        skos:broader     :n534000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Suchtkrankenhilfe (n534060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "534060" ;
+        skos:prefLabel   "Suchtkrankenhilfe"@de .
+
+:n534080  a              skos:Concept ;
+        skos:broader     :n534000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Krankenversorgung (n534000) > Psychiatrie (n534080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "534080" ;
+        skos:prefLabel   "Psychiatrie"@de .
+
+:n535000  a              skos:Concept ;
+        skos:broader     :n530000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Hygiene (n535000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "535000" ;
+        skos:prefLabel   "Hygiene"@de .
+
+:n537000  a              skos:Concept ;
+        skos:broader     :n530000 ;
+        skos:definition  "Gesundheitswesen (n530000) > Veterinärwesen (n537000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "537000" ;
+        skos:prefLabel   "Veterinärwesen"@de .
+
+:n540000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Wirtschaft"@de .
+
+:n540100  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaft allgemein (n540100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "540100" ;
+        skos:prefLabel   "Wirtschaft allgemein"@de .
+
+:n541000  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftspolitik (n541000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "541000" ;
+        skos:prefLabel   "Wirtschaftspolitik"@de .
+
+:n541500  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsrecht (n541500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "541500" ;
+        skos:prefLabel   "Wirtschaftsrecht"@de .
+
+:n542000  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaft / Geschichte (n542000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "542000" ;
+        skos:prefLabel   "Wirtschaft / Geschichte"@de .
+
+:n543000  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsstruktur (n543000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543000" ;
+        skos:prefLabel   "Wirtschaftsstruktur"@de .
+
+:n543010  a              skos:Concept ;
+        skos:broader     :n543000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsstruktur (n543000) > Wirtschaftsförderung (n543010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543010" ;
+        skos:prefLabel   "Wirtschaftsförderung"@de .
+
+:n543040  a              skos:Concept ;
+        skos:broader     :n543000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsstruktur (n543000) > Bruttoinlandsprodukt (n543040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543040" ;
+        skos:prefLabel   "Bruttoinlandsprodukt"@de .
+
+:n543060  a              skos:Concept ;
+        skos:broader     :n543000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsstruktur (n543000) > Außenwirtschaft (n543060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543060" ;
+        skos:prefLabel   "Außenwirtschaft"@de .
+
+:n543080  a              skos:Concept ;
+        skos:broader     :n543000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsstruktur (n543000) > Wirtschaftsstatistik (n543080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543080" ;
+        skos:prefLabel   "Wirtschaftsstatistik"@de .
+
+:n543200  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsverfassung (n543200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543200" ;
+        skos:prefLabel   "Wirtschaftsverfassung"@de .
+
+:n543400  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsverband (n543400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543400" ;
+        skos:prefLabel   "Wirtschaftsverband"@de .
+
+:n543430  a              skos:Concept ;
+        skos:broader     :n543400 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsverband (n543400) > Industrie- und Handelskammer (n543430)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543430" ;
+        skos:prefLabel   "Industrie- und Handelskammer"@de .
+
+:n543440  a              skos:Concept ;
+        skos:broader     :n543400 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsverband (n543400) > Verbraucherverband (n543440)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543440" ;
+        skos:prefLabel   "Verbraucherverband"@de .
+
+:n543460  a              skos:Concept ;
+        skos:broader     :n543400 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsverband (n543400) > Arbeitgeberverband (n543460)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543460" ;
+        skos:prefLabel   "Arbeitgeberverband"@de .
+
+:n543480  a              skos:Concept ;
+        skos:broader     :n543400 ;
+        skos:definition  "Wirtschaft (n540000) > Wirtschaftsverband (n543400) > Gewerkschaft (n543480)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543480" ;
+        skos:prefLabel   "Gewerkschaft"@de .
+
+:n543600  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Arbeitsmarkt (n543600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543600" ;
+        skos:prefLabel   "Arbeitsmarkt"@de .
+
+:n543620  a              skos:Concept ;
+        skos:broader     :n543600 ;
+        skos:definition  "Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Unternehmerin. Unternehmer (n543620)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543620" ;
+        skos:prefLabel   "Unternehmerin. Unternehmer"@de .
+
+:n543630  a              skos:Concept ;
+        skos:broader     :n543600 ;
+        skos:definition  "Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Arbeitnehmerin. Arbeitnehmer (n543630)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543630" ;
+        skos:prefLabel   "Arbeitnehmerin. Arbeitnehmer"@de .
+
+:n543640  a              skos:Concept ;
+        skos:broader     :n543600 ;
+        skos:definition  "Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Freier Beruf (n543640)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543640" ;
+        skos:prefLabel   "Freier Beruf"@de .
+
+:n543660  a              skos:Concept ;
+        skos:broader     :n543600 ;
+        skos:definition  "Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Lohn (n543660)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543660" ;
+        skos:prefLabel   "Lohn"@de .
+
+:n543680  a              skos:Concept ;
+        skos:broader     :n543600 ;
+        skos:definition  "Wirtschaft (n540000) > Arbeitsmarkt (n543600) > Arbeitslosigkeit (n543680)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543680" ;
+        skos:prefLabel   "Arbeitslosigkeit"@de .
+
+:n543800  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Marketing (n543800)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "543800" ;
+        skos:prefLabel   "Marketing"@de .
+
+:n544000  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544000" ;
+        skos:prefLabel   "Landwirtschaft"@de .
+
+:n544010  a              skos:Concept ;
+        skos:broader     :n544000 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Agrarpolitik (n544010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544010" ;
+        skos:prefLabel   "Agrarpolitik"@de .
+
+:n544020  a              skos:Concept ;
+        skos:broader     :n544000 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Geschichte (n544020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544020" ;
+        skos:prefLabel   "Landwirtschaft / Geschichte"@de .
+
+:n544030  a              skos:Concept ;
+        skos:broader     :n544000 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Bauernhof / Geschichte (n544030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544030" ;
+        skos:prefLabel   "Bauernhof / Geschichte"@de .
+
+:n544040  a              skos:Concept ;
+        skos:broader     :n544000 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Flurform (n544040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544040" ;
+        skos:prefLabel   "Flurform"@de .
+
+:n544050  a              skos:Concept ;
+        skos:broader     :n544000 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Beruf (n544050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544050" ;
+        skos:prefLabel   "Landwirtschaft / Beruf"@de .
+
+:n544052  a              skos:Concept ;
+        skos:broader     :n544050 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Beruf (n544050) > Bäuerin. Bauer (n544052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544052" ;
+        skos:prefLabel   "Bäuerin. Bauer"@de .
+
+:n544054  a              skos:Concept ;
+        skos:broader     :n544050 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Beruf (n544050) > Landfrau (n544054)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544054" ;
+        skos:prefLabel   "Landfrau"@de .
+
+:n544056  a              skos:Concept ;
+        skos:broader     :n544050 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaft / Beruf (n544050) > Landarbeiterin. Landarbeiter (n544056)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544056" ;
+        skos:prefLabel   "Landarbeiterin. Landarbeiter"@de .
+
+:n544060  a              skos:Concept ;
+        skos:broader     :n544000 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaftliche Betriebslehre (n544060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544060" ;
+        skos:prefLabel   "Landwirtschaftliche Betriebslehre"@de .
+
+:n544090  a              skos:Concept ;
+        skos:broader     :n544000 ;
+        skos:definition  "Wirtschaft (n540000) > Landwirtschaft (n544000) > Landwirtschaftsgenossenschaft (n544090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544090" ;
+        skos:prefLabel   "Landwirtschaftsgenossenschaft"@de .
+
+:n544200  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Agrarproduktion (n544200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544200" ;
+        skos:prefLabel   "Agrarproduktion"@de .
+
+:n544220  a              skos:Concept ;
+        skos:broader     :n544200 ;
+        skos:definition  "Wirtschaft (n540000) > Agrarproduktion (n544200) > Ackerbau (n544220)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544220" ;
+        skos:prefLabel   "Ackerbau"@de .
+
+:n544230  a              skos:Concept ;
+        skos:broader     :n544200 ;
+        skos:definition  "Wirtschaft (n540000) > Agrarproduktion (n544200) > Grünlandwirtschaft (n544230)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544230" ;
+        skos:prefLabel   "Grünlandwirtschaft"@de .
+
+:n544240  a              skos:Concept ;
+        skos:broader     :n544200 ;
+        skos:definition  "Wirtschaft (n540000) > Agrarproduktion (n544200) > Gartenbau (n544240)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544240" ;
+        skos:prefLabel   "Gartenbau"@de .
+
+:n544245  a              skos:Concept ;
+        skos:broader     :n544240 ;
+        skos:definition  "Wirtschaft (n540000) > Agrarproduktion (n544200) > Gartenbau (n544240) > Baumschule (n544245)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544245" ;
+        skos:prefLabel   "Baumschule"@de .
+
+:n544250  a              skos:Concept ;
+        skos:broader     :n544200 ;
+        skos:definition  "Wirtschaft (n540000) > Agrarproduktion (n544200) > Obstbau (n544250)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544250" ;
+        skos:prefLabel   "Obstbau"@de .
+
+:n544280  a              skos:Concept ;
+        skos:broader     :n544200 ;
+        skos:definition  "Wirtschaft (n540000) > Agrarproduktion (n544200) > Tierzucht (n544280)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544280" ;
+        skos:prefLabel   "Tierzucht"@de .
+
+:n544300  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau (n544300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544300" ;
+        skos:prefLabel   "Weinbau"@de .
+
+:n544310  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau / Geschichte (n544310)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544310" ;
+        skos:prefLabel   "Weinbau / Geschichte"@de .
+
+:n544320  a              skos:Concept ;
+        skos:broader     :n544310 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinbaugebiet (n544320)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544320" ;
+        skos:prefLabel   "Weinbaugebiet"@de .
+
+:n544322  a              skos:Concept ;
+        skos:broader     :n544320 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinbaugebiet (n544320) > Großlage (n544322)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544322" ;
+        skos:prefLabel   "Großlage"@de .
+
+:n544325  a              skos:Concept ;
+        skos:broader     :n544320 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinbaugebiet (n544320) > Weingut (n544325)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544325" ;
+        skos:prefLabel   "Weingut"@de .
+
+:n544340  a              skos:Concept ;
+        skos:broader     :n544310 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinherstellung (n544340)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544340" ;
+        skos:prefLabel   "Weinherstellung"@de .
+
+:n544341  a              skos:Concept ;
+        skos:broader     :n544340 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinherstellung (n544340) > Schaumweinherstellung (n544341)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544341" ;
+        skos:prefLabel   "Schaumweinherstellung"@de .
+
+:n544344  a              skos:Concept ;
+        skos:broader     :n544340 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinherstellung (n544340) > Branntweinherstellung (n544344)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544344" ;
+        skos:prefLabel   "Branntweinherstellung"@de .
+
+:n544360  a              skos:Concept ;
+        skos:broader     :n544310 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinhandel (n544360)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544360" ;
+        skos:prefLabel   "Weinhandel"@de .
+
+:n544361  a              skos:Concept ;
+        skos:broader     :n544360 ;
+        skos:definition  "Wirtschaft (n540000) > Weinbau / Geschichte (n544310) > Weinhandel (n544360) > Schaumwein / Handel (n544361)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544361" ;
+        skos:prefLabel   "Schaumwein / Handel"@de .
+
+:n544400  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Forstwirtschaft (n544400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544400" ;
+        skos:prefLabel   "Forstwirtschaft"@de .
+
+:n544410  a              skos:Concept ;
+        skos:broader     :n544400 ;
+        skos:definition  "Wirtschaft (n540000) > Forstwirtschaft (n544400) > Forstrecht (n544410)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544410" ;
+        skos:prefLabel   "Forstrecht"@de .
+
+:n544420  a              skos:Concept ;
+        skos:broader     :n544400 ;
+        skos:definition  "Wirtschaft (n540000) > Forstwirtschaft (n544400) > Forstwirtschaft / Geschichte (n544420)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544420" ;
+        skos:prefLabel   "Forstwirtschaft / Geschichte"@de .
+
+:n544440  a              skos:Concept ;
+        skos:broader     :n544400 ;
+        skos:definition  "Wirtschaft (n540000) > Forstwirtschaft (n544400) > Forstproduktion (n544440)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544440" ;
+        skos:prefLabel   "Forstproduktion"@de .
+
+:n544450  a              skos:Concept ;
+        skos:broader     :n544400 ;
+        skos:definition  "Wirtschaft (n540000) > Forstwirtschaft (n544400) > Baumart (n544450)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544450" ;
+        skos:prefLabel   "Baumart"@de .
+
+:n544460  a              skos:Concept ;
+        skos:broader     :n544400 ;
+        skos:definition  "Wirtschaft (n540000) > Forstwirtschaft (n544400) > Forst (n544460)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544460" ;
+        skos:prefLabel   "Forst"@de .
+
+:n544490  a              skos:Concept ;
+        skos:broader     :n544400 ;
+        skos:definition  "Wirtschaft (n540000) > Forstwirtschaft (n544400) > Försterin. Förster (n544490)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544490" ;
+        skos:prefLabel   "Försterin. Förster"@de .
+
+:n544600  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Jagd. Fischfang (n544600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544600" ;
+        skos:prefLabel   "Jagd. Fischfang"@de .
+
+:n544610  a              skos:Concept ;
+        skos:broader     :n544600 ;
+        skos:definition  "Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Jagd (n544610)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544610" ;
+        skos:prefLabel   "Jagd"@de .
+
+:n544620  a              skos:Concept ;
+        skos:broader     :n544600 ;
+        skos:definition  "Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Jagdrecht (n544620)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544620" ;
+        skos:prefLabel   "Jagdrecht"@de .
+
+:n544640  a              skos:Concept ;
+        skos:broader     :n544600 ;
+        skos:definition  "Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Wild (n544640)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544640" ;
+        skos:prefLabel   "Wild"@de .
+
+:n544650  a              skos:Concept ;
+        skos:broader     :n544600 ;
+        skos:definition  "Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Fischfang (n544650)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544650" ;
+        skos:prefLabel   "Fischfang"@de .
+
+:n544660  a              skos:Concept ;
+        skos:broader     :n544600 ;
+        skos:definition  "Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Fischereirecht (n544660)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544660" ;
+        skos:prefLabel   "Fischereirecht"@de .
+
+:n544670  a              skos:Concept ;
+        skos:broader     :n544600 ;
+        skos:definition  "Wirtschaft (n540000) > Jagd. Fischfang (n544600) > Fischzucht (n544670)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "544670" ;
+        skos:prefLabel   "Fischzucht"@de .
+
+:n545000  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Bergbau (n545000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "545000" ;
+        skos:prefLabel   "Bergbau"@de .
+
+:n545010  a              skos:Concept ;
+        skos:broader     :n545000 ;
+        skos:definition  "Wirtschaft (n540000) > Bergbau (n545000) > Bergrecht (n545010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "545010" ;
+        skos:prefLabel   "Bergrecht"@de .
+
+:n545020  a              skos:Concept ;
+        skos:broader     :n545000 ;
+        skos:definition  "Wirtschaft (n540000) > Bergbau (n545000) > Bergbau / Geschichte (n545020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "545020" ;
+        skos:prefLabel   "Bergbau / Geschichte"@de .
+
+:n545030  a              skos:Concept ;
+        skos:broader     :n545000 ;
+        skos:definition  "Wirtschaft (n540000) > Bergbau (n545000) > Kohlenbergbau (n545030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "545030" ;
+        skos:prefLabel   "Kohlenbergbau"@de .
+
+:n545040  a              skos:Concept ;
+        skos:broader     :n545000 ;
+        skos:definition  "Wirtschaft (n540000) > Bergbau (n545000) > Gesteinsabbau (n545040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "545040" ;
+        skos:prefLabel   "Gesteinsabbau"@de .
+
+:n545050  a              skos:Concept ;
+        skos:broader     :n545000 ;
+        skos:definition  "Wirtschaft (n540000) > Bergbau (n545000) > Erzbergbau (n545050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "545050" ;
+        skos:prefLabel   "Erzbergbau"@de .
+
+:n545060  a              skos:Concept ;
+        skos:broader     :n545000 ;
+        skos:definition  "Wirtschaft (n540000) > Bergbau (n545000) > Salzbergbau. Kalibergbau (n545060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "545060" ;
+        skos:prefLabel   "Salzbergbau. Kalibergbau"@de .
+
+:n545070  a              skos:Concept ;
+        skos:broader     :n545000 ;
+        skos:definition  "Wirtschaft (n540000) > Bergbau (n545000) > Erdöl (n545070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "545070" ;
+        skos:prefLabel   "Erdöl"@de .
+
+:n545080  a              skos:Concept ;
+        skos:broader     :n545000 ;
+        skos:definition  "Wirtschaft (n540000) > Bergbau (n545000) > Erdgas (n545080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "545080" ;
+        skos:prefLabel   "Erdgas"@de .
+
+:n546000  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Energiewirtschaft (n546000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "546000" ;
+        skos:prefLabel   "Energiewirtschaft"@de .
+
+:n546020  a              skos:Concept ;
+        skos:broader     :n546000 ;
+        skos:definition  "Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "546020" ;
+        skos:prefLabel   "Elektrizitätsversorgung"@de .
+
+:n546022  a              skos:Concept ;
+        skos:broader     :n546020 ;
+        skos:definition  "Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020) > Wasserkraftwerk (n546022)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "546022" ;
+        skos:prefLabel   "Wasserkraftwerk"@de .
+
+:n546024  a              skos:Concept ;
+        skos:broader     :n546020 ;
+        skos:definition  "Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020) > Wärmekraftwerk (n546024)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "546024" ;
+        skos:prefLabel   "Wärmekraftwerk"@de .
+
+:n546026  a              skos:Concept ;
+        skos:broader     :n546020 ;
+        skos:definition  "Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020) > Kernkraftwerk (n546026)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "546026" ;
+        skos:prefLabel   "Kernkraftwerk"@de .
+
+:n546028  a              skos:Concept ;
+        skos:broader     :n546020 ;
+        skos:definition  "Wirtschaft (n540000) > Energiewirtschaft (n546000) > Elektrizitätsversorgung (n546020) > Alternative Energiequelle (n546028)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "546028" ;
+        skos:prefLabel   "Alternative Energiequelle"@de .
+
+:n546040  a              skos:Concept ;
+        skos:broader     :n546000 ;
+        skos:definition  "Wirtschaft (n540000) > Energiewirtschaft (n546000) > Gasversorgung (n546040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "546040" ;
+        skos:prefLabel   "Gasversorgung"@de .
+
+:n546060  a              skos:Concept ;
+        skos:broader     :n546000 ;
+        skos:definition  "Wirtschaft (n540000) > Energiewirtschaft (n546000) > Verbundwirtschaft (n546060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "546060" ;
+        skos:prefLabel   "Verbundwirtschaft"@de .
+
+:n547000  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547000" ;
+        skos:prefLabel   "Handwerk"@de .
+
+:n547020  a              skos:Concept ;
+        skos:broader     :n547000 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Handwerk / Geschichte (n547020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547020" ;
+        skos:prefLabel   "Handwerk / Geschichte"@de .
+
+:n547030  a              skos:Concept ;
+        skos:broader     :n547000 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Handwerk / Beruf (n547030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547030" ;
+        skos:prefLabel   "Handwerk / Beruf"@de .
+
+:n547035  a              skos:Concept ;
+        skos:broader     :n547030 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Handwerk / Beruf (n547030) > Handwerksbetrieb (n547035)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547035" ;
+        skos:prefLabel   "Handwerksbetrieb"@de .
+
+:n547040  a              skos:Concept ;
+        skos:broader     :n547000 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Handwerksorganisation (n547040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547040" ;
+        skos:prefLabel   "Handwerksorganisation"@de .
+
+:n547042  a              skos:Concept ;
+        skos:broader     :n547040 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Handwerksorganisation (n547040) > Handwerkskammer (n547042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547042" ;
+        skos:prefLabel   "Handwerkskammer"@de .
+
+:n547044  a              skos:Concept ;
+        skos:broader     :n547040 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Handwerksorganisation (n547040) > Innung (n547044)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547044" ;
+        skos:prefLabel   "Innung"@de .
+
+:n547400  a              skos:Concept ;
+        skos:broader     :n547000 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Industrie (n547400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547400" ;
+        skos:prefLabel   "Industrie"@de .
+
+:n547420  a              skos:Concept ;
+        skos:broader     :n547400 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Industrie (n547400) > Industrie / Geschichte (n547420)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547420" ;
+        skos:prefLabel   "Industrie / Geschichte"@de .
+
+:n547440  a              skos:Concept ;
+        skos:broader     :n547400 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Industrie (n547400) > Industriezweig (n547440)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547440" ;
+        skos:prefLabel   "Industriezweig"@de .
+
+:n547460  a              skos:Concept ;
+        skos:broader     :n547400 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Industrie (n547400) > Industriebetrieb (n547460)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547460" ;
+        skos:prefLabel   "Industriebetrieb"@de .
+
+:n547600  a              skos:Concept ;
+        skos:broader     :n547000 ;
+        skos:definition  "Wirtschaft (n540000) > Handwerk (n547000) > Technik. Technologie (n547600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "547600" ;
+        skos:prefLabel   "Technik. Technologie"@de .
+
+:n548000  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Handel (n548000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548000" ;
+        skos:prefLabel   "Handel"@de .
+
+:n548010  a              skos:Concept ;
+        skos:broader     :n548000 ;
+        skos:definition  "Wirtschaft (n540000) > Handel (n548000) > Handelsrecht (n548010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548010" ;
+        skos:prefLabel   "Handelsrecht"@de .
+
+:n548020  a              skos:Concept ;
+        skos:broader     :n548000 ;
+        skos:definition  "Wirtschaft (n540000) > Handel (n548000) > Handel / Geschichte (n548020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548020" ;
+        skos:prefLabel   "Handel / Geschichte"@de .
+
+:n548030  a              skos:Concept ;
+        skos:broader     :n548000 ;
+        skos:definition  "Wirtschaft (n540000) > Handel (n548000) > Handelsform (n548030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548030" ;
+        skos:prefLabel   "Handelsform"@de .
+
+:n548040  a              skos:Concept ;
+        skos:broader     :n548000 ;
+        skos:definition  "Wirtschaft (n540000) > Handel (n548000) > Messe / Wirtschaft (n548040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548040" ;
+        skos:prefLabel   "Messe / Wirtschaft"@de .
+
+:n548045  a              skos:Concept ;
+        skos:broader     :n548040 ;
+        skos:definition  "Wirtschaft (n540000) > Handel (n548000) > Messe / Wirtschaft (n548040) > Markt (n548045)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548045" ;
+        skos:prefLabel   "Markt"@de .
+
+:n548050  a              skos:Concept ;
+        skos:broader     :n548000 ;
+        skos:definition  "Wirtschaft (n540000) > Handel (n548000) > Firma (n548050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548050" ;
+        skos:prefLabel   "Firma"@de .
+
+:n548060  a              skos:Concept ;
+        skos:broader     :n548000 ;
+        skos:definition  "Wirtschaft (n540000) > Handel (n548000) > Handelsgut (n548060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548060" ;
+        skos:prefLabel   "Handelsgut"@de .
+
+:n548090  a              skos:Concept ;
+        skos:broader     :n548000 ;
+        skos:definition  "Wirtschaft (n540000) > Handel (n548000) > Handelsgenossenschaft (n548090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548090" ;
+        skos:prefLabel   "Handelsgenossenschaft"@de .
+
+:n548200  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Dienstleistungssektor (n548200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548200" ;
+        skos:prefLabel   "Dienstleistungssektor"@de .
+
+:n548250  a              skos:Concept ;
+        skos:broader     :n548200 ;
+        skos:definition  "Wirtschaft (n540000) > Dienstleistungssektor (n548200) > Dienstleistungsbetrieb (n548250)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548250" ;
+        skos:prefLabel   "Dienstleistungsbetrieb"@de .
+
+:n548300  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Öffentliches Unternehmen (n548300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548300" ;
+        skos:prefLabel   "Öffentliches Unternehmen"@de .
+
+:n548400  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Bank (n548400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548400" ;
+        skos:prefLabel   "Bank"@de .
+
+:n548600  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Versicherung (n548600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548600" ;
+        skos:prefLabel   "Versicherung"@de .
+
+:n548800  a              skos:Concept ;
+        skos:broader     :n540000 ;
+        skos:definition  "Wirtschaft (n540000) > Tourismus (n548800)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548800" ;
+        skos:prefLabel   "Tourismus"@de .
+
+:n548820  a              skos:Concept ;
+        skos:broader     :n548800 ;
+        skos:definition  "Wirtschaft (n540000) > Tourismus (n548800) > Kurort (n548820)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548820" ;
+        skos:prefLabel   "Kurort"@de .
+
+:n548830  a              skos:Concept ;
+        skos:broader     :n548800 ;
+        skos:definition  "Wirtschaft (n540000) > Tourismus (n548800) > Naherholung (n548830)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548830" ;
+        skos:prefLabel   "Naherholung"@de .
+
+:n548840  a              skos:Concept ;
+        skos:broader     :n548800 ;
+        skos:definition  "Wirtschaft (n540000) > Tourismus (n548800) > Gastgewerbe (n548840)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548840" ;
+        skos:prefLabel   "Gastgewerbe"@de .
+
+:n548870  a              skos:Concept ;
+        skos:broader     :n548800 ;
+        skos:definition  "Wirtschaft (n540000) > Tourismus (n548800) > Jugendherberge (n548870)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "548870" ;
+        skos:prefLabel   "Jugendherberge"@de .
+
+:n550000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Verkehr"@de .
+
+:n550100  a              skos:Concept ;
+        skos:broader     :n550000 ;
+        skos:definition  "Verkehr (n550000) > Verkehr allgemein (n550100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "550100" ;
+        skos:prefLabel   "Verkehr allgemein"@de .
+
+:n551000  a              skos:Concept ;
+        skos:broader     :n550000 ;
+        skos:definition  "Verkehr (n550000) > Verkehrsrecht (n551000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "551000" ;
+        skos:prefLabel   "Verkehrsrecht"@de .
+
+:n552000  a              skos:Concept ;
+        skos:broader     :n550000 ;
+        skos:definition  "Verkehr (n550000) > Verkehr / Geschichte (n552000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "552000" ;
+        skos:prefLabel   "Verkehr / Geschichte"@de .
+
+:n553000  a              skos:Concept ;
+        skos:broader     :n550000 ;
+        skos:definition  "Verkehr (n550000) > Straßenverkehr (n553000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "553000" ;
+        skos:prefLabel   "Straßenverkehr"@de .
+
+:n554000  a              skos:Concept ;
+        skos:broader     :n550000 ;
+        skos:definition  "Verkehr (n550000) > Öffentlicher Personennahverkehr (n554000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "554000" ;
+        skos:prefLabel   "Öffentlicher Personennahverkehr"@de .
+
+:n555000  a              skos:Concept ;
+        skos:broader     :n550000 ;
+        skos:definition  "Verkehr (n550000) > Eisenbahn (n555000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "555000" ;
+        skos:prefLabel   "Eisenbahn"@de .
+
+:n555020  a              skos:Concept ;
+        skos:broader     :n555000 ;
+        skos:definition  "Verkehr (n550000) > Eisenbahn (n555000) > Eisenbahn / Geschichte (n555020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "555020" ;
+        skos:prefLabel   "Eisenbahn / Geschichte"@de .
+
+:n556000  a              skos:Concept ;
+        skos:broader     :n550000 ;
+        skos:definition  "Verkehr (n550000) > Luftverkehr (n556000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "556000" ;
+        skos:prefLabel   "Luftverkehr"@de .
+
+:n557000  a              skos:Concept ;
+        skos:broader     :n550000 ;
+        skos:definition  "Verkehr (n550000) > Schifffahrt (n557000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "557000" ;
+        skos:prefLabel   "Schifffahrt"@de .
+
+:n557020  a              skos:Concept ;
+        skos:broader     :n557000 ;
+        skos:definition  "Verkehr (n550000) > Schifffahrt (n557000) > Schifffahrt / Geschichte (n557020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "557020" ;
+        skos:prefLabel   "Schifffahrt / Geschichte"@de .
+
+:n557040  a              skos:Concept ;
+        skos:broader     :n557000 ;
+        skos:definition  "Verkehr (n550000) > Schifffahrt (n557000) > Kanal (n557040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "557040" ;
+        skos:prefLabel   "Kanal"@de .
+
+:n557060  a              skos:Concept ;
+        skos:broader     :n557000 ;
+        skos:definition  "Verkehr (n550000) > Schifffahrt (n557000) > Hafen (n557060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "557060" ;
+        skos:prefLabel   "Hafen"@de .
+
+:n558000  a              skos:Concept ;
+        skos:broader     :n550000 ;
+        skos:definition  "Verkehr (n550000) > Post. Fernmeldewesen (n558000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "558000" ;
+        skos:prefLabel   "Post. Fernmeldewesen"@de .
+
+:n558020  a              skos:Concept ;
+        skos:broader     :n558000 ;
+        skos:definition  "Verkehr (n550000) > Post. Fernmeldewesen (n558000) > Post / Geschichte (n558020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "558020" ;
+        skos:prefLabel   "Post / Geschichte"@de .
+
+:n558040  a              skos:Concept ;
+        skos:broader     :n558000 ;
+        skos:definition  "Verkehr (n550000) > Post. Fernmeldewesen (n558000) > Briefmarke (n558040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "558040" ;
+        skos:prefLabel   "Briefmarke"@de .
+
+:n558050  a              skos:Concept ;
+        skos:broader     :n558000 ;
+        skos:definition  "Verkehr (n550000) > Post. Fernmeldewesen (n558000) > Fernmeldewesen (n558050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "558050" ;
+        skos:prefLabel   "Fernmeldewesen"@de .
+
+:n560000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Siedlung"@de .
+
+:n560100  a              skos:Concept ;
+        skos:broader     :n560000 ;
+        skos:definition  "Siedlung (n560000) > Siedlung allgemein (n560100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "560100" ;
+        skos:prefLabel   "Siedlung allgemein"@de .
+
+:n562000  a              skos:Concept ;
+        skos:broader     :n560000 ;
+        skos:definition  "Siedlung (n560000) > Siedlung / Geschichte (n562000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "562000" ;
+        skos:prefLabel   "Siedlung / Geschichte"@de .
+
+:n562040  a              skos:Concept ;
+        skos:broader     :n562000 ;
+        skos:definition  "Siedlung (n560000) > Siedlung / Geschichte (n562000) > Wüstung (n562040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "562040" ;
+        skos:prefLabel   "Wüstung"@de .
+
+:n562060  a              skos:Concept ;
+        skos:broader     :n562000 ;
+        skos:definition  "Siedlung (n560000) > Siedlung / Geschichte (n562000) > Allmende (n562060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "562060" ;
+        skos:prefLabel   "Allmende"@de .
+
+:n562300  a              skos:Concept ;
+        skos:broader     :n560000 ;
+        skos:definition  "Siedlung (n560000) > Kulturlandschaft (n562300)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "562300" ;
+        skos:prefLabel   "Kulturlandschaft"@de .
+
+:n562600  a              skos:Concept ;
+        skos:broader     :n560000 ;
+        skos:definition  "Siedlung (n560000) > Siedlungsraum (n562600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "562600" ;
+        skos:prefLabel   "Siedlungsraum"@de .
+
+:n563000  a              skos:Concept ;
+        skos:broader     :n560000 ;
+        skos:definition  "Siedlung (n560000) > Siedlungsform (n563000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "563000" ;
+        skos:prefLabel   "Siedlungsform"@de .
+
+:n563020  a              skos:Concept ;
+        skos:broader     :n563000 ;
+        skos:definition  "Siedlung (n560000) > Siedlungsform (n563000) > Industriestadt (n563020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "563020" ;
+        skos:prefLabel   "Industriestadt"@de .
+
+:n563030  a              skos:Concept ;
+        skos:broader     :n563000 ;
+        skos:definition  "Siedlung (n560000) > Siedlungsform (n563000) > Marktzentrum (n563030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "563030" ;
+        skos:prefLabel   "Marktzentrum"@de .
+
+:n563040  a              skos:Concept ;
+        skos:broader     :n563000 ;
+        skos:definition  "Siedlung (n560000) > Siedlungsform (n563000) > Wohnsiedlung (n563040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "563040" ;
+        skos:prefLabel   "Wohnsiedlung"@de .
+
+:n563050  a              skos:Concept ;
+        skos:broader     :n563000 ;
+        skos:definition  "Siedlung (n560000) > Siedlungsform (n563000) > Gewerbegebiet (n563050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "563050" ;
+        skos:prefLabel   "Gewerbegebiet"@de .
+
+:n564000  a              skos:Concept ;
+        skos:broader     :n560000 ;
+        skos:definition  "Siedlung (n560000) > Ländliche Siedlung (n564000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "564000" ;
+        skos:prefLabel   "Ländliche Siedlung"@de .
+
+:n564040  a              skos:Concept ;
+        skos:broader     :n564000 ;
+        skos:definition  "Siedlung (n560000) > Ländliche Siedlung (n564000) > Ländliche Siedlungsform (n564040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "564040" ;
+        skos:prefLabel   "Ländliche Siedlungsform"@de .
+
+:n564050  a              skos:Concept ;
+        skos:broader     :n564000 ;
+        skos:definition  "Siedlung (n560000) > Ländliche Siedlung (n564000) > Dorf / Topographie (n564050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "564050" ;
+        skos:prefLabel   "Dorf / Topographie"@de .
+
+:n564080  a              skos:Concept ;
+        skos:broader     :n564000 ;
+        skos:definition  "Siedlung (n560000) > Ländliche Siedlung (n564000) > Dorferneuerung (n564080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "564080" ;
+        skos:prefLabel   "Dorferneuerung"@de .
+
+:n566000  a              skos:Concept ;
+        skos:broader     :n560000 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566000" ;
+        skos:prefLabel   "Stadt"@de .
+
+:n566010  a              skos:Concept ;
+        skos:broader     :n566000 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadttyp (n566010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566010" ;
+        skos:prefLabel   "Stadttyp"@de .
+
+:n566020  a              skos:Concept ;
+        skos:broader     :n566000 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Städtische Siedlungsform (n566020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566020" ;
+        skos:prefLabel   "Städtische Siedlungsform"@de .
+
+:n566040  a              skos:Concept ;
+        skos:broader     :n566000 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566040" ;
+        skos:prefLabel   "Stadtgliederung"@de .
+
+:n566041  a              skos:Concept ;
+        skos:broader     :n566040 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Stadtkern (n566041)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566041" ;
+        skos:prefLabel   "Stadtkern"@de .
+
+:n566042  a              skos:Concept ;
+        skos:broader     :n566040 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Vorort (n566042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566042" ;
+        skos:prefLabel   "Vorort"@de .
+
+:n566043  a              skos:Concept ;
+        skos:broader     :n566040 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Geschäftsviertel (n566043)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566043" ;
+        skos:prefLabel   "Geschäftsviertel"@de .
+
+:n566045  a              skos:Concept ;
+        skos:broader     :n566040 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Stadtteil (n566045)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566045" ;
+        skos:prefLabel   "Stadtteil"@de .
+
+:n566046  a              skos:Concept ;
+        skos:broader     :n566040 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadtgliederung (n566040) > Stadt / Erholungsgebiet (n566046)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566046" ;
+        skos:prefLabel   "Stadt / Erholungsgebiet"@de .
+
+:n566050  a              skos:Concept ;
+        skos:broader     :n566000 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadt / Topographie (n566050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566050" ;
+        skos:prefLabel   "Stadt / Topographie"@de .
+
+:n566051  a              skos:Concept ;
+        skos:broader     :n566050 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadt / Topographie (n566050) > Platz (n566051)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566051" ;
+        skos:prefLabel   "Platz"@de .
+
+:n566052  a              skos:Concept ;
+        skos:broader     :n566050 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadt / Topographie (n566050) > Straße (n566052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566052" ;
+        skos:prefLabel   "Straße"@de .
+
+:n566053  a              skos:Concept ;
+        skos:broader     :n566050 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadt / Topographie (n566050) > Öffentliches Gebäude (n566053)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566053" ;
+        skos:prefLabel   "Öffentliches Gebäude"@de .
+
+:n566060  a              skos:Concept ;
+        skos:broader     :n566000 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Verstädterung (n566060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566060" ;
+        skos:prefLabel   "Verstädterung"@de .
+
+:n566070  a              skos:Concept ;
+        skos:broader     :n566000 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Ballungsraum (n566070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566070" ;
+        skos:prefLabel   "Ballungsraum"@de .
+
+:n566080  a              skos:Concept ;
+        skos:broader     :n566000 ;
+        skos:definition  "Siedlung (n560000) > Stadt (n566000) > Stadt / Umland (n566080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "566080" ;
+        skos:prefLabel   "Stadt / Umland"@de .
+
+:n570000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Raumordnung und Städtebau"@de .
+
+:n570100  a              skos:Concept ;
+        skos:broader     :n570000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Raumordnung und Städtebau allgemein (n570100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "570100" ;
+        skos:prefLabel   "Raumordnung und Städtebau allgemein"@de .
+
+:n572000  a              skos:Concept ;
+        skos:broader     :n570000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Raumordnung (n572000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "572000" ;
+        skos:prefLabel   "Raumordnung"@de .
+
+:n572020  a              skos:Concept ;
+        skos:broader     :n572000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Landesplanung (n572020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "572020" ;
+        skos:prefLabel   "Landesplanung"@de .
+
+:n572030  a              skos:Concept ;
+        skos:broader     :n572000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Regionalplanung (n572030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "572030" ;
+        skos:prefLabel   "Regionalplanung"@de .
+
+:n572040  a              skos:Concept ;
+        skos:broader     :n572000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Kreisplanung (n572040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "572040" ;
+        skos:prefLabel   "Kreisplanung"@de .
+
+:n572050  a              skos:Concept ;
+        skos:broader     :n572000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Landschaftsplanung (n572050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "572050" ;
+        skos:prefLabel   "Landschaftsplanung"@de .
+
+:n572060  a              skos:Concept ;
+        skos:broader     :n572000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Raumordnung (n572000) > Gemeindeplanung (n572060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "572060" ;
+        skos:prefLabel   "Gemeindeplanung"@de .
+
+:n574000  a              skos:Concept ;
+        skos:broader     :n570000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Bauwesen (n574000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "574000" ;
+        skos:prefLabel   "Bauwesen"@de .
+
+:n574020  a              skos:Concept ;
+        skos:broader     :n574000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Bau- und Bodenrecht (n574020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "574020" ;
+        skos:prefLabel   "Bau- und Bodenrecht"@de .
+
+:n574030  a              skos:Concept ;
+        skos:broader     :n574000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Städtebau (n574030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "574030" ;
+        skos:prefLabel   "Städtebau"@de .
+
+:n574040  a              skos:Concept ;
+        skos:broader     :n574000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Straßenbau (n574040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "574040" ;
+        skos:prefLabel   "Straßenbau"@de .
+
+:n574050  a              skos:Concept ;
+        skos:broader     :n574000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Wohnungsbau (n574050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "574050" ;
+        skos:prefLabel   "Wohnungsbau"@de .
+
+:n574060  a              skos:Concept ;
+        skos:broader     :n574000 ;
+        skos:definition  "Raumordnung und Städtebau (n570000) > Bauwesen (n574000) > Wohnungswirtschaft (n574060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "574060" ;
+        skos:prefLabel   "Wohnungswirtschaft"@de .
+
+:n580000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Umwelt- und Naturschutz"@de .
+
+:n580100  a              skos:Concept ;
+        skos:broader     :n580000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umwelt- und Naturschutz allgemein (n580100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "580100" ;
+        skos:prefLabel   "Umwelt- und Naturschutz allgemein"@de .
+
+:n582000  a              skos:Concept ;
+        skos:broader     :n580000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582000" ;
+        skos:prefLabel   "Umweltschutz"@de .
+
+:n582010  a              skos:Concept ;
+        skos:broader     :n582000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Klimaschutz (n582010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582010" ;
+        skos:prefLabel   "Klimaschutz"@de .
+
+:n582020  a              skos:Concept ;
+        skos:broader     :n582000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Bodenschutz (n582020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582020" ;
+        skos:prefLabel   "Bodenschutz"@de .
+
+:n582030  a              skos:Concept ;
+        skos:broader     :n582000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Luftverschmutzung (n582030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582030" ;
+        skos:prefLabel   "Luftverschmutzung"@de .
+
+:n582040  a              skos:Concept ;
+        skos:broader     :n582000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Lärmbelastung (n582040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582040" ;
+        skos:prefLabel   "Lärmbelastung"@de .
+
+:n582050  a              skos:Concept ;
+        skos:broader     :n582000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Gewässerschutz (n582050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582050" ;
+        skos:prefLabel   "Gewässerschutz"@de .
+
+:n582052  a              skos:Concept ;
+        skos:broader     :n582050 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Gewässerschutz (n582050) > Abwasser (n582052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582052" ;
+        skos:prefLabel   "Abwasser"@de .
+
+:n582054  a              skos:Concept ;
+        skos:broader     :n582050 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Gewässerschutz (n582050) > Kanalisation (n582054)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582054" ;
+        skos:prefLabel   "Kanalisation"@de .
+
+:n582060  a              skos:Concept ;
+        skos:broader     :n582000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Abfallbeseitigung (n582060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582060" ;
+        skos:prefLabel   "Abfallbeseitigung"@de .
+
+:n582070  a              skos:Concept ;
+        skos:broader     :n582000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Umweltschutz (n582000) > Strahlenbelastung (n582070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "582070" ;
+        skos:prefLabel   "Strahlenbelastung"@de .
+
+:n584000  a              skos:Concept ;
+        skos:broader     :n580000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "584000" ;
+        skos:prefLabel   "Naturschutz. Landschaftspflege"@de .
+
+:n584040  a              skos:Concept ;
+        skos:broader     :n584000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Naturdenkmal (n584040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "584040" ;
+        skos:prefLabel   "Naturdenkmal"@de .
+
+:n584050  a              skos:Concept ;
+        skos:broader     :n584000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Pflanzen / Artenschutz (n584050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "584050" ;
+        skos:prefLabel   "Pflanzen / Artenschutz"@de .
+
+:n584060  a              skos:Concept ;
+        skos:broader     :n584000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Tierschutz (n584060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "584060" ;
+        skos:prefLabel   "Tierschutz"@de .
+
+:n584070  a              skos:Concept ;
+        skos:broader     :n584000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Naturschutzgebiet (n584070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "584070" ;
+        skos:prefLabel   "Naturschutzgebiet"@de .
+
+:n584075  a              skos:Concept ;
+        skos:broader     :n584000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Nationalpark (n584075)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "584075" ;
+        skos:prefLabel   "Nationalpark"@de .
+
+:n584080  a              skos:Concept ;
+        skos:broader     :n584000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Naturpark (n584080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "584080" ;
+        skos:prefLabel   "Naturpark"@de .
+
+:n584090  a              skos:Concept ;
+        skos:broader     :n584000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Naturschutz. Landschaftspflege (n584000) > Landschaftsentwicklung (n584090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "584090" ;
+        skos:prefLabel   "Landschaftsentwicklung"@de .
+
+:n586000  a              skos:Concept ;
+        skos:broader     :n580000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Grünanlage (n586000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "586000" ;
+        skos:prefLabel   "Grünanlage"@de .
+
+:n586020  a              skos:Concept ;
+        skos:broader     :n586000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Grünanlage (n586000) > Park (n586020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "586020" ;
+        skos:prefLabel   "Park"@de .
+
+:n586030  a              skos:Concept ;
+        skos:broader     :n586000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Grünanlage (n586000) > Botanischer Garten (n586030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "586030" ;
+        skos:prefLabel   "Botanischer Garten"@de .
+
+:n586040  a              skos:Concept ;
+        skos:broader     :n586000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Grünanlage (n586000) > Zoologischer Garten (n586040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "586040" ;
+        skos:prefLabel   "Zoologischer Garten"@de .
+
+:n586080  a              skos:Concept ;
+        skos:broader     :n586000 ;
+        skos:definition  "Umwelt- und Naturschutz (n580000) > Grünanlage (n586000) > Gartenbauausstellung (n586080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "586080" ;
+        skos:prefLabel   "Gartenbauausstellung"@de .
+
+:n610000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Kirche"@de .
+
+:n610100  a              skos:Concept ;
+        skos:broader     :n610000 ;
+        skos:definition  "Kirche (n610000) > Kirche allgemein (n610100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "610100" ;
+        skos:prefLabel   "Kirche allgemein"@de .
+
+:n611000  a              skos:Concept ;
+        skos:broader     :n610000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611000" ;
+        skos:prefLabel   "Katholische Kirche"@de .
+
+:n611010  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kirchengeschichte (n611010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611010" ;
+        skos:prefLabel   "Kirchengeschichte"@de .
+
+:n611020  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kirchenrecht (n611020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611020" ;
+        skos:prefLabel   "Kirchenrecht"@de .
+
+:n611025  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kirchenverwaltung (n611025)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611025" ;
+        skos:prefLabel   "Kirchenverwaltung"@de .
+
+:n611030  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kirchengemeinde (n611030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611030" ;
+        skos:prefLabel   "Kirchengemeinde"@de .
+
+:n611040  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611040" ;
+        skos:prefLabel   "Kirchliches Leben"@de .
+
+:n611042  a              skos:Concept ;
+        skos:broader     :n611040 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040) > Seelsorge (n611042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611042" ;
+        skos:prefLabel   "Seelsorge"@de .
+
+:n611043  a              skos:Concept ;
+        skos:broader     :n611040 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040) > Laienamt (n611043)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611043" ;
+        skos:prefLabel   "Laienamt"@de .
+
+:n611044  a              skos:Concept ;
+        skos:broader     :n611040 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040) > Kirchlicher Verein (n611044)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611044" ;
+        skos:prefLabel   "Kirchlicher Verein"@de .
+
+:n611045  a              skos:Concept ;
+        skos:broader     :n611040 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kirchliches Leben (n611040) > Kirchliche Stiftung (n611045)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611045" ;
+        skos:prefLabel   "Kirchliche Stiftung"@de .
+
+:n611050  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Geistlicher. Ordensleute (n611050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611050" ;
+        skos:prefLabel   "Geistlicher. Ordensleute"@de .
+
+:n611060  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Kloster. Stift (n611060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611060" ;
+        skos:prefLabel   "Kloster. Stift"@de .
+
+:n611070  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Orden (n611070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611070" ;
+        skos:prefLabel   "Orden"@de .
+
+:n611080  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611080" ;
+        skos:prefLabel   "Gottesdienst"@de .
+
+:n611082  a              skos:Concept ;
+        skos:broader     :n611080 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080) > Sakrament (n611082)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611082" ;
+        skos:prefLabel   "Sakrament"@de .
+
+:n611083  a              skos:Concept ;
+        skos:broader     :n611080 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080) > Kirchenfest (n611083)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611083" ;
+        skos:prefLabel   "Kirchenfest"@de .
+
+:n611084  a              skos:Concept ;
+        skos:broader     :n611080 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080) > Prozession (n611084)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611084" ;
+        skos:prefLabel   "Prozession"@de .
+
+:n611085  a              skos:Concept ;
+        skos:broader     :n611080 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Gottesdienst (n611080) > Wallfahrt (n611085)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611085" ;
+        skos:prefLabel   "Wallfahrt"@de .
+
+:n611090  a              skos:Concept ;
+        skos:broader     :n611000 ;
+        skos:definition  "Kirche (n610000) > Katholische Kirche (n611000) > Heiligenverehrung (n611090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "611090" ;
+        skos:prefLabel   "Heiligenverehrung"@de .
+
+:n612000  a              skos:Concept ;
+        skos:broader     :n610000 ;
+        skos:definition  "Kirche (n610000) > Reformation (n612000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612000" ;
+        skos:prefLabel   "Reformation"@de .
+
+:n612020  a              skos:Concept ;
+        skos:broader     :n612000 ;
+        skos:definition  "Kirche (n610000) > Reformation (n612000) > Calvinismus (n612020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612020" ;
+        skos:prefLabel   "Calvinismus"@de .
+
+:n612022  a              skos:Concept ;
+        skos:broader     :n612020 ;
+        skos:definition  "Kirche (n610000) > Reformation (n612000) > Calvinismus (n612020) > Zwinglianer (n612022)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612022" ;
+        skos:prefLabel   "Zwinglianer"@de .
+
+:n612030  a              skos:Concept ;
+        skos:broader     :n612000 ;
+        skos:definition  "Kirche (n610000) > Reformation (n612000) > Täufer (n612030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612030" ;
+        skos:prefLabel   "Täufer"@de .
+
+:n612032  a              skos:Concept ;
+        skos:broader     :n612030 ;
+        skos:definition  "Kirche (n610000) > Reformation (n612000) > Täufer (n612030) > Mennoniten (n612032)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612032" ;
+        skos:prefLabel   "Mennoniten"@de .
+
+:n612040  a              skos:Concept ;
+        skos:broader     :n612000 ;
+        skos:definition  "Kirche (n610000) > Reformation (n612000) > Schwärmer / Theologie (n612040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612040" ;
+        skos:prefLabel   "Schwärmer / Theologie"@de .
+
+:n612050  a              skos:Concept ;
+        skos:broader     :n612000 ;
+        skos:definition  "Kirche (n610000) > Reformation (n612000) > Reformator (n612050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612050" ;
+        skos:prefLabel   "Reformator"@de .
+
+:n612070  a              skos:Concept ;
+        skos:broader     :n612000 ;
+        skos:definition  "Kirche (n610000) > Reformation (n612000) > Glaubensflüchtling (n612070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612070" ;
+        skos:prefLabel   "Glaubensflüchtling"@de .
+
+:n612080  a              skos:Concept ;
+        skos:broader     :n612000 ;
+        skos:definition  "Kirche (n610000) > Reformation (n612000) > Hugenotten (n612080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612080" ;
+        skos:prefLabel   "Hugenotten"@de .
+
+:n612500  a              skos:Concept ;
+        skos:broader     :n610000 ;
+        skos:definition  "Kirche (n610000) > Gegenreformation (n612500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "612500" ;
+        skos:prefLabel   "Gegenreformation"@de .
+
+:n613000  a              skos:Concept ;
+        skos:broader     :n610000 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613000" ;
+        skos:prefLabel   "Evangelische Kirche"@de .
+
+:n613010  a              skos:Concept ;
+        skos:broader     :n613000 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Kirchengeschichte (n613010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613010" ;
+        skos:prefLabel   "Kirchengeschichte"@de .
+
+:n613020  a              skos:Concept ;
+        skos:broader     :n613000 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Kirchenrecht (n613020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613020" ;
+        skos:prefLabel   "Kirchenrecht"@de .
+
+:n613025  a              skos:Concept ;
+        skos:broader     :n613000 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Kirchenverwaltung (n613025)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613025" ;
+        skos:prefLabel   "Kirchenverwaltung"@de .
+
+:n613030  a              skos:Concept ;
+        skos:broader     :n613000 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Kirchengemeinde (n613030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613030" ;
+        skos:prefLabel   "Kirchengemeinde"@de .
+
+:n613040  a              skos:Concept ;
+        skos:broader     :n613000 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613040" ;
+        skos:prefLabel   "Kirchliches Leben"@de .
+
+:n613042  a              skos:Concept ;
+        skos:broader     :n613040 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040) > Seelsorge (n613042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613042" ;
+        skos:prefLabel   "Seelsorge"@de .
+
+:n613043  a              skos:Concept ;
+        skos:broader     :n613040 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040) > Diakonie (n613043)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613043" ;
+        skos:prefLabel   "Diakonie"@de .
+
+:n613044  a              skos:Concept ;
+        skos:broader     :n613040 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040) > Kirchlicher Verein (n613044)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613044" ;
+        skos:prefLabel   "Kirchlicher Verein"@de .
+
+:n613045  a              skos:Concept ;
+        skos:broader     :n613040 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Kirchliches Leben (n613040) > Kirchliche Stiftung (n613045)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613045" ;
+        skos:prefLabel   "Kirchliche Stiftung"@de .
+
+:n613050  a              skos:Concept ;
+        skos:broader     :n613000 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Pfarrerin. Pfarrer. Geistliche (n613050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613050" ;
+        skos:prefLabel   "Pfarrerin. Pfarrer. Geistliche"@de .
+
+:n613070  a              skos:Concept ;
+        skos:broader     :n613000 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Gottesdienst (n613070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613070" ;
+        skos:prefLabel   "Gottesdienst"@de .
+
+:n613072  a              skos:Concept ;
+        skos:broader     :n613070 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Gottesdienst (n613070) > Sakrament (n613072)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613072" ;
+        skos:prefLabel   "Sakrament"@de .
+
+:n613073  a              skos:Concept ;
+        skos:broader     :n613070 ;
+        skos:definition  "Kirche (n610000) > Evangelische Kirche (n613000) > Gottesdienst (n613070) > Kirchenfest (n613073)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "613073" ;
+        skos:prefLabel   "Kirchenfest"@de .
+
+:n615000  a              skos:Concept ;
+        skos:broader     :n610000 ;
+        skos:definition  "Kirche (n610000) > Sonstige christliche Religionsgemeinschaften (n615000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "615000" ;
+        skos:prefLabel   "Sonstige christliche Religionsgemeinschaften"@de .
+
+:n616000  a              skos:Concept ;
+        skos:broader     :n610000 ;
+        skos:definition  "Kirche (n610000) > Ökumene (n616000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "616000" ;
+        skos:prefLabel   "Ökumene"@de .
+
+:n617000  a              skos:Concept ;
+        skos:broader     :n610000 ;
+        skos:definition  "Kirche (n610000) > Bestattung (n617000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "617000" ;
+        skos:prefLabel   "Bestattung"@de .
+
+:n617030  a              skos:Concept ;
+        skos:broader     :n617000 ;
+        skos:definition  "Kirche (n610000) > Bestattung (n617000) > Friedhof (n617030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "617030" ;
+        skos:prefLabel   "Friedhof"@de .
+
+:n617050  a              skos:Concept ;
+        skos:broader     :n617000 ;
+        skos:definition  "Kirche (n610000) > Bestattung (n617000) > Grabmal (n617050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "617050" ;
+        skos:prefLabel   "Grabmal"@de .
+
+:n630000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Juden"@de .
+
+:n630100  a              skos:Concept ;
+        skos:broader     :n630000 ;
+        skos:definition  "Juden (n630000) > Juden allgemein (n630100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "630100" ;
+        skos:prefLabel   "Juden allgemein"@de .
+
+:n631000  a              skos:Concept ;
+        skos:broader     :n630000 ;
+        skos:definition  "Juden (n630000) > Judentum (n631000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "631000" ;
+        skos:prefLabel   "Judentum"@de .
+
+:n632000  a              skos:Concept ;
+        skos:broader     :n630000 ;
+        skos:definition  "Juden (n630000) > Juden / Geschichte (n632000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "632000" ;
+        skos:prefLabel   "Juden / Geschichte"@de .
+
+:n632050  a              skos:Concept ;
+        skos:broader     :n632000 ;
+        skos:definition  "Juden (n630000) > Juden / Geschichte (n632000) > Judenverfolgung (n632050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "632050" ;
+        skos:prefLabel   "Judenverfolgung"@de .
+
+:n650000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Nichtchristliche Religion"@de .
+
+:n651000  a              skos:Concept ;
+        skos:broader     :n650000 ;
+        skos:definition  "Nichtchristliche Religion (n650000) > Nichtchristliche Religion allgemein (n651000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "651000" ;
+        skos:prefLabel   "Nichtchristliche Religion allgemein"@de .
+
+:n651020  a              skos:Concept ;
+        skos:broader     :n651000 ;
+        skos:definition  "Nichtchristliche Religion (n650000) > Nichtchristliche Religion allgemein (n651000) > Islam (n651020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "651020" ;
+        skos:prefLabel   "Islam"@de .
+
+:n651030  a              skos:Concept ;
+        skos:broader     :n651000 ;
+        skos:definition  "Nichtchristliche Religion (n650000) > Nichtchristliche Religion allgemein (n651000) > Buddhismus (n651030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "651030" ;
+        skos:prefLabel   "Buddhismus"@de .
+
+:n655000  a              skos:Concept ;
+        skos:broader     :n650000 ;
+        skos:definition  "Nichtchristliche Religion (n650000) > Weltanschauungsgemeinschaft (n655000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "655000" ;
+        skos:prefLabel   "Weltanschauungsgemeinschaft"@de .
+
+:n655030  a              skos:Concept ;
+        skos:broader     :n655000 ;
+        skos:definition  "Nichtchristliche Religion (n650000) > Weltanschauungsgemeinschaft (n655000) > Freimaurer (n655030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "655030" ;
+        skos:prefLabel   "Freimaurer"@de .
+
+:n700000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Volkskunde"@de .
+
+:n700100  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Volkskunde allgemein (n700100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "700100" ;
+        skos:prefLabel   "Volkskunde allgemein"@de .
+
+:n702000  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Alltag (n702000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "702000" ;
+        skos:prefLabel   "Alltag"@de .
+
+:n704000  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704000" ;
+        skos:prefLabel   "Brauch"@de .
+
+:n704020  a              skos:Concept ;
+        skos:broader     :n704000 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Brauch / Alltag (n704020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704020" ;
+        skos:prefLabel   "Brauch / Alltag"@de .
+
+:n704040  a              skos:Concept ;
+        skos:broader     :n704000 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704040" ;
+        skos:prefLabel   "Brauch / Jahreslauf"@de .
+
+:n704042  a              skos:Concept ;
+        skos:broader     :n704040 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Winter / Brauch. Weihnachten. Neujahr (n704042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704042" ;
+        skos:prefLabel   "Winter / Brauch. Weihnachten. Neujahr"@de .
+
+:n704043  a              skos:Concept ;
+        skos:broader     :n704040 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Karneval (n704043)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704043" ;
+        skos:prefLabel   "Karneval"@de .
+
+:n704044  a              skos:Concept ;
+        skos:broader     :n704040 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Frühling / Brauch. Ostern (n704044)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704044" ;
+        skos:prefLabel   "Frühling / Brauch. Ostern"@de .
+
+:n704045  a              skos:Concept ;
+        skos:broader     :n704040 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Mai / Brauch. Pfingsten. Sommer / Brauch (n704045)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704045" ;
+        skos:prefLabel   "Mai / Brauch. Pfingsten. Sommer / Brauch"@de .
+
+:n704046  a              skos:Concept ;
+        skos:broader     :n704040 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Erntedankfest (n704046)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704046" ;
+        skos:prefLabel   "Erntedankfest"@de .
+
+:n704047  a              skos:Concept ;
+        skos:broader     :n704040 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Brauch / Jahreslauf (n704040) > Kirchweih (n704047)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704047" ;
+        skos:prefLabel   "Kirchweih"@de .
+
+:n704060  a              skos:Concept ;
+        skos:broader     :n704000 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Lebenslauf / Brauch (n704060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704060" ;
+        skos:prefLabel   "Lebenslauf / Brauch"@de .
+
+:n704061  a              skos:Concept ;
+        skos:broader     :n704060 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Lebenslauf / Brauch (n704060) > Geburt (n704061)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704061" ;
+        skos:prefLabel   "Geburt"@de .
+
+:n704063  a              skos:Concept ;
+        skos:broader     :n704060 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Lebenslauf / Brauch (n704060) > Liebe / Brauch. Verlobung. Hochzeit (n704063)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704063" ;
+        skos:prefLabel   "Liebe / Brauch. Verlobung. Hochzeit"@de .
+
+:n704064  a              skos:Concept ;
+        skos:broader     :n704060 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Lebenslauf / Brauch (n704060) > Tod / Brauch. Bestattung (n704064)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704064" ;
+        skos:prefLabel   "Tod / Brauch. Bestattung"@de .
+
+:n704080  a              skos:Concept ;
+        skos:broader     :n704000 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Beruf / Brauch (n704080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704080" ;
+        skos:prefLabel   "Beruf / Brauch"@de .
+
+:n704082  a              skos:Concept ;
+        skos:broader     :n704080 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Beruf / Brauch (n704080) > Handwerk / Brauch (n704082)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704082" ;
+        skos:prefLabel   "Handwerk / Brauch"@de .
+
+:n704090  a              skos:Concept ;
+        skos:broader     :n704000 ;
+        skos:definition  "Volkskunde (n700000) > Brauch (n704000) > Brauchtumspflege / Verein (n704090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704090" ;
+        skos:prefLabel   "Brauchtumspflege / Verein"@de .
+
+:n704200  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Volkswissen (n704200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704200" ;
+        skos:prefLabel   "Volkswissen"@de .
+
+:n704220  a              skos:Concept ;
+        skos:broader     :n704200 ;
+        skos:definition  "Volkskunde (n700000) > Volkswissen (n704200) > Volksmedizin (n704220)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704220" ;
+        skos:prefLabel   "Volksmedizin"@de .
+
+:n704230  a              skos:Concept ;
+        skos:broader     :n704200 ;
+        skos:definition  "Volkskunde (n700000) > Volkswissen (n704200) > Ethnobotanik (n704230)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704230" ;
+        skos:prefLabel   "Ethnobotanik"@de .
+
+:n704240  a              skos:Concept ;
+        skos:broader     :n704200 ;
+        skos:definition  "Volkskunde (n700000) > Volkswissen (n704200) > Volkszoologie (n704240)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704240" ;
+        skos:prefLabel   "Volkszoologie"@de .
+
+:n704250  a              skos:Concept ;
+        skos:broader     :n704200 ;
+        skos:definition  "Volkskunde (n700000) > Volkswissen (n704200) > Wetter / Bauernregel (n704250)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704250" ;
+        skos:prefLabel   "Wetter / Bauernregel"@de .
+
+:n704260  a              skos:Concept ;
+        skos:broader     :n704200 ;
+        skos:definition  "Volkskunde (n700000) > Volkswissen (n704200) > Astrologie (n704260)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704260" ;
+        skos:prefLabel   "Astrologie"@de .
+
+:n704270  a              skos:Concept ;
+        skos:broader     :n704200 ;
+        skos:definition  "Volkskunde (n700000) > Volkswissen (n704200) > Wahrsagen (n704270)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704270" ;
+        skos:prefLabel   "Wahrsagen"@de .
+
+:n704280  a              skos:Concept ;
+        skos:broader     :n704200 ;
+        skos:definition  "Volkskunde (n700000) > Volkswissen (n704200) > Alchemie (n704280)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704280" ;
+        skos:prefLabel   "Alchemie"@de .
+
+:n704400  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Rechtliche Volkskunde (n704400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704400" ;
+        skos:prefLabel   "Rechtliche Volkskunde"@de .
+
+:n704600  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Religiöse Volkskunde (n704600)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704600" ;
+        skos:prefLabel   "Religiöse Volkskunde"@de .
+
+:n704630  a              skos:Concept ;
+        skos:broader     :n704600 ;
+        skos:definition  "Volkskunde (n700000) > Religiöse Volkskunde (n704600) > Volksfrömmigkeit (n704630)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704630" ;
+        skos:prefLabel   "Volksfrömmigkeit"@de .
+
+:n704634  a              skos:Concept ;
+        skos:broader     :n704630 ;
+        skos:definition  "Volkskunde (n700000) > Religiöse Volkskunde (n704600) > Volksfrömmigkeit (n704630) > Gegenstände der Volksfrömmigkeit (n704634)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704634" ;
+        skos:prefLabel   "Gegenstände der Volksfrömmigkeit"@de .
+
+:n704700  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Volksglaube (n704700)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "704700" ;
+        skos:prefLabel   "Volksglaube"@de .
+
+:n706000  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Volksliteratur (n706000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706000" ;
+        skos:prefLabel   "Volksliteratur"@de .
+
+:n706020  a              skos:Concept ;
+        skos:broader     :n706000 ;
+        skos:definition  "Volkskunde (n700000) > Volksliteratur (n706000) > Volksbuch (n706020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706020" ;
+        skos:prefLabel   "Volksbuch"@de .
+
+:n706040  a              skos:Concept ;
+        skos:broader     :n706000 ;
+        skos:definition  "Volkskunde (n700000) > Volksliteratur (n706000) > Märchen. Sage. Legende (n706040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706040" ;
+        skos:prefLabel   "Märchen. Sage. Legende"@de .
+
+:n706050  a              skos:Concept ;
+        skos:broader     :n706000 ;
+        skos:definition  "Volkskunde (n700000) > Volksliteratur (n706000) > Schwank (n706050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706050" ;
+        skos:prefLabel   "Schwank"@de .
+
+:n706052  a              skos:Concept ;
+        skos:broader     :n706050 ;
+        skos:definition  "Volkskunde (n700000) > Volksliteratur (n706000) > Schwank (n706050) > Witz (n706052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706052" ;
+        skos:prefLabel   "Witz"@de .
+
+:n706060  a              skos:Concept ;
+        skos:broader     :n706000 ;
+        skos:definition  "Volkskunde (n700000) > Volksliteratur (n706000) > Sprichwort (n706060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706060" ;
+        skos:prefLabel   "Sprichwort"@de .
+
+:n706070  a              skos:Concept ;
+        skos:broader     :n706000 ;
+        skos:definition  "Volkskunde (n700000) > Volksliteratur (n706000) > Inschrift (n706070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706070" ;
+        skos:prefLabel   "Inschrift"@de .
+
+:n706080  a              skos:Concept ;
+        skos:broader     :n706000 ;
+        skos:definition  "Volkskunde (n700000) > Volksliteratur (n706000) > Rätsel (n706080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706080" ;
+        skos:prefLabel   "Rätsel"@de .
+
+:n706090  a              skos:Concept ;
+        skos:broader     :n706000 ;
+        skos:definition  "Volkskunde (n700000) > Volksliteratur (n706000) > Mundartliteratur (n706090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706090" ;
+        skos:prefLabel   "Mundartliteratur"@de .
+
+:n706200  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Volksmusik. Volkstanz (n706200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706200" ;
+        skos:prefLabel   "Volksmusik. Volkstanz"@de .
+
+:n706210  a              skos:Concept ;
+        skos:broader     :n706200 ;
+        skos:definition  "Volkskunde (n700000) > Volksmusik. Volkstanz (n706200) > Volksmusik (n706210)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706210" ;
+        skos:prefLabel   "Volksmusik"@de .
+
+:n706230  a              skos:Concept ;
+        skos:broader     :n706200 ;
+        skos:definition  "Volkskunde (n700000) > Volksmusik. Volkstanz (n706200) > Volkslied (n706230)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706230" ;
+        skos:prefLabel   "Volkslied"@de .
+
+:n706240  a              skos:Concept ;
+        skos:broader     :n706200 ;
+        skos:definition  "Volkskunde (n700000) > Volksmusik. Volkstanz (n706200) > Volkstanz (n706240)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "706240" ;
+        skos:prefLabel   "Volkstanz"@de .
+
+:n708000  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708000" ;
+        skos:prefLabel   "Sachkulturforschung"@de .
+
+:n708020  a              skos:Concept ;
+        skos:broader     :n708000 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708020" ;
+        skos:prefLabel   "Hausform"@de .
+
+:n708024  a              skos:Concept ;
+        skos:broader     :n708020 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020) > Bürgerhaus (n708024)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708024" ;
+        skos:prefLabel   "Bürgerhaus"@de .
+
+:n708026  a              skos:Concept ;
+        skos:broader     :n708020 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020) > Bauernhaus (n708026)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708026" ;
+        skos:prefLabel   "Bauernhaus"@de .
+
+:n708028  a              skos:Concept ;
+        skos:broader     :n708020 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020) > Landwirtschaftliches Gebäude (n708028)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708028" ;
+        skos:prefLabel   "Landwirtschaftliches Gebäude"@de .
+
+:n708029  a              skos:Concept ;
+        skos:broader     :n708020 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausform (n708020) > Mühle (n708029)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708029" ;
+        skos:prefLabel   "Mühle"@de .
+
+:n708030  a              skos:Concept ;
+        skos:broader     :n708000 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Hausrat (n708030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708030" ;
+        skos:prefLabel   "Hausrat"@de .
+
+:n708040  a              skos:Concept ;
+        skos:broader     :n708000 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Gerät (n708040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708040" ;
+        skos:prefLabel   "Gerät"@de .
+
+:n708050  a              skos:Concept ;
+        skos:broader     :n708000 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Spielzeug (n708050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708050" ;
+        skos:prefLabel   "Spielzeug"@de .
+
+:n708060  a              skos:Concept ;
+        skos:broader     :n708000 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Nahrung (n708060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708060" ;
+        skos:prefLabel   "Nahrung"@de .
+
+:n708200  a              skos:Concept ;
+        skos:broader     :n708000 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708200" ;
+        skos:prefLabel   "Volkskunst"@de .
+
+:n708220  a              skos:Concept ;
+        skos:broader     :n708200 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Holzbearbeitung (n708220)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708220" ;
+        skos:prefLabel   "Holzbearbeitung"@de .
+
+:n708230  a              skos:Concept ;
+        skos:broader     :n708200 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Malerei (n708230)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708230" ;
+        skos:prefLabel   "Malerei"@de .
+
+:n708250  a              skos:Concept ;
+        skos:broader     :n708200 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Keramik (n708250)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708250" ;
+        skos:prefLabel   "Keramik"@de .
+
+:n708260  a              skos:Concept ;
+        skos:broader     :n708200 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Steinbearbeitung (n708260)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708260" ;
+        skos:prefLabel   "Steinbearbeitung"@de .
+
+:n708270  a              skos:Concept ;
+        skos:broader     :n708200 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Metallbearbeitung (n708270)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708270" ;
+        skos:prefLabel   "Metallbearbeitung"@de .
+
+:n708280  a              skos:Concept ;
+        skos:broader     :n708200 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Glas (n708280)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708280" ;
+        skos:prefLabel   "Glas"@de .
+
+:n708290  a              skos:Concept ;
+        skos:broader     :n708200 ;
+        skos:definition  "Volkskunde (n700000) > Sachkulturforschung (n708000) > Volkskunst (n708200) > Textilien (n708290)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708290" ;
+        skos:prefLabel   "Textilien"@de .
+
+:n708400  a              skos:Concept ;
+        skos:broader     :n700000 ;
+        skos:definition  "Volkskunde (n700000) > Kleidung (n708400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708400" ;
+        skos:prefLabel   "Kleidung"@de .
+
+:n708420  a              skos:Concept ;
+        skos:broader     :n708400 ;
+        skos:definition  "Volkskunde (n700000) > Kleidung (n708400) > Kostümkunde (n708420)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708420" ;
+        skos:prefLabel   "Kostümkunde"@de .
+
+:n708430  a              skos:Concept ;
+        skos:broader     :n708400 ;
+        skos:definition  "Volkskunde (n700000) > Kleidung (n708400) > Tracht (n708430)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708430" ;
+        skos:prefLabel   "Tracht"@de .
+
+:n708450  a              skos:Concept ;
+        skos:broader     :n708400 ;
+        skos:definition  "Volkskunde (n700000) > Kleidung (n708400) > Schmuck (n708450)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "708450" ;
+        skos:prefLabel   "Schmuck"@de .
+
+:n720000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Gesellschaft"@de .
+
+:n720100  a              skos:Concept ;
+        skos:broader     :n720000 ;
+        skos:definition  "Gesellschaft (n720000) > Gesellschaft allgemein (n720100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "720100" ;
+        skos:prefLabel   "Gesellschaft allgemein"@de .
+
+:n722000  a              skos:Concept ;
+        skos:broader     :n720000 ;
+        skos:definition  "Gesellschaft (n720000) > Sozialgeschichte (n722000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "722000" ;
+        skos:prefLabel   "Sozialgeschichte"@de .
+
+:n724000  a              skos:Concept ;
+        skos:broader     :n720000 ;
+        skos:definition  "Gesellschaft (n720000) > Sozialstruktur (n724000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "724000" ;
+        skos:prefLabel   "Sozialstruktur"@de .
+
+:n724020  a              skos:Concept ;
+        skos:broader     :n724000 ;
+        skos:definition  "Gesellschaft (n720000) > Sozialstruktur (n724000) > Kind (n724020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "724020" ;
+        skos:prefLabel   "Kind"@de .
+
+:n724030  a              skos:Concept ;
+        skos:broader     :n724000 ;
+        skos:definition  "Gesellschaft (n720000) > Sozialstruktur (n724000) > Jugend (n724030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "724030" ;
+        skos:prefLabel   "Jugend"@de .
+
+:n724040  a              skos:Concept ;
+        skos:broader     :n724000 ;
+        skos:definition  "Gesellschaft (n720000) > Sozialstruktur (n724000) > Frau (n724040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "724040" ;
+        skos:prefLabel   "Frau"@de .
+
+:n724050  a              skos:Concept ;
+        skos:broader     :n724000 ;
+        skos:definition  "Gesellschaft (n720000) > Sozialstruktur (n724000) > Mann (n724050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "724050" ;
+        skos:prefLabel   "Mann"@de .
+
+:n724060  a              skos:Concept ;
+        skos:broader     :n724000 ;
+        skos:definition  "Gesellschaft (n720000) > Sozialstruktur (n724000) > Alter (n724060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "724060" ;
+        skos:prefLabel   "Alter"@de .
+
+:n724070  a              skos:Concept ;
+        skos:broader     :n724000 ;
+        skos:definition  "Gesellschaft (n720000) > Sozialstruktur (n724000) > Original / Person (n724070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "724070" ;
+        skos:prefLabel   "Original / Person"@de .
+
+:n725000  a              skos:Concept ;
+        skos:broader     :n720000 ;
+        skos:definition  "Gesellschaft (n720000) > Gruppe (n725000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "725000" ;
+        skos:prefLabel   "Gruppe"@de .
+
+:n725010  a              skos:Concept ;
+        skos:broader     :n725000 ;
+        skos:definition  "Gesellschaft (n720000) > Gruppe (n725000) > Familie (n725010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "725010" ;
+        skos:prefLabel   "Familie"@de .
+
+:n725020  a              skos:Concept ;
+        skos:broader     :n725000 ;
+        skos:definition  "Gesellschaft (n720000) > Gruppe (n725000) > Nachbarschaft (n725020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "725020" ;
+        skos:prefLabel   "Nachbarschaft"@de .
+
+:n725030  a              skos:Concept ;
+        skos:broader     :n725000 ;
+        skos:definition  "Gesellschaft (n720000) > Gruppe (n725000) > Dorfgemeinschaft (n725030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "725030" ;
+        skos:prefLabel   "Dorfgemeinschaft"@de .
+
+:n725040  a              skos:Concept ;
+        skos:broader     :n725000 ;
+        skos:definition  "Gesellschaft (n720000) > Gruppe (n725000) > Alternativbewegung (n725040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "725040" ;
+        skos:prefLabel   "Alternativbewegung"@de .
+
+:n725050  a              skos:Concept ;
+        skos:broader     :n725000 ;
+        skos:definition  "Gesellschaft (n720000) > Gruppe (n725000) > Interessenverband (n725050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "725050" ;
+        skos:prefLabel   "Interessenverband"@de .
+
+:n725060  a              skos:Concept ;
+        skos:broader     :n725000 ;
+        skos:definition  "Gesellschaft (n720000) > Gruppe (n725000) > Randgruppe (n725060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "725060" ;
+        skos:prefLabel   "Randgruppe"@de .
+
+:n725070  a              skos:Concept ;
+        skos:broader     :n725000 ;
+        skos:definition  "Gesellschaft (n720000) > Gruppe (n725000) > Ausländerin. Ausländer (n725070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "725070" ;
+        skos:prefLabel   "Ausländerin. Ausländer"@de .
+
+:n725080  a              skos:Concept ;
+        skos:broader     :n725000 ;
+        skos:definition  "Gesellschaft (n720000) > Gruppe (n725000) > Behinderter Mensch (n725080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "725080" ;
+        skos:prefLabel   "Behinderter Mensch"@de .
+
+:n726000  a              skos:Concept ;
+        skos:broader     :n720000 ;
+        skos:definition  "Gesellschaft (n720000) > Sozialer Wandel (n726000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "726000" ;
+        skos:prefLabel   "Sozialer Wandel"@de .
+
+:n730000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Kultur und Freizeit"@de .
+
+:n730100  a              skos:Concept ;
+        skos:broader     :n730000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Kultur und Freizeit allgemein (n730100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "730100" ;
+        skos:prefLabel   "Kultur und Freizeit allgemein"@de .
+
+:n731000  a              skos:Concept ;
+        skos:broader     :n730000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Kulturpolitik (n731000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "731000" ;
+        skos:prefLabel   "Kulturpolitik"@de .
+
+:n732000  a              skos:Concept ;
+        skos:broader     :n730000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Kulturgeschichte (n732000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "732000" ;
+        skos:prefLabel   "Kulturgeschichte"@de .
+
+:n733000  a              skos:Concept ;
+        skos:broader     :n730000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Kulturleben (n733000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "733000" ;
+        skos:prefLabel   "Kulturleben"@de .
+
+:n733030  a              skos:Concept ;
+        skos:broader     :n733000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Kulturleben (n733000) > Kulturveranstaltung (n733030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "733030" ;
+        skos:prefLabel   "Kulturveranstaltung"@de .
+
+:n733050  a              skos:Concept ;
+        skos:broader     :n733000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Kulturleben (n733000) > Kulturpreis (n733050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "733050" ;
+        skos:prefLabel   "Kulturpreis"@de .
+
+:n733070  a              skos:Concept ;
+        skos:broader     :n733000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Kulturleben (n733000) > Kulturverein (n733070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "733070" ;
+        skos:prefLabel   "Kulturverein"@de .
+
+:n734000  a              skos:Concept ;
+        skos:broader     :n730000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Feier. Fest (n734000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "734000" ;
+        skos:prefLabel   "Feier. Fest"@de .
+
+:n735000  a              skos:Concept ;
+        skos:broader     :n730000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Freizeit und Erholung (n735000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "735000" ;
+        skos:prefLabel   "Freizeit und Erholung"@de .
+
+:n735020  a              skos:Concept ;
+        skos:broader     :n735000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Freizeit und Erholung (n735000) > Freizeiteinrichtung (n735020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "735020" ;
+        skos:prefLabel   "Freizeiteinrichtung"@de .
+
+:n735040  a              skos:Concept ;
+        skos:broader     :n735000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Freizeit und Erholung (n735000) > Freizeitgestaltung (n735040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "735040" ;
+        skos:prefLabel   "Freizeitgestaltung"@de .
+
+:n735090  a              skos:Concept ;
+        skos:broader     :n735000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Freizeit und Erholung (n735000) > Verein (n735090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "735090" ;
+        skos:prefLabel   "Verein"@de .
+
+:n736000  a              skos:Concept ;
+        skos:broader     :n730000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Sport und Spiel (n736000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "736000" ;
+        skos:prefLabel   "Sport und Spiel"@de .
+
+:n736030  a              skos:Concept ;
+        skos:broader     :n736000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Sport und Spiel (n736000) > Sportart (n736030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "736030" ;
+        skos:prefLabel   "Sportart"@de .
+
+:n736050  a              skos:Concept ;
+        skos:broader     :n736000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Sport und Spiel (n736000) > Sportverein (n736050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "736050" ;
+        skos:prefLabel   "Sportverein"@de .
+
+:n736080  a              skos:Concept ;
+        skos:broader     :n736000 ;
+        skos:definition  "Kultur und Freizeit (n730000) > Sport und Spiel (n736000) > Sportlerin. Sportler (n736080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "736080" ;
+        skos:prefLabel   "Sportlerin. Sportler"@de .
+
+:n740000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Sprache"@de .
+
+:n740100  a              skos:Concept ;
+        skos:broader     :n740000 ;
+        skos:definition  "Sprache (n740000) > Sprache allgemein (n740100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "740100" ;
+        skos:prefLabel   "Sprache allgemein"@de .
+
+:n742000  a              skos:Concept ;
+        skos:broader     :n740000 ;
+        skos:definition  "Sprache (n740000) > Sprache / Geschichte (n742000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "742000" ;
+        skos:prefLabel   "Sprache / Geschichte"@de .
+
+:n743000  a              skos:Concept ;
+        skos:broader     :n740000 ;
+        skos:definition  "Sprache (n740000) > Grammatik (n743000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "743000" ;
+        skos:prefLabel   "Grammatik"@de .
+
+:n744000  a              skos:Concept ;
+        skos:broader     :n740000 ;
+        skos:definition  "Sprache (n740000) > Mundart (n744000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "744000" ;
+        skos:prefLabel   "Mundart"@de .
+
+:n745000  a              skos:Concept ;
+        skos:broader     :n740000 ;
+        skos:definition  "Sprache (n740000) > Sprachgeographie (n745000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "745000" ;
+        skos:prefLabel   "Sprachgeographie"@de .
+
+:n746000  a              skos:Concept ;
+        skos:broader     :n740000 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746000" ;
+        skos:prefLabel   "Namenkunde"@de .
+
+:n746020  a              skos:Concept ;
+        skos:broader     :n746000 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Personenname (n746020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746020" ;
+        skos:prefLabel   "Personenname"@de .
+
+:n746030  a              skos:Concept ;
+        skos:broader     :n746000 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Hausname. Hofname (n746030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746030" ;
+        skos:prefLabel   "Hausname. Hofname"@de .
+
+:n746032  a              skos:Concept ;
+        skos:broader     :n746030 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Hausname. Hofname (n746030) > Hausname (n746032)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746032" ;
+        skos:prefLabel   "Hausname"@de .
+
+:n746034  a              skos:Concept ;
+        skos:broader     :n746030 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Hausname. Hofname (n746030) > Hofname (n746034)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746034" ;
+        skos:prefLabel   "Hofname"@de .
+
+:n746040  a              skos:Concept ;
+        skos:broader     :n746000 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746040" ;
+        skos:prefLabel   "Geographischer Name"@de .
+
+:n746042  a              skos:Concept ;
+        skos:broader     :n746040 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Ortsname (n746042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746042" ;
+        skos:prefLabel   "Ortsname"@de .
+
+:n746043  a              skos:Concept ;
+        skos:broader     :n746040 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Straßenname (n746043)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746043" ;
+        skos:prefLabel   "Straßenname"@de .
+
+:n746044  a              skos:Concept ;
+        skos:broader     :n746040 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Flurname (n746044)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746044" ;
+        skos:prefLabel   "Flurname"@de .
+
+:n746045  a              skos:Concept ;
+        skos:broader     :n746040 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Bergname (n746045)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746045" ;
+        skos:prefLabel   "Bergname"@de .
+
+:n746046  a              skos:Concept ;
+        skos:broader     :n746040 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Geographischer Name (n746040) > Gewässername (n746046)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746046" ;
+        skos:prefLabel   "Gewässername"@de .
+
+:n746050  a              skos:Concept ;
+        skos:broader     :n746000 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Tiername (n746050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746050" ;
+        skos:prefLabel   "Tiername"@de .
+
+:n746060  a              skos:Concept ;
+        skos:broader     :n746000 ;
+        skos:definition  "Sprache (n740000) > Namenkunde (n746000) > Pflanzenname (n746060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "746060" ;
+        skos:prefLabel   "Pflanzenname"@de .
+
+:n747000  a              skos:Concept ;
+        skos:broader     :n740000 ;
+        skos:definition  "Sprache (n740000) > Soziolinguistik (n747000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "747000" ;
+        skos:prefLabel   "Soziolinguistik"@de .
+
+:n747010  a              skos:Concept ;
+        skos:broader     :n747000 ;
+        skos:definition  "Sprache (n740000) > Soziolinguistik (n747000) > Umgangssprache (n747010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "747010" ;
+        skos:prefLabel   "Umgangssprache"@de .
+
+:n747020  a              skos:Concept ;
+        skos:broader     :n747000 ;
+        skos:definition  "Sprache (n740000) > Soziolinguistik (n747000) > Geheimsprache (n747020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "747020" ;
+        skos:prefLabel   "Geheimsprache"@de .
+
+:n747030  a              skos:Concept ;
+        skos:broader     :n747000 ;
+        skos:definition  "Sprache (n740000) > Soziolinguistik (n747000) > Fachsprache (n747030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "747030" ;
+        skos:prefLabel   "Fachsprache"@de .
+
+:n747040  a              skos:Concept ;
+        skos:broader     :n747000 ;
+        skos:definition  "Sprache (n740000) > Soziolinguistik (n747000) > Spracherwerb (n747040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "747040" ;
+        skos:prefLabel   "Spracherwerb"@de .
+
+:n747050  a              skos:Concept ;
+        skos:broader     :n747000 ;
+        skos:definition  "Sprache (n740000) > Soziolinguistik (n747000) > Sprachunterricht (n747050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "747050" ;
+        skos:prefLabel   "Sprachunterricht"@de .
+
+:n747060  a              skos:Concept ;
+        skos:broader     :n747000 ;
+        skos:definition  "Sprache (n740000) > Soziolinguistik (n747000) > Sprachpflege (n747060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "747060" ;
+        skos:prefLabel   "Sprachpflege"@de .
+
+:n760000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Literatur"@de .
+
+:n760100  a              skos:Concept ;
+        skos:broader     :n760000 ;
+        skos:definition  "Literatur (n760000) > Literatur allgemein (n760100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "760100" ;
+        skos:prefLabel   "Literatur allgemein"@de .
+
+:n761000  a              skos:Concept ;
+        skos:broader     :n760000 ;
+        skos:definition  "Literatur (n760000) > Literaturwissenschaft (n761000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "761000" ;
+        skos:prefLabel   "Literaturwissenschaft"@de .
+
+:n761020  a              skos:Concept ;
+        skos:broader     :n761000 ;
+        skos:definition  "Literatur (n760000) > Literaturwissenschaft (n761000) > Literaturgeographie (n761020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "761020" ;
+        skos:prefLabel   "Literaturgeographie"@de .
+
+:n761050  a              skos:Concept ;
+        skos:broader     :n761000 ;
+        skos:definition  "Literatur (n760000) > Literaturwissenschaft (n761000) > Stoff / Literatur. Motiv / Literatur (n761050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "761050" ;
+        skos:prefLabel   "Stoff / Literatur. Motiv / Literatur"@de .
+
+:n762000  a              skos:Concept ;
+        skos:broader     :n760000 ;
+        skos:definition  "Literatur (n760000) > Literatur / Geschichte (n762000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "762000" ;
+        skos:prefLabel   "Literatur / Geschichte"@de .
+
+:n766000  a              skos:Concept ;
+        skos:broader     :n760000 ;
+        skos:definition  "Literatur (n760000) > Literatursoziologie (n766000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "766000" ;
+        skos:prefLabel   "Literatursoziologie"@de .
+
+:n766030  a              skos:Concept ;
+        skos:broader     :n766000 ;
+        skos:definition  "Literatur (n760000) > Literatursoziologie (n766000) > Leserin. Leser (n766030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "766030" ;
+        skos:prefLabel   "Leserin. Leser"@de .
+
+:n766050  a              skos:Concept ;
+        skos:broader     :n766000 ;
+        skos:definition  "Literatur (n760000) > Literatursoziologie (n766000) > Literaturförderung (n766050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "766050" ;
+        skos:prefLabel   "Literaturförderung"@de .
+
+:n766060  a              skos:Concept ;
+        skos:broader     :n766000 ;
+        skos:definition  "Literatur (n760000) > Literatursoziologie (n766000) > Literaturausstellung (n766060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "766060" ;
+        skos:prefLabel   "Literaturausstellung"@de .
+
+:n767000  a              skos:Concept ;
+        skos:broader     :n760000 ;
+        skos:definition  "Literatur (n760000) > Literarischer Text (n767000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "767000" ;
+        skos:prefLabel   "Literarischer Text"@de .
+
+:n767040  a              skos:Concept ;
+        skos:broader     :n767000 ;
+        skos:definition  "Literatur (n760000) > Literarischer Text (n767000) > Anthologie (n767040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "767040" ;
+        skos:prefLabel   "Anthologie"@de .
+
+:n768000  a              skos:Concept ;
+        skos:broader     :n760000 ;
+        skos:definition  "Literatur (n760000) > Schriftstellerin. Schriftsteller (n768000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "768000" ;
+        skos:prefLabel   "Schriftstellerin. Schriftsteller"@de .
+
+:n768010  a              skos:Concept ;
+        skos:broader     :n768000 ;
+        skos:definition  "Literatur (n760000) > Schriftstellerin. Schriftsteller (n768000) > Schriftstellerin. Schriftsteller / Primärliteratur (n768010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "768010" ;
+        skos:prefLabel   "Schriftstellerin. Schriftsteller / Primärliteratur"@de .
+
+:n768030  a              skos:Concept ;
+        skos:broader     :n768000 ;
+        skos:definition  "Literatur (n760000) > Schriftstellerin. Schriftsteller (n768000) > Schriftstellerin. Schriftsteller / Sekundärliteratur (n768030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "768030" ;
+        skos:prefLabel   "Schriftstellerin. Schriftsteller / Sekundärliteratur"@de .
+
+:n769000  a              skos:Concept ;
+        skos:broader     :n760000 ;
+        skos:definition  "Literatur (n760000) > Literaturgattung (n769000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "769000" ;
+        skos:prefLabel   "Literaturgattung"@de .
+
+:n769020  a              skos:Concept ;
+        skos:broader     :n769000 ;
+        skos:definition  "Literatur (n760000) > Literaturgattung (n769000) > Lyrik (n769020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "769020" ;
+        skos:prefLabel   "Lyrik"@de .
+
+:n769030  a              skos:Concept ;
+        skos:broader     :n769000 ;
+        skos:definition  "Literatur (n760000) > Literaturgattung (n769000) > Drama (n769030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "769030" ;
+        skos:prefLabel   "Drama"@de .
+
+:n769040  a              skos:Concept ;
+        skos:broader     :n769000 ;
+        skos:definition  "Literatur (n760000) > Literaturgattung (n769000) > Epik (n769040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "769040" ;
+        skos:prefLabel   "Epik"@de .
+
+:n769050  a              skos:Concept ;
+        skos:broader     :n769000 ;
+        skos:definition  "Literatur (n760000) > Literaturgattung (n769000) > Kurzform (n769050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "769050" ;
+        skos:prefLabel   "Kurzform"@de .
+
+:n780000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Bildung. Erziehung"@de .
+
+:n780100  a              skos:Concept ;
+        skos:broader     :n780000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Bildung. Erziehung allgemein (n780100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "780100" ;
+        skos:prefLabel   "Bildung. Erziehung allgemein"@de .
+
+:n781000  a              skos:Concept ;
+        skos:broader     :n780000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Bildungspolitik (n781000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "781000" ;
+        skos:prefLabel   "Bildungspolitik"@de .
+
+:n781040  a              skos:Concept ;
+        skos:broader     :n781000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Bildungspolitik (n781000) > Ausbildungsförderung (n781040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "781040" ;
+        skos:prefLabel   "Ausbildungsförderung"@de .
+
+:n782000  a              skos:Concept ;
+        skos:broader     :n780000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Erziehung (n782000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "782000" ;
+        skos:prefLabel   "Erziehung"@de .
+
+:n782500  a              skos:Concept ;
+        skos:broader     :n782000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Erziehung (n782000) > Vorschulerziehung (n782500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "782500" ;
+        skos:prefLabel   "Vorschulerziehung"@de .
+
+:n783000  a              skos:Concept ;
+        skos:broader     :n780000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Schule / Geschichte (n783000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "783000" ;
+        skos:prefLabel   "Schule / Geschichte"@de .
+
+:n784000  a              skos:Concept ;
+        skos:broader     :n780000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784000" ;
+        skos:prefLabel   "Allgemein bildende Schule"@de .
+
+:n784010  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulpolitik (n784010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784010" ;
+        skos:prefLabel   "Schulpolitik"@de .
+
+:n784012  a              skos:Concept ;
+        skos:broader     :n784010 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulpolitik (n784010) > Schulreform (n784012)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784012" ;
+        skos:prefLabel   "Schulreform"@de .
+
+:n784014  a              skos:Concept ;
+        skos:broader     :n784010 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulpolitik (n784010) > Schulversuch (n784014)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784014" ;
+        skos:prefLabel   "Schulversuch"@de .
+
+:n784016  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Privatschule (n784016)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784016" ;
+        skos:prefLabel   "Privatschule"@de .
+
+:n784020  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulrecht (n784020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784020" ;
+        skos:prefLabel   "Schulrecht"@de .
+
+:n784025  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Elternarbeit (n784025)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784025" ;
+        skos:prefLabel   "Elternarbeit"@de .
+
+:n784030  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulverwaltung (n784030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784030" ;
+        skos:prefLabel   "Schulverwaltung"@de .
+
+:n784033  a              skos:Concept ;
+        skos:broader     :n784043 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Realschule (n784043) > Realschule Plus (n784033)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784033" ;
+        skos:prefLabel   "Realschule Plus"@de .
+
+:n784035  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulbau (n784035)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784035" ;
+        skos:prefLabel   "Schulbau"@de .
+
+:n784040  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulgliederung (n784040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784040" ;
+        skos:prefLabel   "Schulgliederung"@de .
+
+:n784041  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Grundschule (n784041)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784041" ;
+        skos:prefLabel   "Grundschule"@de .
+
+:n784042  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Hauptschule (n784042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784042" ;
+        skos:prefLabel   "Hauptschule"@de .
+
+:n784043  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Realschule (n784043)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784043" ;
+        skos:prefLabel   "Realschule"@de .
+
+:n784044  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Gymnasium (n784044)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784044" ;
+        skos:prefLabel   "Gymnasium"@de .
+
+:n784045  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Gesamtschule (n784045)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784045" ;
+        skos:prefLabel   "Gesamtschule"@de .
+
+:n784046  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Kollegschule (n784046)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784046" ;
+        skos:prefLabel   "Kollegschule"@de .
+
+:n784047  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Sonderschule (n784047)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784047" ;
+        skos:prefLabel   "Sonderschule"@de .
+
+:n784048  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Regionale Schule (n784048)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784048" ;
+        skos:prefLabel   "Regionale Schule"@de .
+
+:n784049  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Duale Oberschule (n784049)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784049" ;
+        skos:prefLabel   "Duale Oberschule"@de .
+
+:n784050  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulstufe (n784050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784050" ;
+        skos:prefLabel   "Schulstufe"@de .
+
+:n784052  a              skos:Concept ;
+        skos:broader     :n784050 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulstufe (n784050) > Primarstufe (n784052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784052" ;
+        skos:prefLabel   "Primarstufe"@de .
+
+:n784053  a              skos:Concept ;
+        skos:broader     :n784050 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulstufe (n784050) > Sekundarstufe 1 (n784053)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784053" ;
+        skos:prefLabel   "Sekundarstufe 1"@de .
+
+:n784054  a              skos:Concept ;
+        skos:broader     :n784050 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulstufe (n784050) > Sekundarstufe 2 (n784054)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784054" ;
+        skos:prefLabel   "Sekundarstufe 2"@de .
+
+:n784060  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Lehrerin. Lehrer (n784060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784060" ;
+        skos:prefLabel   "Lehrerin. Lehrer"@de .
+
+:n784062  a              skos:Concept ;
+        skos:broader     :n784060 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Lehrerin. Lehrer (n784060) > Lehrerbildung (n784062)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784062" ;
+        skos:prefLabel   "Lehrerbildung"@de .
+
+:n784064  a              skos:Concept ;
+        skos:broader     :n784060 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Lehrerin. Lehrer (n784060) > Lehrerfortbildung (n784064)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784064" ;
+        skos:prefLabel   "Lehrerfortbildung"@de .
+
+:n784066  a              skos:Concept ;
+        skos:broader     :n784060 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Lehrerin. Lehrer (n784060) > Lehrerin. Lehrer / Besoldung (n784066)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784066" ;
+        skos:prefLabel   "Lehrerin. Lehrer / Besoldung"@de .
+
+:n784070  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784070" ;
+        skos:prefLabel   "Schülerin. Schüler"@de .
+
+:n784072  a              skos:Concept ;
+        skos:broader     :n784070 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070) > Schülermitverwaltung (n784072)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784072" ;
+        skos:prefLabel   "Schülermitverwaltung"@de .
+
+:n784074  a              skos:Concept ;
+        skos:broader     :n784070 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070) > Schülertransport (n784074)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784074" ;
+        skos:prefLabel   "Schülertransport"@de .
+
+:n784076  a              skos:Concept ;
+        skos:broader     :n784070 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070) > Schulverpflegung (n784076)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784076" ;
+        skos:prefLabel   "Schulverpflegung"@de .
+
+:n784078  a              skos:Concept ;
+        skos:broader     :n784070 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schülerin. Schüler (n784070) > Schüleraustausch (n784078)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784078" ;
+        skos:prefLabel   "Schüleraustausch"@de .
+
+:n784080  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Unterricht (n784080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784080" ;
+        skos:prefLabel   "Unterricht"@de .
+
+:n784090  a              skos:Concept ;
+        skos:broader     :n784000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Allgemein bildende Schule (n784000) > Schulleben (n784090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "784090" ;
+        skos:prefLabel   "Schulleben"@de .
+
+:n785000  a              skos:Concept ;
+        skos:broader     :n780000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "785000" ;
+        skos:prefLabel   "Berufsbildende Schule"@de .
+
+:n785020  a              skos:Concept ;
+        skos:broader     :n785000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Berufsschule (n785020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "785020" ;
+        skos:prefLabel   "Berufsschule"@de .
+
+:n785030  a              skos:Concept ;
+        skos:broader     :n785000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Berufsfachschule (n785030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "785030" ;
+        skos:prefLabel   "Berufsfachschule"@de .
+
+:n785040  a              skos:Concept ;
+        skos:broader     :n785000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Berufsaufbauschule (n785040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "785040" ;
+        skos:prefLabel   "Berufsaufbauschule"@de .
+
+:n785050  a              skos:Concept ;
+        skos:broader     :n785000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Fachoberschule (n785050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "785050" ;
+        skos:prefLabel   "Fachoberschule"@de .
+
+:n785060  a              skos:Concept ;
+        skos:broader     :n785000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Berufliches Gymnasium (n785060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "785060" ;
+        skos:prefLabel   "Berufliches Gymnasium"@de .
+
+:n785070  a              skos:Concept ;
+        skos:broader     :n785000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Fachschule (n785070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "785070" ;
+        skos:prefLabel   "Fachschule"@de .
+
+:n785080  a              skos:Concept ;
+        skos:broader     :n785000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Berufsbildende Schule (n785000) > Nichtstaatliche Berufsschule (n785080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "785080" ;
+        skos:prefLabel   "Nichtstaatliche Berufsschule"@de .
+
+:n785500  a              skos:Concept ;
+        skos:broader     :n780000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Berufsausbildung (n785500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "785500" ;
+        skos:prefLabel   "Berufsausbildung"@de .
+
+:n786000  a              skos:Concept ;
+        skos:broader     :n780000 ;
+        skos:definition  "Bildung. Erziehung (n780000) > Außerschulische Bildung (n786000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "786000" ;
+        skos:prefLabel   "Außerschulische Bildung"@de .
+
+:n790000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Hochschule. Wissenschaft"@de .
+
+:n790100  a              skos:Concept ;
+        skos:broader     :n790000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Hochschule. Wissenschaft allgemein (n790100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "790100" ;
+        skos:prefLabel   "Hochschule. Wissenschaft allgemein"@de .
+
+:n791000  a              skos:Concept ;
+        skos:broader     :n790000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Hochschulrecht (n791000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "791000" ;
+        skos:prefLabel   "Hochschulrecht"@de .
+
+:n792000  a              skos:Concept ;
+        skos:broader     :n790000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Hochschulpolitik (n792000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "792000" ;
+        skos:prefLabel   "Hochschulpolitik"@de .
+
+:n794000  a              skos:Concept ;
+        skos:broader     :n790000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Hochschule (n794000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "794000" ;
+        skos:prefLabel   "Hochschule"@de .
+
+:n794010  a              skos:Concept ;
+        skos:broader     :n794000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Hochschule (n794000) > Einzelne Hochschule (n794010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "794010" ;
+        skos:prefLabel   "Einzelne Hochschule"@de .
+
+:n796000  a              skos:Concept ;
+        skos:broader     :n790000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Fachhochschule (n796000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "796000" ;
+        skos:prefLabel   "Fachhochschule"@de .
+
+:n797000  a              skos:Concept ;
+        skos:broader     :n790000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Hochschullehrerin. Hochschullehrer. Wissenschaft (n797000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "797000" ;
+        skos:prefLabel   "Hochschullehrerin. Hochschullehrer. Wissenschaft"@de .
+
+:n798000  a              skos:Concept ;
+        skos:broader     :n790000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Studentin. Student (n798000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "798000" ;
+        skos:prefLabel   "Studentin. Student"@de .
+
+:n798200  a              skos:Concept ;
+        skos:broader     :n790000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Außeruniversitäre Forschung (n798200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "798200" ;
+        skos:prefLabel   "Außeruniversitäre Forschung"@de .
+
+:n799000  a              skos:Concept ;
+        skos:broader     :n790000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Wissenschaftsförderung (n799000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "799000" ;
+        skos:prefLabel   "Wissenschaftsförderung"@de .
+
+:n799200  a              skos:Concept ;
+        skos:broader     :n799000 ;
+        skos:definition  "Hochschule. Wissenschaft (n790000) > Wissenschaftsförderung (n799000) > Wissenschaftliche Gesellschaft (n799200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "799200" ;
+        skos:prefLabel   "Wissenschaftliche Gesellschaft"@de .
+
+:n800000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Darstellende Kunst"@de .
+
+:n800100  a              skos:Concept ;
+        skos:broader     :n800000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Darstellende Kunst allgemein (n800100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "800100" ;
+        skos:prefLabel   "Darstellende Kunst allgemein"@de .
+
+:n802000  a              skos:Concept ;
+        skos:broader     :n800000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Theater (n802000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "802000" ;
+        skos:prefLabel   "Theater"@de .
+
+:n802020  a              skos:Concept ;
+        skos:broader     :n802000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Theater (n802000) > Theater / Geschichte (n802020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "802020" ;
+        skos:prefLabel   "Theater / Geschichte"@de .
+
+:n802030  a              skos:Concept ;
+        skos:broader     :n802000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Theater (n802000) > Volksschauspiel (n802030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "802030" ;
+        skos:prefLabel   "Volksschauspiel"@de .
+
+:n802040  a              skos:Concept ;
+        skos:broader     :n802000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Theater (n802000) > Laienspiel (n802040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "802040" ;
+        skos:prefLabel   "Laienspiel"@de .
+
+:n802050  a              skos:Concept ;
+        skos:broader     :n802000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Theater (n802000) > Kindertheater. Jugendtheater (n802050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "802050" ;
+        skos:prefLabel   "Kindertheater. Jugendtheater"@de .
+
+:n802060  a              skos:Concept ;
+        skos:broader     :n802000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Theater (n802000) > Einzelne Theater (n802060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "802060" ;
+        skos:prefLabel   "Einzelne Theater"@de .
+
+:n802070  a              skos:Concept ;
+        skos:broader     :n802000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Theater (n802000) > Inszenierung (n802070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "802070" ;
+        skos:prefLabel   "Inszenierung"@de .
+
+:n802080  a              skos:Concept ;
+        skos:broader     :n802000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Theater (n802000) > Schauspielerin. Schauspieler (n802080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "802080" ;
+        skos:prefLabel   "Schauspielerin. Schauspieler"@de .
+
+:n803000  a              skos:Concept ;
+        skos:broader     :n800000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Ballett (n803000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "803000" ;
+        skos:prefLabel   "Ballett"@de .
+
+:n804000  a              skos:Concept ;
+        skos:broader     :n800000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Film (n804000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "804000" ;
+        skos:prefLabel   "Film"@de .
+
+:n804020  a              skos:Concept ;
+        skos:broader     :n804000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Film (n804000) > Filmtheater (n804020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "804020" ;
+        skos:prefLabel   "Filmtheater"@de .
+
+:n806000  a              skos:Concept ;
+        skos:broader     :n800000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Kleinkunst (n806000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "806000" ;
+        skos:prefLabel   "Kleinkunst"@de .
+
+:n806020  a              skos:Concept ;
+        skos:broader     :n806000 ;
+        skos:definition  "Darstellende Kunst (n800000) > Kleinkunst (n806000) > Kabarett (n806020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "806020" ;
+        skos:prefLabel   "Kabarett"@de .
+
+:n820000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Musik"@de .
+
+:n820100  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Musik allgemein (n820100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "820100" ;
+        skos:prefLabel   "Musik allgemein"@de .
+
+:n821000  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Musikwissenschaft (n821000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "821000" ;
+        skos:prefLabel   "Musikwissenschaft"@de .
+
+:n822000  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Musikerin. Musiker / Ausbildung (n822000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "822000" ;
+        skos:prefLabel   "Musikerin. Musiker / Ausbildung"@de .
+
+:n822400  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Musikförderung (n822400)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "822400" ;
+        skos:prefLabel   "Musikförderung"@de .
+
+:n822500  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Musikpreis (n822500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "822500" ;
+        skos:prefLabel   "Musikpreis"@de .
+
+:n823000  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Musik / Geschichte (n823000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "823000" ;
+        skos:prefLabel   "Musik / Geschichte"@de .
+
+:n824000  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Musikerin. Musiker (n824000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "824000" ;
+        skos:prefLabel   "Musikerin. Musiker"@de .
+
+:n824020  a              skos:Concept ;
+        skos:broader     :n824000 ;
+        skos:definition  "Musik (n820000) > Musikerin. Musiker (n824000) > Instrumentalmusikerin. Instrumentalmusiker (n824020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "824020" ;
+        skos:prefLabel   "Instrumentalmusikerin. Instrumentalmusiker"@de .
+
+:n824040  a              skos:Concept ;
+        skos:broader     :n824000 ;
+        skos:definition  "Musik (n820000) > Musikerin. Musiker (n824000) > Komponistin. Komponist (n824040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "824040" ;
+        skos:prefLabel   "Komponistin. Komponist"@de .
+
+:n824060  a              skos:Concept ;
+        skos:broader     :n824000 ;
+        skos:definition  "Musik (n820000) > Musikerin. Musiker (n824000) > Dirigentin. Dirigent (n824060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "824060" ;
+        skos:prefLabel   "Dirigentin. Dirigent"@de .
+
+:n824080  a              skos:Concept ;
+        skos:broader     :n824000 ;
+        skos:definition  "Musik (n820000) > Musikerin. Musiker (n824000) > Sängerin. Sänger (n824080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "824080" ;
+        skos:prefLabel   "Sängerin. Sänger"@de .
+
+:n824500  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Chor (n824500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "824500" ;
+        skos:prefLabel   "Chor"@de .
+
+:n825000  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Orchester (n825000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "825000" ;
+        skos:prefLabel   "Orchester"@de .
+
+:n826000  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Konzert. Musikveranstaltung (n826000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "826000" ;
+        skos:prefLabel   "Konzert. Musikveranstaltung"@de .
+
+:n826020  a              skos:Concept ;
+        skos:broader     :n826000 ;
+        skos:definition  "Musik (n820000) > Konzert. Musikveranstaltung (n826000) > Einzelne Aufführungen (n826020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "826020" ;
+        skos:prefLabel   "Einzelne Aufführungen"@de .
+
+:n827000  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Kirchenmusik (n827000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "827000" ;
+        skos:prefLabel   "Kirchenmusik"@de .
+
+:n827010  a              skos:Concept ;
+        skos:broader     :n827000 ;
+        skos:definition  "Musik (n820000) > Kirchenmusik (n827000) > Kirchenmusik / Aufführung (n827010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "827010" ;
+        skos:prefLabel   "Kirchenmusik / Aufführung"@de .
+
+:n828000  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Musikinstrument (n828000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "828000" ;
+        skos:prefLabel   "Musikinstrument"@de .
+
+:n829000  a              skos:Concept ;
+        skos:broader     :n820000 ;
+        skos:definition  "Musik (n820000) > Laienmusik (n829000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "829000" ;
+        skos:prefLabel   "Laienmusik"@de .
+
+:n840000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Kunst. Architektur"@de .
+
+:n840100  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst. Architektur allgemein (n840100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "840100" ;
+        skos:prefLabel   "Kunst. Architektur allgemein"@de .
+
+:n841000  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841000" ;
+        skos:prefLabel   "Kunst"@de .
+
+:n841020  a              skos:Concept ;
+        skos:broader     :n841000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Kunststudium (n841020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841020" ;
+        skos:prefLabel   "Kunststudium"@de .
+
+:n841040  a              skos:Concept ;
+        skos:broader     :n841000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Kunstmuseum. Kunstsammlung (n841040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841040" ;
+        skos:prefLabel   "Kunstmuseum. Kunstsammlung"@de .
+
+:n841050  a              skos:Concept ;
+        skos:broader     :n841000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Kunstgalerie (n841050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841050" ;
+        skos:prefLabel   "Kunstgalerie"@de .
+
+:n841060  a              skos:Concept ;
+        skos:broader     :n841000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Kunstausstellung (n841060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841060" ;
+        skos:prefLabel   "Kunstausstellung"@de .
+
+:n841070  a              skos:Concept ;
+        skos:broader     :n841000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841070" ;
+        skos:prefLabel   "Künstlerin.Künstler"@de .
+
+:n841072  a              skos:Concept ;
+        skos:broader     :n841070 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Bildhauerin. Bildhauer (n841072)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841072" ;
+        skos:prefLabel   "Bildhauerin. Bildhauer"@de .
+
+:n841074  a              skos:Concept ;
+        skos:broader     :n841070 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Malerin. Maler (n841074)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841074" ;
+        skos:prefLabel   "Malerin. Maler"@de .
+
+:n841076  a              skos:Concept ;
+        skos:broader     :n841070 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Zeichnerin. Zeichner (n841076)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841076" ;
+        skos:prefLabel   "Zeichnerin. Zeichner"@de .
+
+:n841078  a              skos:Concept ;
+        skos:broader     :n841070 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Grafikerin. Grafiker (n841078)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841078" ;
+        skos:prefLabel   "Grafikerin. Grafiker"@de .
+
+:n841079  a              skos:Concept ;
+        skos:broader     :n841070 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Künstlerin.Künstler (n841070) > Fotografin. Fotograf (n841079)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841079" ;
+        skos:prefLabel   "Fotografin. Fotograf"@de .
+
+:n841080  a              skos:Concept ;
+        skos:broader     :n841000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Künstlervereinigung (n841080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841080" ;
+        skos:prefLabel   "Künstlervereinigung"@de .
+
+:n841090  a              skos:Concept ;
+        skos:broader     :n841000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst (n841000) > Kunstförderung (n841090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "841090" ;
+        skos:prefLabel   "Kunstförderung"@de .
+
+:n842000  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunst / Geschichte (n842000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "842000" ;
+        skos:prefLabel   "Kunst / Geschichte"@de .
+
+:n843000  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843000" ;
+        skos:prefLabel   "Architektur"@de .
+
+:n843010  a              skos:Concept ;
+        skos:broader     :n843000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000) > Baukonstruktion. Bautechnik (n843010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843010" ;
+        skos:prefLabel   "Baukonstruktion. Bautechnik"@de .
+
+:n843020  a              skos:Concept ;
+        skos:broader     :n843000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000) > Öffentliches Gebäude (n843020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843020" ;
+        skos:prefLabel   "Öffentliches Gebäude"@de .
+
+:n843040  a              skos:Concept ;
+        skos:broader     :n843000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000) > Büro-, Geschäfts- und Industriebauten (n843040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843040" ;
+        skos:prefLabel   "Büro-, Geschäfts- und Industriebauten"@de .
+
+:n843042  a              skos:Concept ;
+        skos:broader     :n843040 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000) > Büro-, Geschäfts- und Industriebauten (n843040) > Bürohaus (n843042)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843042" ;
+        skos:prefLabel   "Bürohaus"@de .
+
+:n843044  a              skos:Concept ;
+        skos:broader     :n843040 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000) > Büro-, Geschäfts- und Industriebauten (n843040) > Geschäftshaus (n843044)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843044" ;
+        skos:prefLabel   "Geschäftshaus"@de .
+
+:n843046  a              skos:Concept ;
+        skos:broader     :n843040 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000) > Büro-, Geschäfts- und Industriebauten (n843040) > Industriebau (n843046)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843046" ;
+        skos:prefLabel   "Industriebau"@de .
+
+:n843050  a              skos:Concept ;
+        skos:broader     :n843000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000) > Bauernhaus (n843050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843050" ;
+        skos:prefLabel   "Bauernhaus"@de .
+
+:n843060  a              skos:Concept ;
+        skos:broader     :n843000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000) > Wohnhaus (n843060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843060" ;
+        skos:prefLabel   "Wohnhaus"@de .
+
+:n843090  a              skos:Concept ;
+        skos:broader     :n843000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Architektur (n843000) > Architektin. Architekt (n843090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "843090" ;
+        skos:prefLabel   "Architektin. Architekt"@de .
+
+:n844000  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844000" ;
+        skos:prefLabel   "Baudenkmal. Kunstwerk"@de .
+
+:n844010  a              skos:Concept ;
+        skos:broader     :n844000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Kunst / Inventar (n844010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844010" ;
+        skos:prefLabel   "Kunst / Inventar"@de .
+
+:n844020  a              skos:Concept ;
+        skos:broader     :n844000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Baustil (n844020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844020" ;
+        skos:prefLabel   "Baustil"@de .
+
+:n844030  a              skos:Concept ;
+        skos:broader     :n844000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Sakralbau (n844030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844030" ;
+        skos:prefLabel   "Sakralbau"@de .
+
+:n844040  a              skos:Concept ;
+        skos:broader     :n844000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Burg. Schloss (n844040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844040" ;
+        skos:prefLabel   "Burg. Schloss"@de .
+
+:n844050  a              skos:Concept ;
+        skos:broader     :n844000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Profanarchitektur (n844050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844050" ;
+        skos:prefLabel   "Profanarchitektur"@de .
+
+:n844060  a              skos:Concept ;
+        skos:broader     :n844000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Park. Garten (n844060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844060" ;
+        skos:prefLabel   "Park. Garten"@de .
+
+:n844070  a              skos:Concept ;
+        skos:broader     :n844000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Brunnen (n844070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844070" ;
+        skos:prefLabel   "Brunnen"@de .
+
+:n844080  a              skos:Concept ;
+        skos:broader     :n844000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Baudenkmal. Kunstwerk (n844000) > Denkmal (n844080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844080" ;
+        skos:prefLabel   "Denkmal"@de .
+
+:n844200  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Denkmalpflege. Denkmalschutz (n844200)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844200" ;
+        skos:prefLabel   "Denkmalpflege. Denkmalschutz"@de .
+
+:n844500  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Städtebau (n844500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "844500" ;
+        skos:prefLabel   "Städtebau"@de .
+
+:n845000  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Plastik (n845000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "845000" ;
+        skos:prefLabel   "Plastik"@de .
+
+:n845020  a              skos:Concept ;
+        skos:broader     :n845000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Plastik (n845000) > Plastik / Einzelne Objekte (n845020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "845020" ;
+        skos:prefLabel   "Plastik / Einzelne Objekte"@de .
+
+:n846000  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Malerei (n846000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "846000" ;
+        skos:prefLabel   "Malerei"@de .
+
+:n846020  a              skos:Concept ;
+        skos:broader     :n846000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Malerei (n846000) > Malerei / Einzelne Objekte (n846020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "846020" ;
+        skos:prefLabel   "Malerei / Einzelne Objekte"@de .
+
+:n847000  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Zeichnung (n847000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "847000" ;
+        skos:prefLabel   "Zeichnung"@de .
+
+:n847500  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Druckgrafik (n847500)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "847500" ;
+        skos:prefLabel   "Druckgrafik"@de .
+
+:n848000  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Fotografie (n848000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "848000" ;
+        skos:prefLabel   "Fotografie"@de .
+
+:n849000  a              skos:Concept ;
+        skos:broader     :n840000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849000" ;
+        skos:prefLabel   "Kunsthandwerk"@de .
+
+:n849020  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Goldschmiedekunst. Silberschmiedekunst. Schmuck (n849020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849020" ;
+        skos:prefLabel   "Goldschmiedekunst. Silberschmiedekunst. Schmuck"@de .
+
+:n849030  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Eisenguss (n849030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849030" ;
+        skos:prefLabel   "Eisenguss"@de .
+
+:n849032  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Bronzeguss (n849032)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849032" ;
+        skos:prefLabel   "Bronzeguss"@de .
+
+:n849034  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Zinnguss (n849034)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849034" ;
+        skos:prefLabel   "Zinnguss"@de .
+
+:n849040  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Keramik (n849040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849040" ;
+        skos:prefLabel   "Keramik"@de .
+
+:n849050  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Porzellan. Glas. Fayence (n849050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849050" ;
+        skos:prefLabel   "Porzellan. Glas. Fayence"@de .
+
+:n849052  a              skos:Concept ;
+        skos:broader     :n849050 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Porzellan. Glas. Fayence (n849050) > Porzellan (n849052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849052" ;
+        skos:prefLabel   "Porzellan"@de .
+
+:n849054  a              skos:Concept ;
+        skos:broader     :n849050 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Porzellan. Glas. Fayence (n849050) > Fayence (n849054)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849054" ;
+        skos:prefLabel   "Fayence"@de .
+
+:n849056  a              skos:Concept ;
+        skos:broader     :n849050 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Porzellan. Glas. Fayence (n849050) > Glas (n849056)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849056" ;
+        skos:prefLabel   "Glas"@de .
+
+:n849060  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Hausrat (n849060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849060" ;
+        skos:prefLabel   "Hausrat"@de .
+
+:n849070  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Möbel (n849070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849070" ;
+        skos:prefLabel   "Möbel"@de .
+
+:n849080  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Textilien. Teppich. Tapete (n849080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849080" ;
+        skos:prefLabel   "Textilien. Teppich. Tapete"@de .
+
+:n849082  a              skos:Concept ;
+        skos:broader     :n849080 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Textilien. Teppich. Tapete (n849080) > Textilien (n849082)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849082" ;
+        skos:prefLabel   "Textilien"@de .
+
+:n849084  a              skos:Concept ;
+        skos:broader     :n849080 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Textilien. Teppich. Tapete (n849080) > Teppich (n849084)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849084" ;
+        skos:prefLabel   "Teppich"@de .
+
+:n849086  a              skos:Concept ;
+        skos:broader     :n849080 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Textilien. Teppich. Tapete (n849080) > Tapete (n849086)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849086" ;
+        skos:prefLabel   "Tapete"@de .
+
+:n849090  a              skos:Concept ;
+        skos:broader     :n849000 ;
+        skos:definition  "Kunst. Architektur (n840000) > Kunsthandwerk (n849000) > Uhr. Musikinstrument (n849090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "849090" ;
+        skos:prefLabel   "Uhr. Musikinstrument"@de .
+
+:n860000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Buch. Bibliothek"@de .
+
+:n860100  a              skos:Concept ;
+        skos:broader     :n860000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch. Bibliothek allgemein (n860100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "860100" ;
+        skos:prefLabel   "Buch. Bibliothek allgemein"@de .
+
+:n861000  a              skos:Concept ;
+        skos:broader     :n860000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861000" ;
+        skos:prefLabel   "Buch"@de .
+
+:n861010  a              skos:Concept ;
+        skos:broader     :n861000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000) > Schrift / Geschichte (n861010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861010" ;
+        skos:prefLabel   "Schrift / Geschichte"@de .
+
+:n861020  a              skos:Concept ;
+        skos:broader     :n861000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000) > Handschrift (n861020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861020" ;
+        skos:prefLabel   "Handschrift"@de .
+
+:n861030  a              skos:Concept ;
+        skos:broader     :n861000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000) > Buch / Geschichte (n861030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861030" ;
+        skos:prefLabel   "Buch / Geschichte"@de .
+
+:n861040  a              skos:Concept ;
+        skos:broader     :n861000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000) > Buchdruck (n861040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861040" ;
+        skos:prefLabel   "Buchdruck"@de .
+
+:n861050  a              skos:Concept ;
+        skos:broader     :n861000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000) > Verlag (n861050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861050" ;
+        skos:prefLabel   "Verlag"@de .
+
+:n861052  a              skos:Concept ;
+        skos:broader     :n861050 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000) > Verlag (n861050) > Urheberrecht (n861052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861052" ;
+        skos:prefLabel   "Urheberrecht"@de .
+
+:n861054  a              skos:Concept ;
+        skos:broader     :n861050 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000) > Verlag (n861050) > Verlagsrecht (n861054)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861054" ;
+        skos:prefLabel   "Verlagsrecht"@de .
+
+:n861056  a              skos:Concept ;
+        skos:broader     :n861050 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000) > Verlag (n861050) > Verlegerin. Verleger (n861056)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861056" ;
+        skos:prefLabel   "Verlegerin. Verleger"@de .
+
+:n861060  a              skos:Concept ;
+        skos:broader     :n861000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Buch (n861000) > Buchhandel (n861060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "861060" ;
+        skos:prefLabel   "Buchhandel"@de .
+
+:n865000  a              skos:Concept ;
+        skos:broader     :n860000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865000" ;
+        skos:prefLabel   "Bibliothek"@de .
+
+:n865010  a              skos:Concept ;
+        skos:broader     :n865000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Bibliotheksrecht (n865010)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865010" ;
+        skos:prefLabel   "Bibliotheksrecht"@de .
+
+:n865020  a              skos:Concept ;
+        skos:broader     :n865000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Bibliothek / Geschichte (n865020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865020" ;
+        skos:prefLabel   "Bibliothek / Geschichte"@de .
+
+:n865030  a              skos:Concept ;
+        skos:broader     :n865000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Bibliotheksplanung (n865030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865030" ;
+        skos:prefLabel   "Bibliotheksplanung"@de .
+
+:n865040  a              skos:Concept ;
+        skos:broader     :n865000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Wissenschaftliche Bibliothek (n865040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865040" ;
+        skos:prefLabel   "Wissenschaftliche Bibliothek"@de .
+
+:n865050  a              skos:Concept ;
+        skos:broader     :n865000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Öffentliche Bibliothek (n865050)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865050" ;
+        skos:prefLabel   "Öffentliche Bibliothek"@de .
+
+:n865052  a              skos:Concept ;
+        skos:broader     :n865050 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Öffentliche Bibliothek (n865050) > Stadtbibliothek (n865052)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865052" ;
+        skos:prefLabel   "Stadtbibliothek"@de .
+
+:n865054  a              skos:Concept ;
+        skos:broader     :n865050 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Öffentliche Bibliothek (n865050) > Kommunale Bibliothek (n865054)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865054" ;
+        skos:prefLabel   "Kommunale Bibliothek"@de .
+
+:n865060  a              skos:Concept ;
+        skos:broader     :n865000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Spezialbibliothek (n865060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865060" ;
+        skos:prefLabel   "Spezialbibliothek"@de .
+
+:n865070  a              skos:Concept ;
+        skos:broader     :n865000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Schulbibliothek (n865070)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865070" ;
+        skos:prefLabel   "Schulbibliothek"@de .
+
+:n865080  a              skos:Concept ;
+        skos:broader     :n865000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Privatbibliothek (n865080)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865080" ;
+        skos:prefLabel   "Privatbibliothek"@de .
+
+:n865090  a              skos:Concept ;
+        skos:broader     :n865000 ;
+        skos:definition  "Buch. Bibliothek (n860000) > Bibliothek (n865000) > Bibliothekarin. Bibliothekar (n865090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "865090" ;
+        skos:prefLabel   "Bibliothekarin. Bibliothekar"@de .
+
+:n880000  a             skos:Concept ;
+        skos:inScheme   <http://purl.org/lobid/rpb> ;
+        skos:prefLabel  "Publizistik. Information. Dokumentation"@de .
+
+:n880100  a              skos:Concept ;
+        skos:broader     :n880000 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Publizistik. Information. Dokumentation allgemein (n880100)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "880100" ;
+        skos:prefLabel   "Publizistik. Information. Dokumentation allgemein"@de .
+
+:n882000  a              skos:Concept ;
+        skos:broader     :n880000 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "882000" ;
+        skos:prefLabel   "Publizistik"@de .
+
+:n882020  a              skos:Concept ;
+        skos:broader     :n882000 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Presse (n882020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "882020" ;
+        skos:prefLabel   "Presse"@de .
+
+:n882022  a              skos:Concept ;
+        skos:broader     :n882020 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Presse (n882020) > Presserecht (n882022)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "882022" ;
+        skos:prefLabel   "Presserecht"@de .
+
+:n882026  a              skos:Concept ;
+        skos:broader     :n882020 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Presse (n882020) > Zeitung. Zeitschrift (n882026)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "882026" ;
+        skos:prefLabel   "Zeitung. Zeitschrift"@de .
+
+:n882030  a              skos:Concept ;
+        skos:broader     :n882000 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Audiovisuelle Medien (n882030)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "882030" ;
+        skos:prefLabel   "Audiovisuelle Medien"@de .
+
+:n882040  a              skos:Concept ;
+        skos:broader     :n882000 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Hörfunk (n882040)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "882040" ;
+        skos:prefLabel   "Hörfunk"@de .
+
+:n882060  a              skos:Concept ;
+        skos:broader     :n882000 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Fernsehen (n882060)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "882060" ;
+        skos:prefLabel   "Fernsehen"@de .
+
+:n882090  a              skos:Concept ;
+        skos:broader     :n882000 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Publizistik (n882000) > Journalistin. Journalist (n882090)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "882090" ;
+        skos:prefLabel   "Journalistin. Journalist"@de .
+
+:n884000  a              skos:Concept ;
+        skos:broader     :n880000 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Information und Dokumentation (n884000)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "884000" ;
+        skos:prefLabel   "Information und Dokumentation"@de .
+
+:n884020  a              skos:Concept ;
+        skos:broader     :n884000 ;
+        skos:definition  "Publizistik. Information. Dokumentation (n880000) > Information und Dokumentation (n884000) > Internet (n884020)"@de ;
+        skos:inScheme    <http://purl.org/lobid/rpb> ;
+        skos:notation    "884020" ;
+        skos:prefLabel   "Internet"@de .
+


### PR DESCRIPTION
For https://jira.hbz-nrw.de/browse/RPB-319

This is the first automatic generation of rpb.ttl, resulting in some changes bringing it in line with rpb-spatial.ttl, in particular using an empty `@prefix` instead of `@base` and removing `narrower`.

See https://github.com/hbz/rpb/commit/6e4b727